### PR TITLE
Remove weird character that breaks 2.9 upgrade SQL

### DIFF
--- a/conf.php.sample.au
+++ b/conf.php.sample.au
@@ -23,6 +23,7 @@ define('SYSTEM_NAME', "St Demo's Smithsville");
 // Ref: http://en.wikipedia.org/wiki/Database_Source_Name
 define('PUBLIC_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
 define('PRIVATE_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
+define('MEMBERS_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
 
 // The URL jethro will be running at.  NB The final slash is important!!
 define('BASE_URL', 'http://example.com/jethro/');
@@ -127,6 +128,8 @@ define('MEMBER_REGO_FAILURE_EMAIL', '');
 // Address to which people are directed if they have trouble with account registration, eg office@mychurch.com
 define('MEMBER_REGO_HELP_EMAIL', '');
 
+// Minimum password length when members register an account
+define('MEMBER_PASSWORD_MIN_LENGTH', '7');
 
 
 ////////////////////////////////////////////////////////////////

--- a/conf.php.sample.in
+++ b/conf.php.sample.in
@@ -23,6 +23,7 @@ define('SYSTEM_NAME', "St Demo's Smithsville");
 // Ref: http://en.wikipedia.org/wiki/Database_Source_Name
 define('PUBLIC_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
 define('PRIVATE_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
+define('MEMBERS_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
 
 // The URL jethro will be running at.  NB The final slash is important!!
 define('BASE_URL', 'http://example.com/jethro/');
@@ -102,6 +103,34 @@ define('SYSADMIN_HREF', '');
 
 // Where to email errors to
 define('ERRORS_EMAIL_ADDRESS', '');
+
+////////////////////////////////////////////////////////////////
+// MEMBER LOGIN SETTINGS - Regarding the /members/ sub-site
+////////////////////////////////////////////////////////////////
+
+// Whether members should be allowed to log in at all - set to TRUE to enable
+define('MEMBER_LOGIN_ENABLED', TRUE);
+
+// Subject line to use for the account-verification email
+define('MEMBER_REGO_EMAIL_SUBJECT', 'Setting up your Member Account');
+
+// Email address which account-verification emails should appear to come from, eg office@mychurch.com
+define('MEMBER_REGO_EMAIL_FROM_ADDRESS', '');
+
+// Name which account-verification emails should appear to come from
+define('MEMBER_REGO_EMAIL_FROM_NAME', "St Demo's Church");
+
+// Email Address to CC in account-verification emails (if you want to know what's going on)
+define('MEMBER_REGO_EMAIL_CC', '');
+
+// Address to notify if an unknown person tries to activate an account, eg office@mychurch.com
+define('MEMBER_REGO_FAILURE_EMAIL', '');
+
+// Address to which people are directed if they have trouble with account registration, eg office@mychurch.com
+define('MEMBER_REGO_HELP_EMAIL', '');
+
+// Minimum password length when members register an account
+define('MEMBER_PASSWORD_MIN_LENGTH', '7');
 
 
 ////////////////////////////////////////////////////////////////

--- a/conf.php.sample.uk
+++ b/conf.php.sample.uk
@@ -23,6 +23,7 @@ define('SYSTEM_NAME', "St Demo's Smithsville");
 // Ref: http://en.wikipedia.org/wiki/Database_Source_Name
 define('PUBLIC_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
 define('PRIVATE_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
+define('MEMBERS_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
 
 // The URL jethro will be running at.  NB The final slash is important!!
 define('BASE_URL', 'http://example.com/jethro/');
@@ -102,6 +103,34 @@ define('SYSADMIN_HREF', '');
 
 // Where to email errors to
 define('ERRORS_EMAIL_ADDRESS', '');
+
+////////////////////////////////////////////////////////////////
+// MEMBER LOGIN SETTINGS - Regarding the /members/ sub-site
+////////////////////////////////////////////////////////////////
+
+// Whether members should be allowed to log in at all - set to TRUE to enable
+define('MEMBER_LOGIN_ENABLED', TRUE);
+
+// Subject line to use for the account-verification email
+define('MEMBER_REGO_EMAIL_SUBJECT', 'Setting up your Member Account');
+
+// Email address which account-verification emails should appear to come from, eg office@mychurch.com
+define('MEMBER_REGO_EMAIL_FROM_ADDRESS', '');
+
+// Name which account-verification emails should appear to come from
+define('MEMBER_REGO_EMAIL_FROM_NAME', "St Demo's Church");
+
+// Email Address to CC in account-verification emails (if you want to know what's going on)
+define('MEMBER_REGO_EMAIL_CC', '');
+
+// Address to notify if an unknown person tries to activate an account, eg office@mychurch.com
+define('MEMBER_REGO_FAILURE_EMAIL', '');
+
+// Address to which people are directed if they have trouble with account registration, eg office@mychurch.com
+define('MEMBER_REGO_HELP_EMAIL', '');
+
+// Minimum password length when members register an account
+define('MEMBER_PASSWORD_MIN_LENGTH', '7');
 
 
 ////////////////////////////////////////////////////////////////

--- a/conf.php.sample.usa
+++ b/conf.php.sample.usa
@@ -23,6 +23,7 @@ define('SYSTEM_NAME', "St Demo's Smithsville");
 // Ref: http://en.wikipedia.org/wiki/Database_Source_Name
 define('PUBLIC_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
 define('PRIVATE_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
+define('MEMBERS_DSN', "mysql://USERNAME:PASSWORD@localhost/DB_NAME");
 
 // The URL jethro will be running at.  NB The final slash is important!!
 define('BASE_URL', 'http://example.com/jethro/');
@@ -101,6 +102,34 @@ define('SYSADMIN_HREF', '');
 
 // Where to email errors to
 define('ERRORS_EMAIL_ADDRESS', '');
+
+////////////////////////////////////////////////////////////////
+// MEMBER LOGIN SETTINGS - Regarding the /members/ sub-site
+////////////////////////////////////////////////////////////////
+
+// Whether members should be allowed to log in at all - set to TRUE to enable
+define('MEMBER_LOGIN_ENABLED', TRUE);
+
+// Subject line to use for the account-verification email
+define('MEMBER_REGO_EMAIL_SUBJECT', 'Setting up your Member Account');
+
+// Email address which account-verification emails should appear to come from, eg office@mychurch.com
+define('MEMBER_REGO_EMAIL_FROM_ADDRESS', '');
+
+// Name which account-verification emails should appear to come from
+define('MEMBER_REGO_EMAIL_FROM_NAME', "St Demo's Church");
+
+// Email Address to CC in account-verification emails (if you want to know what's going on)
+define('MEMBER_REGO_EMAIL_CC', '');
+
+// Address to notify if an unknown person tries to activate an account, eg office@mychurch.com
+define('MEMBER_REGO_FAILURE_EMAIL', '');
+
+// Address to which people are directed if they have trouble with account registration, eg office@mychurch.com
+define('MEMBER_REGO_HELP_EMAIL', '');
+
+// Minimum password length when members register an account
+define('MEMBER_PASSWORD_MIN_LENGTH', '7');
 
 
 ////////////////////////////////////////////////////////////////

--- a/upgrades/2015-upgrade-to-2.9.sql
+++ b/upgrades/2015-upgrade-to-2.9.sql
@@ -70,7 +70,6 @@ CREATE TABLE `service_item` (
 
 ALTER TABLE `service_component_tagging`
   ADD CONSTRAINT `tagid` FOREIGN KEY (`tagid`) REFERENCES `service_component_tag` (`id`) ON DELETE CASCADE;
-Ø
 
 CREATE TABLE IF NOT EXISTS `congregation_service_component` (
   `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
Hi Tom,

There's a weird non-ASCII character (Ø) in upgrades/2015-upgrade-to-2.9.sql that causes upgrades to break:

`````
ERROR 1064 (42000) at line 73: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'Ø

CREATE TABLE IF NOT EXISTS `congregation_service_component` (
  `id` int(11)' at line 1
`````
This pull request fixes it.

If anyone hits this bug, they have to remove the char, then create a new SQL file containing only the SQL from line 73 onwards, and run that. 

