### PR TITLE
Jethro loses data when marking attendees with over 1000 people

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,3 @@
+# The 'Record Attendance' page has an 'input var' for each person, and breaks if the PHP default of 1000 is used.
+# So we increase this variable to an arbitrary high number.
+php_value max_input_vars 100000


### PR DESCRIPTION
When the Record Attendance form has over 1000 people, Jethro will fail to record the attendance selections of the last ones. In the Apache error log we see:
```
PHP Warning:  Unknown: Input variables exceeded 1000. To increase the limit change max_input_vars in php.ini. in Unknown on line 0, referer: https://jethro.coastec.net.au/?view=attendance__record&age_bracket=&for_type=congregationid&congregationid%5B%5D=1&congregationid%5B%5D=2&congregationid%5B%5D=&attendance_date_d=08&attendance_date_m=2&attendance_date_y=2015&params_submitted=1
```

PHP is silently restricting the submitted HTTP POST data to 1000 users (even if most are 'unknown').

This patch increases the max_input_vars limit to 100,000.