### PR TITLE
Minor fix for PHP 5.3.3 compatibility, plus spelling fixes in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Jethro is designed to facilitate and encourage good team ministry, so its name c
 
 # Acknowledgements
 Jethro development has been sponsored or contributed to by several churches worldwide:
-* [Christ Church Inner West Anlgican Community](http://cciw.org.au), Sydney, Australia (founding sponsor)
+* [Christ Church Inner West Anglican Community](http://cciw.org.au), Sydney, Australia (founding sponsor)
 * [Redlands Presbyterian Church](http://www.redlands.org.au/), Queensland, Australia (sponsor of service planning features)
 * [St Peter's Woolton](http://www.stpeters-woolton.org.uk), Liverpool, UK (sponsor of date field and photo features)
 * [Coast Evanglical Church](http://www.coastec.net.au)</a>, Forster, Australia (sponsor of group-membership statuses, attendance enhancements and more)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Jethro development has been sponsored or contributed to by several churches worl
 * [Christ Church Inner West Anglican Community](http://cciw.org.au), Sydney, Australia (founding sponsor)
 * [Redlands Presbyterian Church](http://www.redlands.org.au/), Queensland, Australia (sponsor of service planning features)
 * [St Peter's Woolton](http://www.stpeters-woolton.org.uk), Liverpool, UK (sponsor of date field and photo features)
-* [Coast Evanglical Church](http://www.coastec.net.au)</a>, Forster, Australia (sponsor of group-membership statuses, attendance enhancements and more)
+* [Coast Evangelical Church](http://www.coastec.net.au)</a>, Forster, Australia (sponsor of group-membership statuses, attendance enhancements and more)
 * [St George North Anglican Church](http://snac.org.au)</a>, Sydney, Australia (contributor of vCard export)
 * [Macquarie Anglican Church](http://www.macquarieanglican.org/)</a>, Sydney, Australia (contributor of note-search and SMS-family feature)
 * [Dalby Presbyterian Church](http://www.dpc.cc/)</a>, Queensland, Australia (sponsor of edit/delete note features)

--- a/views/view_0_generate_service_documents.class.php
+++ b/views/view_0_generate_service_documents.class.php
@@ -150,9 +150,14 @@ class View__Generate_Service_Documents extends View
 
 	public function printView()
 	{
+		/* 
+		 * Assign a temporary variable to make the empty() statement 
+		 * work correctly on PHP versions earlier than 5.5.
+		 */
 		$selfCongregations = self::getCongregations();
 		if (empty($selfCongregations) || empty($this->_action) || empty($this->_service_date) || empty($this->_filename)) return;
-
+		$selfCongregations = null;//Finished with temporary variable.
+		
 		if (!empty($this->_generated_files)) {
 			echo "The following files were generated: <ul>";
 			foreach ($this->_generated_files as $path => $label) {

--- a/views/view_0_generate_service_documents.class.php
+++ b/views/view_0_generate_service_documents.class.php
@@ -150,7 +150,8 @@ class View__Generate_Service_Documents extends View
 
 	public function printView()
 	{
-		if (empty(self::getCongregations()) || empty($this->_action) || empty($this->_service_date) || empty($this->_filename)) return;
+		$selfCongregations = self::getCongregations();
+		if (empty($selfCongregations) || empty($this->_action) || empty($this->_service_date) || empty($this->_filename)) return;
 
 		if (!empty($this->_generated_files)) {
 			echo "The following files were generated: <ul>";


### PR DESCRIPTION
view_0_generate_service_documents.class line 153 makes a call to empty() and passes in the output of a function.  On versions of PHP prior to 5.5 this executes incorrectly; it only works if a variable is passed in.  So I assigned the output of that function call to a temporary variable and passed that in, and it works.