### PR TITLE
Added ON DUPLICATE KEY UPDATE so that errors don't happen when saving services with the same key.

### DIFF
--- a/include/db_object.class.php
+++ b/include/db_object.class.php
@@ -215,9 +215,13 @@ class db_object
 			array_unshift($flds, 'id');
 			array_unshift($vals, $db->quote((int)$this->id));
 		}
-
+		$updateVals = Array();
+		for($i = 0; $i < count($flds); $i++){
+			array_push($updateVals, $flds[$i] . "=" . $vals[$i]);
+		}
 		$sql = 'INSERT INTO '.strtolower(get_class($this)).' ('.implode(', ', $flds).')
-				 VALUES ('.implode(', ', $vals).')';
+				 VALUES ('.implode(', ', $vals).') ON DUPLICATE KEY UPDATE ' . implode(', ',$updateVals);
+		$updateVals = null;
 		$res = $db->query($sql);
 		check_db_result($res);
 		if (empty($this->id)) $this->id = $db->lastInsertId();


### PR DESCRIPTION
This change stopped the errors in issue #78 (https://github.com/tbar0970/jethro-pmm/issues/78) from happening however I haven't tested the change thoroughly; it could break things because it is in a commonly-used function.  It causes the subsequent records in a set of new records to be inserted to clobber any existing records having the same primary key, even records that were inserted in the same transaction.  In the case of issue 78 two services for the same congregation on the same date will have the same primary key.  The first will get lost while the second will be saved.