### PR TITLE
Sort notes descending instead of ascending

### DIFF
--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -311,8 +311,17 @@ class Person extends DB_Object
 
 	function _compareCreatedDates($a, $b)
 	{
-		return $a['created'] > $b['created'];
-
+      $aDate = strtotime($a['created']);
+      $bDate = strtotime($b['created']);
+      foreach ($a['comments'] as $id=>$comment) {
+        $cDate = strtotime($comment['created']);
+        if ($cDate > $aDate) { $aDate = $cDate;}
+      }
+      foreach ($b['comments'] as $id=>$comment) {
+        $cDate = strtotime($comment['created']);
+        if ($cDate > $aDate) { $bDate = $cDate;}
+      }
+      return $aDate < $bDate;
 	}
 
 	function validateFields()

--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -313,14 +313,18 @@ class Person extends DB_Object
 	{
       $aDate = strtotime($a['created']);
       $bDate = strtotime($b['created']);
-      foreach ($a['comments'] as $id=>$comment) {
-        $cDate = strtotime($comment['created']);
+      // comments are always in chronological order, so grab the last comment
+      if (count($a['comments']) > 0) {
+        $cDate = strtotime(end($a['comments'])['created']);
+        reset($a['comments']);
         if ($cDate > $aDate) { $aDate = $cDate;}
       }
-      foreach ($b['comments'] as $id=>$comment) {
-        $cDate = strtotime($comment['created']);
-        if ($cDate > $aDate) { $bDate = $cDate;}
+      if (count($b['comments']) > 0) {
+        $cDate = strtotime(end($b['comments'])['created']);
+        reset($b['comments']);
+        if ($cDate > $bDate) { $bDate = $cDate;}
       }
+
       return $aDate < $bDate;
 	}
 

--- a/templates/view_family.template.php
+++ b/templates/view_family.template.php
@@ -1,8 +1,28 @@
 <?php
 include_once 'include/size_detector.class.php';
+  function _compareCreatedDates($a, $b)
+  {
+    print "<pre>SORTING</pre>";
+      $aDate = strtotime($a['created']);
+      $bDate = strtotime($b['created']);
+      // comments are always in chronological order, so grab the last comment
+      if (count($a['comments']) > 0) {
+        $cDate = strtotime(end($a['comments'])['created']);
+        reset($a['comments']);
+        if ($cDate > $aDate) { $aDate = $cDate;}
+      }
+      if (count($b['comments']) > 0) {
+        $cDate = strtotime(end($b['comments'])['created']);
+        reset($b['comments']);
+        if ($cDate > $bDate) { $bDate = $cDate;}
+      }
+      return $aDate < $bDate;
+    }
+
 $accordion = SizeDetector::getWidth() && SizeDetector::isNarrow();
 if ($GLOBALS['user_system']->havePerm(PERM_VIEWNOTE)) {
 	$notes = $GLOBALS['system']->getDBObjectData('family_note', Array('familyid' => $family->id), 'OR', 'created');
+  	uasort($notes, '_compareCreatedDates');
 }
 
 if (!$accordion) {
@@ -14,7 +34,6 @@ if (!$accordion) {
 		<li class="active"><a data-toggle="tab" href="#basic">Basic Details</a></li>
 	<?php
 	if ($GLOBALS['user_system']->havePerm(PERM_VIEWNOTE)) {
-		$notes = $GLOBALS['system']->getDBObjectData('family_note', Array('familyid' => $family->id), 'OR', 'created');
 		?>
 		<li><a data-toggle="tab" href="#notes">Notes (<?php echo count($notes); ?>)</a></li>
 		<?php

--- a/templates/view_family.template.php
+++ b/templates/view_family.template.php
@@ -2,7 +2,6 @@
 include_once 'include/size_detector.class.php';
   function _compareCreatedDates($a, $b)
   {
-    print "<pre>SORTING</pre>";
       $aDate = strtotime($a['created']);
       $bDate = strtotime($b['created']);
       // comments are always in chronological order, so grab the last comment


### PR DESCRIPTION
This way, the latest notes are at the top. Also, uses time instead of the string to sort, meaning it sorts with a better granularity. Also, it also considers the comments in the sort. That way, whatever was done last is at the top.