### PR TITLE
Fix Issue 153 - include/exclude archived families

### DIFF
--- a/views/view_2_families__1_list_all.class.php
+++ b/views/view_2_families__1_list_all.class.php
@@ -10,6 +10,8 @@ class View_Families__List_All extends View
 		$params = Array();
 		if (empty($_REQUEST['show_archived'])) {
 			$params['!status'] = 'archived';
+		} else {
+			$params['!status'] = '';
 		}
 		if (empty($_SESSION['total_families'])) {
 			$_SESSION['total_families'] = $GLOBALS['db']->queryOne('SELECT count(familyid) from family f join person p on p.familyid = f.id');

--- a/views/view_3_persons__1_list_all.class.php
+++ b/views/view_3_persons__1_list_all.class.php
@@ -10,6 +10,8 @@ class View_Persons__List_All extends View
 		$params = Array();
 		if (empty($_REQUEST['show_archived'])) {
 			$params['!status'] = 'archived';
+		} else {
+			$params['!status'] = '';
 		}
 		if (empty($_SESSION['total_persons'])) {
 			$_SESSION['total_persons'] = $GLOBALS['db']->queryOne('SELECT count(*) from person');

--- a/views/view_5_groups.class.php
+++ b/views/view_5_groups.class.php
@@ -108,7 +108,12 @@ class View_Groups extends View
 
 
 			<?php
-			$mParams = empty($_SESSION['show_archived_group_members']) ? Array() : Array('!status' => 'archived');
+            $mParams = Array('!status' => 'archived');
+            if (!empty($_SESSION['show_archived_group_members']) && ($_SESSION['show_archived_group_members'] == 1)) {
+		$mParams = Array('!status' => '');
+	    }
+
+
 			$persons = $this->_group->getMembers($mParams);
 			list ($status_options, $default_status) = Person_Group::getMembershipStatusOptionsAndDefault();
 			?>

--- a/views/view_5_groups.class.php
+++ b/views/view_5_groups.class.php
@@ -108,11 +108,10 @@ class View_Groups extends View
 
 
 			<?php
-            $mParams = Array('!status' => 'archived');
-            if (!empty($_SESSION['show_archived_group_members']) && ($_SESSION['show_archived_group_members'] == 1)) {
-		$mParams = Array('!status' => '');
-	    }
-
+			$mParams = Array('!status' => 'archived');
+			if (!empty($_SESSION['show_archived_group_members']) && ($_SESSION['show_archived_group_members'] == 1)) {
+				$mParams = Array('!status' => '');
+			}
 
 			$persons = $this->_group->getMembers($mParams);
 			list ($status_options, $default_status) = Person_Group::getMembershipStatusOptionsAndDefault();


### PR DESCRIPTION
This fix does the trick.
It seems the _family_ db class has a different default for status than the _person_. Both are adjusted to the same coding style for completeness