### PR TITLE
Set sql_mode to avoid strict mode errors

### DIFF
--- a/conf.php.sample.au
+++ b/conf.php.sample.au
@@ -305,6 +305,7 @@ define('MAP_LOOKUP_URL', 'http://maps.google.com.au?q=__ADDRESS_STREET__,%20__AD
 ///////////////////////////////////////////////////////
 define('LOCK_LENGTH', '10 minutes');
 define('LOCK_CLEANUP_PROBABLILITY', 10);
+//define('STRICT_MODE_FIX', TRUE); //Set TRUE if you experience database errors because of MySQL's STRICT Mode.
 
 // the chunk size to aim for when dividing lists (of persons or families) into pages
 define('CHUNK_SIZE', 100);

--- a/conf.php.sample.in
+++ b/conf.php.sample.in
@@ -301,6 +301,7 @@ define('MAP_LOOKUP_URL', 'http://maps.google.co.in?q=__ADDRESS_STREET__,%20__ADD
 ///////////////////////////////////////////////////////
 define('LOCK_LENGTH', '10 minutes');
 define('LOCK_CLEANUP_PROBABLILITY', 10);
+//define('STRICT_MODE_FIX', TRUE); //Set TRUE if you experience database errors because of MySQL's STRICT Mode.
 
 // the chunk size to aim for when dividing lists (of persons or families) into pages
 define('CHUNK_SIZE', 100);

--- a/conf.php.sample.uk
+++ b/conf.php.sample.uk
@@ -309,6 +309,7 @@ define('MAP_LOOKUP_URL', 'http://maps.google.co.uk?q=__ADDRESS_STREET__,%20__ADD
 ///////////////////////////////////////////////////////
 define('LOCK_LENGTH', '10 minutes');
 define('LOCK_CLEANUP_PROBABLILITY', 10);
+//define('STRICT_MODE_FIX', TRUE); //Set TRUE if you experience database errors because of MySQL's STRICT Mode.
 
 // the chunk size to aim for when dividing lists (of persons or families) into pages
 define('CHUNK_SIZE', 100);

--- a/conf.php.sample.usa
+++ b/conf.php.sample.usa
@@ -303,6 +303,7 @@ define('MAP_LOOKUP_URL', 'http://maps.google.com?q=__ADDRESS_STREET__,%20__ADDRE
 ///////////////////////////////////////////////////////
 define('LOCK_LENGTH', '10 minutes');
 define('LOCK_CLEANUP_PROBABLILITY', 10);
+//define('STRICT_MODE_FIX', TRUE); //Set TRUE if you experience database errors because of MySQL's STRICT Mode.
 
 // the chunk size to aim for when dividing lists (of persons or families) into pages
 define('CHUNK_SIZE', 100);

--- a/include/init.php
+++ b/include/init.php
@@ -61,6 +61,8 @@ if (defined('TIMEZONE') && constant('TIMEZONE')) {
 }
 
 //SET MySQL session variables to account for strict mode
-$GLOBALS['db']->query('SET SESSION sql_mode="NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"');
+if (defined('STRICT_MODE_FIX') && STRICT_MODE_FIX) {
+	$GLOBALS['db']->query('SET SESSION sql_mode="NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"');
+}
 
 @ini_set('default_charset', 'UTF-8');

--- a/include/init.php
+++ b/include/init.php
@@ -60,4 +60,7 @@ if (defined('TIMEZONE') && constant('TIMEZONE')) {
 	$GLOBALS['db']->query('SET time_zone = "'.date('P').'"');
 }
 
+//SET MySQL session variables to account for strict mode
+$GLOBALS['db']->query('SET SESSION sql_mode="NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"');
+
 @ini_set('default_charset', 'UTF-8');


### PR DESCRIPTION
I wonder whether Jethro should set the appropriate MySQL modes per session, rather than relying on the admin needing to know about such things. (It seems that the errors are popping up for a few people.)

This seems to be working for me.