### PR TITLE
Fixes to SMS error reporting

### DIFF
--- a/calls/call_sms.class.php
+++ b/calls/call_sms.class.php
@@ -30,9 +30,13 @@ class Call_sms extends Call
 		$success = $sendResponse['success'];
 		$successes = $sendResponse['successes'];
 		$failures = $sendResponse['failures'];
+		$rawresponse = $sendResponse['rawresponse'];
+		$error = $sendResponse['error'];
+
+		$ajax['rawresponse'] = $rawresponse;
 
         if (!$success) {
-          $ajax['error'] = "Failure communicating with SMS server";
+          $ajax['error'] = "Unable to send SMS\n" . $error;
         } else {
           if ((!empty($successes)) || (!empty($failures))) { // we managed to parse the server response to get information
             if (!empty($successes)) {

--- a/include/sms_sender.class.php
+++ b/include/sms_sender.class.php
@@ -108,21 +108,22 @@ Class SMS_Sender
 			$fp = fopen(SMS_HTTP_URL, 'r', false, stream_context_create($opts));
 			if (!$fp) {
 				$http_error = "ERROR: Unable to connect to SMS Server.<br>" . join("<br>", $http_response_header);
-				return array("success" => false, "successes" => array(), "failures" => array(), "rawresponse" => $http_error);
+				return array("success" => false, "successes" => array(), "failures" => array(), "rawresponse" => $http_error, "error" => $http_error);
 			} else {
 				$response = stream_get_contents($fp);
 				fclose($fp);
 			}
 		} catch (Exception $e) {
 			$error = "ERROR: Unable to connect to SMS Server. " + $e->getMessage();
-			return array("success" => false, "successes" => array(), "failures" => array(), "rawresponse" => $error);
+			return array("success" => false, "successes" => array(), "failures" => array(), "rawresponse" => $error, "error" => $error);
 		}
 		restore_error_handler(); // Restore system error_handler
 		$success = !empty($response);
+		$error = null;
 		if (ifdef('SMS_HTTP_RESPONSE_ERROR_REGEX')) {
-			if (preg_match(SMS_HTTP_RESPONSE_ERROR_REGEX, $rawresponse)) {
+			if (preg_match("/" . SMS_HTTP_RESPONSE_ERROR_REGEX . "/", $response)) {
 				$success = FALSE;
-				$ajax['error'] = $rawresponse;
+				$error = "$response";
 			}
 		}
 		$successes = $failures = Array();
@@ -152,6 +153,7 @@ Class SMS_Sender
 			"successes" => $successes,
 			"failures" => $failures,
 			"rawresponse" => $response,
+			"error" => $error
 		);
 	}
 

--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -623,7 +623,7 @@ JethroSMS.onAJAXSuccess = function (data, resultsDiv) {
 	resultsDiv.html(""); // Reset results in case there's something there
 	var message = '';
 	if (data.error!==undefined) {
-		alert('Server error sending SMS\n '+data.error);
+		alert('Server error sending SMS\n'+data.error);
 		return true;
 	}
 	if (sentCount > 0) {

--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -572,11 +572,13 @@ JethroSMS.init = function() {
 				context: $(this),
 				error: function(jqXHR, status, error) {
 					alert('Server error while sending SMS');
+					console.log(jqXHR);
+					console.log(status);
+					console.log(error);
 					sendButton.html("Send");
 				},
 				success: function(data) {
 					var modalDiv = $("#send-sms-modal");
-
 					var showResults = JethroSMS.onAJAXSuccess(data, resultsDiv);
 					if (showResults) {
 						resultsDiv.show();
@@ -621,7 +623,7 @@ JethroSMS.onAJAXSuccess = function (data, resultsDiv) {
 	resultsDiv.html(""); // Reset results in case there's something there
 	var message = '';
 	if (data.error!==undefined) {
-		alert('Server error sending SMS: '+data.error);
+		alert('Server error sending SMS\n '+data.error);
 		return true;
 	}
 	if (sentCount > 0) {


### PR DESCRIPTION
Turns out I had a configuration error when I upgraded - and figuring that out took ages! Partly because I wasn't using an ERROR regex, and partly because the ERROR regex functionality just plain wasn't working. This code fixes that, meaning that people with broken configurations should be able to figure it out more easily. Also logs errors to the Javascript console, for those who don't have an ERROR regex set up (which is, admittedly, a more advanced use case!)