### PR TITLE
Send a report as an email with a .csv attachment - issue #384

### DIFF
--- a/scripts/email_report.php
+++ b/scripts/email_report.php
@@ -1,29 +1,23 @@
 <?php
 /*****************************************************************
 This script will send the results of a report in an email and also attached as a .csv file. 
-
-usage:  php /path/to/this-script-and-path.php /pathe/to/variables-in-a-file.ini
-
+usage:  php /path/to/this-script.php /path/to/variables-in-a-file.ini
 Possible application could be:
-- email a list of people who have missed church for three sundays to the minister
-- email a list of newcomers to welcome coordinator
-- email upcoming birthdays to the Sunday School coordinator
+- email a list of people who have missed church for three sundays to the minister or the pastoral care group
+- email a list of newcomers to welcome coordinator or the welcomers group
+- email upcoming birthdays to the Sunday School coordinator or sunday school teachers group
 - generate a regular report (e.g. monthly) of childsafe training details for childsafe administrator
-
-The recipient/s of the email need not be giving user access to Jethro. 
-
-You can adjust the format of the report in Jethro without needing to change this script or the cron job that calls it. 
-
-With a bit of work this script could be modified to send a report to a 'group' and/or an over-ride email or emails. 
-Or you could work a bit harder and use one ini file to send multiple different reports. 
-
+The recipient/s of the email need not be given user access to Jethro. You can send to a specific Jethro group, or to one or more emails entered in the ini file
+You can adjust the format of the report, or the membership of the recipient group in Jethro without needing to change this script or the cron job that calls it. 
+With a bit of work this script could be modified to send multiple different reports. 
+TODO - there may be issues with formatting if a report is grouped into multiple tables?
 ******************************************************************/
 //
 //read the ini file
 //
 if (empty($_SERVER['argv'][1]) || !is_readable($_SERVER['argv'][1])) {
 	echo "You must specify an ini file as the first argument \n";
-	echo "Eg:  php date_reminder.php my-config-file.ini \n";
+	echo "Eg:  php email_report.php email_report_sample.ini \n";
 	exit;
 }
 ini_set('display_errors', 1);
@@ -38,6 +32,7 @@ if (!is_readable(JETHRO_ROOT.'/conf.php')) {
 	exit(1);
 }
 require_once JETHRO_ROOT.'/conf.php';
+if (!defined('DSN')) define('DSN', constant('PRIVATE_DSN'));
 require_once JETHRO_ROOT.'/include/init.php';
 require_once JETHRO_ROOT.'/include/user_system.class.php';
 $GLOBALS['user_system'] = new User_System();
@@ -67,7 +62,7 @@ ob_end_clean();
 $csv_array = preg_split("/\\r\\n|\\r|\\n/", $csv_string);
 $rows=(count($csv_array)-1);
 $x=0; 
-$email_html="<html><head></head><body>This is the result of a report generatated from the ".SYSTEM_NAME." Jethro system. <br><br> <i>(If the rest of this email is blank (and the attached .csv file empty) then the report returned no results.</i><br><br><h2>Report name: ".$reportname."</h2>";
+$email_html="<html><head></head><body>This is the result of a report generatated from the ".SYSTEM_NAME." Jethro system. <br><br>".$ini['MESSAGE']."<br><h2>Report name: ".$reportname."</h2>";
   $email_html.="<table border='1' cellpadding='5' cellspacing='1'>";
 // TODO: this doesn't handle values containing commas or newlines properly
 while($x < $rows) {
@@ -81,21 +76,38 @@ while($x < $rows) {
  	$email_html.="</tr>";	
   $x++;
 } 
-$email_html.="</table></body></html>";
+$email_html.="</table><br><br><i>If there is no table above then the report returned no results.</i><br></body></html>";
 $email_subject="Jethro Report: ".$reportname;
 $file_name=$reportname.".csv";
+// 
+// compile the list of recipients for the email
+//
+if ((int)$ini['GROUP_ID']!=0) {
+  $group = $GLOBALS['system']->getDBObject('person_group', (int)$ini['GROUP_ID']);
+  $members = $group->getMembers();
+  $recipients_array = Array();
+  foreach ($members as $m) {
+      $recipients[] = $m['email'];
+  }
+  $recipients_string = (implode(',', $recipients));
+}else{
+$recipients_string = $ini['EMAIL_TO'];	
+}
 //
 // send the email with .cvs attachment
 //
+if ((int)$ini['PHP_MAIL']==0) {
 require_once JETHRO_ROOT.'/include/emailer.class.php'; 
 	$message = Emailer::newMessage()
 	  ->setSubject($email_subject)
 	  ->setFrom(array($ini['EMAIL_FROM'] => $ini['EMAIL_FROM_NAME']))
 	  ->setBody("See CSV data attached")
 	  ->addPart($email_html, 'text/html')
-	  ->setTo($ini['EMAIL_TO']);
-	$attachment = new Swift_Attachment($csv_string, $file_name, 'text/csv');
-	$message->attach($attachment);    
+	  ->setTo($recipients_string);
+	if ((int)$ini['CSV']==1) {
+	  $attachment = new Swift_Attachment($csv_string, $file_name, 'text/csv');
+	  $message->attach($attachment);  
+	}	
 	$res = Emailer::send($message);
 	if (!$res) {
 		echo "Failed to send report (".$reportname.") to ".$ini['EMAIL_TO']."\n";
@@ -106,3 +118,32 @@ require_once JETHRO_ROOT.'/include/emailer.class.php';
 		}
 		exit(0);
 	}
+}
+// send the email with attachment uaing php mail()
+if ((int)$ini['PHP_MAIL']==1) {
+  $eol = PHP_EOL;
+  $content = chunk_split(base64_encode($csv_string));
+  $uid = md5(uniqid(time()));
+  $email_from=$ini['EMAIL_FROM'];
+  $email_to=$recipients_string;
+  $header = "From: ".$email_from.$eol;
+  $header .= "MIME-Version: 1.0".$eol;
+  $header .= "Content-Type: multipart/mixed; boundary=\"".$uid."\"";
+  $message = "--".$uid.$eol;
+  $message .= "Content-type:text/html; charset=iso-8859-1".$eol;
+  $message .= "Content-Transfer-Encoding: 8bit".$eol.$eol;
+  $message .= $email_html.$eol;
+  if ((int)$ini['CSV']==1) {
+	$message .= "--".$uid.$eol;
+	$message .= "Content-Type: text/csv; name=\"".$file_name."\"".$eol;
+	$message .= "Content-Transfer-Encoding: base64".$eol;
+	$message .= "Content-Disposition: attachment; filename=\"".$file_name."\"".$eol.$eol;
+	$message .= $content.$eol;
+	}
+  $message .= "--".$uid."--";
+   if (mail($email_to, $email_subject, "$message", $header)) {
+   echo $reportname." Mail send ... OK";
+   } else {
+   echo $reportname." Mail send ... ERROR!";
+   }
+  }

--- a/scripts/email_report.php
+++ b/scripts/email_report.php
@@ -103,7 +103,7 @@ require_once JETHRO_ROOT.'/include/emailer.class.php';
 	  ->setFrom(array($ini['EMAIL_FROM'] => $ini['EMAIL_FROM_NAME']))
 	  ->setBody("See CSV data attached")
 	  ->addPart($email_html, 'text/html')
-	  ->setTo($recipients_string);
+	  ->setTo(explode(',', $recipients_string));
 	if ((int)$ini['CSV']==1) {
 	  $attachment = new Swift_Attachment($csv_string, $file_name, 'text/csv');
 	  $message->attach($attachment);  

--- a/scripts/email_report_sample.ini
+++ b/scripts/email_report_sample.ini
@@ -1,11 +1,27 @@
 ; Edit the values below and save as another filename
-;
 ; Then run   php email_report.php /path/to/my/config.ini
 ;
-REPORT_ID=1;
+REPORT_ID=4;
+;
 EMAIL_FROM='somebody@example.com';
+;
 EMAIL_FROM_NAME='no-reply';
+;
+;messages to appear above the report table in the email, use <br> for new line <b>for bold</b> etc.
+MESSAGE='Include a message about the report.';
+;
+;send to one or more email addresses separated by a comma, and without spaces
+;e.g. EMAIL_TO='email@address.com'; or EMAIL_TO='email@address.com,email2@address.com';
 EMAIL_TO='minister@somechurch.org.au';
+;
+;Enter a GROUP_ID number to overide the EMAIL_TO addresses and send to a jethro group instead - otherwise leave next line as GROUP_ID=0;
+GROUP_ID=0;
+;
+;if you would like the report attached as a .csv file then leave this next line as CSV=1;
+;Otherwise change to CSV=0;
+CSV=1;
+;
+;if your server can not email using Jethro-pmm built-in email script (swiftmail) try using php mail() by changing the next line to PHP_MAIL=1; otherwise leave as PHP_MAIL=0;
+PHP_MAIL=0;
 
 VERBOSE=0;
-

--- a/scripts/email_report_sample.ini
+++ b/scripts/email_report_sample.ini
@@ -21,7 +21,7 @@ GROUP_ID=0;
 ;Otherwise change to CSV=0;
 CSV=1;
 ;
-;if your server can not email using Jethro-pmm built-in email script (swiftmail) try using php mail() by changing the next line to PHP_MAIL=1; otherwise leave as PHP_MAIL=0;
+;if your server can not email using Jethro-pmm built-in email script (swiftmailer) try using php mail() by changing the next line to PHP_MAIL=1; otherwise leave as PHP_MAIL=0;
 PHP_MAIL=0;
 
 VERBOSE=0;


### PR DESCRIPTION
This is my first ever attempt at a pull request. So let me know if I'm not following protocol or if I have missed a step. 

I have made changes to jethro/scripts/email_report.php and jethro/scripts/email_report.ini
- some typo corrections in comments
- added a line to stop an error which was killing the script on the server here...  +if (!defined('DSN')) define('DSN', constant('PRIVATE_DSN'));
- modified the .ini file and .php script so that there are now  the following options:
    - send email w/o attachment
    - send email to a jethro-group instead of a string of email addresses
    - insert a message into the email above the report
    - send the email using mail() 


