### PR TITLE
Issue 427 - MySQL 5.7 reports date format error

### DIFF
--- a/include/db_object.class.php
+++ b/include/db_object.class.php
@@ -331,7 +331,7 @@ class db_object
 		// Set any last-changed fields
 		foreach ($this->_old_values as $i => $v) {
 			if (array_key_exists($i.'_last_changed', $this->fields)) {
-				$this->values[$i.'_last_changed'] = date('c');
+				$this->values[$i.'_last_changed'] = date('Y-m-d H:i:s');
 				$this->_old_values[$i.'_last_changed'] = 1;
 			}
 		}


### PR DESCRIPTION
Changed date format - MySQL 5.7 doesn't accept ISO 8601 date format.