### PR TITLE
Fix for Issue 344

### DIFF
--- a/db_objects/attendance_record_set.class.php
+++ b/db_objects/attendance_record_set.class.php
@@ -512,7 +512,7 @@ class Attendance_Record_Set
 						GROUP BY ar.personid, '.$selectCol.'
 					) indiv
 					GROUP BY '.$rank.' '.$groupingField.' WITH ROLLUP';
-			$res = $db->queryAll($sql);			
+			$res = $db->queryAll($sql);
 
 			foreach ($res as $row) {
 				if (NULL !== $row[$groupingField]) {

--- a/db_objects/roster_view.class.php
+++ b/db_objects/roster_view.class.php
@@ -353,7 +353,7 @@ class roster_view extends db_object
 				IF(privateassignee.id IS NULL, 1, 0) as assigneehidden,
 				privateassignee.email as email,
 				privateassignee.mobile_tel as mobile,
-				CONCAT(assigner.first_name, " ", assigner.last_name) as assigner, 
+				CONCAT(assigner.first_name, " ", assigner.last_name) as assigner,
 				rra.assignedon
 				FROM roster_role_assignment rra
 				LEFT JOIN person privateassignee ON rra.personid = privateassignee.id
@@ -671,7 +671,7 @@ class roster_view extends db_object
 			</div>
 			<?php
 		}
-		
+
 		?>
 		<table class="table roster" border="1" cellspacing="0" cellpadding="1">
 
@@ -710,7 +710,11 @@ class roster_view extends db_object
 				                </span>
 								<?php
 							}
-							if (!empty($mobiles) && defined('SMS_HTTP_URL') && constant('SMS_HTTP_URL') && $GLOBALS['user_system']->havePerm(PERM_SENDSMS)) {
+							$enable_sms =  $GLOBALS['user_system']->havePerm(PERM_SENDSMS)
+													&& defined('SMS_HTTP_URL') && constant('SMS_HTTP_URL')
+													&& defined('SMS_HTTP_POST_TEMPLATE') && constant('SMS_HTTP_POST_TEMPLATE')
+													&& ((defined('SMS_OVERRIDE_SENDER_NUMBER') && strlen(constant('SMS_OVERRIDE_SENDER_NUMBER'))) || ($GLOBALS['user_system']->getCurrentUser('mobile_tel') !== ''));
+							if (!empty($mobiles) && $enable_sms) {
 								?>
 								<span class="smallprint no-print">
 								  <a href="#send-sms-modal" data-personid="<?php echo implode(',', array_unique($personids)); ?>" data-toggle="sms-modal" data-name="People Rostered on <?php echo $date;?>" onclick="$(this).parents('tr:first').addClass('tblib-hover')">SMS All</a>

--- a/include/db_object.class.php
+++ b/include/db_object.class.php
@@ -885,7 +885,7 @@ class db_object
 				if ($field[0] == '=') {
 					$operator .= '=';
 					$field = substr($field, 1);
-				}				
+				}
 			} else if ($field[0] == '-') {
 				$operator = 'BETWEEN';
 				$field = substr($field, 1);

--- a/include/sms_sender.class.php
+++ b/include/sms_sender.class.php
@@ -44,7 +44,7 @@ Class SMS_Sender
 		}
 		return Array($recips, $blanks, $archived);
 	}
-	
+
 	/**
 	 * Remove invalid characters from message.
 	 * Only understands GSM0338 at the moment - any other charset does not get filtered.
@@ -124,10 +124,19 @@ Class SMS_Sender
 			$mobile_tels = array_keys($mobile_tels);
 		}
 
+		$sendermobile = "";
+		if (defined('SMS_OVERRIDE_SENDER_NUMBER') && strlen(constant('SMS_OVERRIDE_SENDER_NUMBER'))) {
+			$sendermobile =constant('SMS_OVERRIDE_SENDER_NUMBER');
+		} else {
+			$sendermobile = $GLOBALS['user_system']->getCurrentUser('mobile_tel');
+		}
+
 		$response = '';
 		$success = false;
+
 		$content = SMS_HTTP_POST_TEMPLATE;
-		$content = str_replace('_USER_MOBILE_', urlencode($GLOBALS['user_system']->getCurrentUser('mobile_tel')), $content);
+		$content = str_replace('_USER_MOBILE_', urlencode($sendermobile), $content);
+		$content = str_replace('_USER_INTERNATIONAL_MOBILE_', urlencode(self::internationaliseNumber($sendermobile)), $content);
 		$content = str_replace('_USER_EMAIL_', urlencode($GLOBALS['user_system']->getCurrentUser('email')), $content);
 		$content = str_replace('_MESSAGE_', urlencode($message), $content);
 		$content = str_replace('_RECIPIENTS_COMMAS_', urlencode(implode(',', $mobile_tels)), $content);

--- a/scripts/email_report.php
+++ b/scripts/email_report.php
@@ -61,7 +61,7 @@ ob_end_clean();
 //
 $csv_array = preg_split("/\\r\\n|\\r|\\n/", $csv_string);
 $rows=(count($csv_array)-1);
-$x=0; 
+$x=0;
 $email_html="<html><head></head><body>This is the result of a report generatated from the ".SYSTEM_NAME." Jethro system. <br><br>".$ini['MESSAGE']."<br><h2>Report name: ".$reportname."</h2>";
   $email_html.="<table border='1' cellpadding='5' cellspacing='1'>";
 // TODO: this doesn't handle values containing commas or newlines properly
@@ -73,9 +73,9 @@ while($x < $rows) {
 	} else {
      	foreach ($line as $cell) {$email_html.="<td>".(str_replace('"', "", $cell))."</td>";}
 	}
- 	$email_html.="</tr>";	
+ 	$email_html.="</tr>";
   $x++;
-} 
+}
 $email_html.="</table><br><br><i>If there is no table above then the report returned no results.</i><br></body></html>";
 $email_subject="Jethro Report: ".$reportname;
 $file_name=$reportname.".csv";
@@ -91,13 +91,13 @@ if ((int)$ini['GROUP_ID']!=0) {
   }
   $recipients_string = (implode(',', $recipients));
 }else{
-$recipients_string = $ini['EMAIL_TO'];	
+$recipients_string = $ini['EMAIL_TO'];
 }
 //
 // send the email with .cvs attachment
 //
 if ((int)$ini['PHP_MAIL']==0) {
-require_once JETHRO_ROOT.'/include/emailer.class.php'; 
+require_once JETHRO_ROOT.'/include/emailer.class.php';
 	$message = Emailer::newMessage()
 	  ->setSubject($email_subject)
 	  ->setFrom(array($ini['EMAIL_FROM'] => $ini['EMAIL_FROM_NAME']))
@@ -106,8 +106,8 @@ require_once JETHRO_ROOT.'/include/emailer.class.php';
 	  ->setTo(explode(',', $recipients_string));
 	if ((int)$ini['CSV']==1) {
 	  $attachment = new Swift_Attachment($csv_string, $file_name, 'text/csv');
-	  $message->attach($attachment);  
-	}	
+	  $message->attach($attachment);
+	}
 	$res = Emailer::send($message);
 	if (!$res) {
 		echo "Failed to send report (".$reportname.") to ".$ini['EMAIL_TO']."\n";

--- a/templates/bulk_actions.template.php
+++ b/templates/bulk_actions.template.php
@@ -32,7 +32,10 @@ $groupid = array_get($_REQUEST, 'groupid', array_get($_REQUEST, 'person_groupid'
 				?>
 					<option value="email"><?php echo _('Send email')?></option>
 				<?php
-				$enable_sms = $GLOBALS['user_system']->havePerm(PERM_SENDSMS) && defined('SMS_HTTP_URL') && constant('SMS_HTTP_URL') && defined('SMS_HTTP_POST_TEMPLATE') && constant('SMS_HTTP_POST_TEMPLATE');
+				$enable_sms =  $GLOBALS['user_system']->havePerm(PERM_SENDSMS)
+										&& defined('SMS_HTTP_URL') && constant('SMS_HTTP_URL')
+										&& defined('SMS_HTTP_POST_TEMPLATE') && constant('SMS_HTTP_POST_TEMPLATE')
+										&& ((defined('SMS_OVERRIDE_SENDER_NUMBER') && strlen(constant('SMS_OVERRIDE_SENDER_NUMBER'))) || ($GLOBALS['user_system']->getCurrentUser('mobile_tel') !== ''));
 				if ($enable_sms) {
 					?>
 					<option value="smshttp"><?php echo _('Send SMS')?></option>
@@ -295,7 +298,7 @@ $groupid = array_get($_REQUEST, 'groupid', array_get($_REQUEST, 'person_groupid'
 			</div>
 		<?php
 		if ($GLOBALS['user_system']->havePerm(PERM_EDITNOTE)) {
-			?>			
+			?>
 			<div class="control-group">
 				<label class="control-label">After sending:</label>
 				<div class="controls">
@@ -357,13 +360,11 @@ $groupid = array_get($_REQUEST, 'groupid', array_get($_REQUEST, 'person_groupid'
 	<div class="bulk-action well" id="vcf">
 		<input type="submit" value="Go" class="btn" data-set-form-action="<?php echo BASE_URL; ?>?call=vcf" />
 	</div>
-	
+
 	<?php
 	if (function_exists('custom_bulk_action_bodies')) {
 		custom_bulk_action_bodies();
 	}
 	?>
-	
+
 </div>
-
-

--- a/upgrades/2018-upgrade-to-2.24.sql
+++ b/upgrades/2018-upgrade-to-2.24.sql
@@ -1,0 +1,12 @@
+/* Fix #344 - SMS sending fails when current user has blank mobile number */
+SET @newRank = (SELECT rank FROM setting WHERE symbol = 'SMS_MAX_LENGTH');
+
+INSERT IGNORE INTO setting (rank, heading, symbol, note, type, value)
+VALUES
+(@newRank := @newRank+1, '', 'SMS_OVERRIDE_SENDER_NUMBER', 'Phone number from which SMS messages are to be sent. Leave this blank to use phone number associated with the user sending the SMS.', 'text', '');
+
+/* Let users know what variables they can use in SMS_POST_TEMPLATE. */
+ALTER TABLE setting MODIFY COLUMN note VARCHAR(350);
+
+UPDATE setting SET note = 'Template for the body of a request to the SMS messaging service. Supports the variables:_USER_MOBILE_, _USER_INTERNATIONAL_MOBILE_, _USER_EMAIL_, _MESSAGE_, _RECIPIENTS_COMMAS_, _RECIPIENTS_NEWLINES_, _RECIPIENTS_ARRAY_, _RECIPIENTS_INTERNATIONAL_COMMAS_, _RECIPIENTS_INTERNATIONAL_NEWLINES_, _RECIPIENTS_INTERNATIONAL_ARRAY_'
+WHERE symbol = 'SMS_HTTP_POST_TEMPLATE';

--- a/views/view_0_persons_bulk_update.class.php
+++ b/views/view_0_persons_bulk_update.class.php
@@ -35,7 +35,7 @@ class View__Persons_Bulk_Update extends View
 			if (!empty($_REQUEST['backto'])) {
 				parse_str($_REQUEST['backto'], $back);
 				unset($back['backto']);
-				$back['*'] = NULL;		
+				$back['*'] = NULL;
 				redirect($back['view'], $back);
 			}
 			return;


### PR DESCRIPTION
Fix for issue #344 

Creates a new system setting, allowing one to use a global mobile number to send SMS messages, rather than the user's number.

Disables SMS sending if there is no global number *AND* the user doesn't have an mobile number.

Also includes a small fix to show users what variables are available in the SMS_POST_TEMPLATE.
