### PR TITLE
Make roster_reminders.php set the envelope From address by default, and use the email from name

### DIFF
--- a/scripts/roster_reminder.php
+++ b/scripts/roster_reminder.php
@@ -314,7 +314,7 @@ if ($sendemail) {
 		  $message .= "Content-Transfer-Encoding: 8bit".$eol.$eol;
 		  $message .= $longstring.$eol;
 		  $message .= "--".$uid."--";
-		   if (mail($email_to, $email_subject . "$roster_date", "$message", $header)) {
+		   if (mail($email_to, $email_subject . "$roster_date", "$message", $header, "-f ".$email_from)) {
 		   	echo "Mail send roster reminder - ".$roster_name." sent OK <br>";
 		   } else {
 		   	echo "Mail send roster reminder - ".$roster_name." send ERROR!";
@@ -366,7 +366,7 @@ if ($sendemail) {
 		$message .= "Content-Transfer-Encoding: 8bit".$eol.$eol;
 		$message .= $summary.$eol;
 		$message .= "--".$uid."--";
-		if (mail($email_to,$summary_notification_subject . "$roster_date","$message",$header)) {
+		if (mail($email_to,$summary_notification_subject . "$roster_date","$message",$header, "-f ".$email_from)) {
 			if (!empty($verbose)) {
 				echo "Sent roster ($roster_name) reminder notification to coordinator.\n";
 			}

--- a/scripts/roster_reminder.php
+++ b/scripts/roster_reminder.php
@@ -305,7 +305,7 @@ if ($sendemail) {
 			}
 		} else { // using php mail()
 		  $email_to=$roster_coordinator;
-		  $header = "From: ".$email_from.$eol;
+		  $header = "From: \"".addslashes($email_from_name)."\" <".$email_from.">".$eol;
 		  $header .= "MIME-Version: 1.0".$eol;
 		  $header .= "Bcc: ".$emails_string.$eol;
 		  $header .= "Content-Type: multipart/mixed; boundary=\"".$uid."\"";
@@ -358,7 +358,7 @@ if ($sendemail) {
 		}
 	} else {
 		$email_to=$roster_coordinator;
-		$header = "From: ".$email_from.$eol;
+		$header = "From: \"".addslashes($email_from_name)."\" <".$email_from.">".$eol;
 		$header .= "MIME-Version: 1.0".$eol;
 		$header .= "Content-Type: multipart/mixed; boundary=\"".$uid."\"";
 		$message = "--".$uid.$eol;


### PR DESCRIPTION
Addresses #705 by setting envelope from to the EMAIL_FROM value, for users with PHP_MAIL=1 set in the ini config (the default is PHP_MAIL=0).

Although I think setting the envelope from is a much better default behaviour, this change is not backwards-compatible, so it should probably be called out in the release notes. Previously, assuming roster_reminders.php was run as root, the envelope from would have been root@<server fqdn>, and the change from root@ to whatever EMAIL_FROM is will certainly be noticed, and will change what users see as the sender.

A second commit sets the From: header to include EMAIL_FROM_NAME. I think the lack of this was just an oversight, as I get the impression very few people use PHP_MAIL=1.