### PR TITLE
'Export check-ins' ignores date parameters

### DIFF
--- a/views/view_0_export_checkins.class.php
+++ b/views/view_0_export_checkins.class.php
@@ -16,7 +16,7 @@ class View__Export_Checkins extends View
 			$to = process_widget('to', Array('type' => 'date')).' 23:59:59';
 			$params['-timestamp'] = Array($from, $to);
 			$params['venueid'] = $_REQUEST['venueid'];
-			$this->data = $GLOBALS['system']->getDBObjectData('checkin', $params);
+			$this->data = $GLOBALS['system']->getDBObjectData('checkin', $params, 'AND');
 			if ($this->data) {
 				header("Content-type: text/csv");
 				header("Content-Disposition: attachment; filename=checkins.csv");
@@ -45,7 +45,7 @@ class View__Export_Checkins extends View
 		Please select the date range to export:
 		<form method="post" class="form-horizontal well">
 		From <?php print_widget('from', Array('type' => 'date'), date('Y-m-d', strtotime('-1 month'))); ?>
-		to <?php print_widget('from', Array('type' => 'date'), date('Y-m-d')); ?>
+		to <?php print_widget('to', Array('type' => 'date'), date('Y-m-d')); ?>
 		<?php
 		?>
 		<input type="submit" class="btn" />


### PR DESCRIPTION
If one goes to Attendance -> Checkins, there is a form letting one pick a date range for checkins to export:
![image](https://user-images.githubusercontent.com/205995/149683194-6911fe58-82b3-4dfc-a01e-6588efd92672.png)
In Jethro 2.31.1 specifying the date range does nothing. You always get back CSV containing every checkin ever made.

Attached is a small patch fixing the logic in two places: a copy-paste error in the form fields ('from' and 'from' should be 'from' and 'to'), and the SQL should AND the 'venue' clause with the date clause.