### PR TITLE
Load person history column

### DIFF
--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -831,7 +831,7 @@ class Person extends DB_Object
 	function getInstancesQueryComps($params, $logic, $order)
 	{
 		$res = parent::getInstancesQueryComps($params, $logic, $order);
-		$res['select'][] = 'f.family_name, f.address_street, f.address_suburb, f.address_state, f.address_postcode, f.home_tel, c.name as congregation, ab.label as age_bracket';
+		$res['select'][] = 'person.history, f.family_name, f.address_street, f.address_suburb, f.address_state, f.address_postcode, f.home_tel, c.name as congregation, ab.label as age_bracket';
 		$res['from'] = '(('.$res['from'].')
 						JOIN family f ON person.familyid = f.id)
 						LEFT JOIN congregation c ON person.congregationid = c.id


### PR DESCRIPTION
Fixes #836 

Explicitly load the person history column so that the history value is an array and not an empty string.