### PR TITLE
Set X-Jethro-User header, etc, to identify user operations in webserver logs

### DIFF
--- a/include/system_controller.class.php
+++ b/include/system_controller.class.php
@@ -81,6 +81,8 @@ class System_Controller
 
 	public function run()
 	{
+
+		$this->setGlobalHeaders();
 		if (!empty($_REQUEST['call'])) {
 			$this->initErrorHandler();
 			$call_name = str_replace('/', '', $_REQUEST['call']);
@@ -378,6 +380,21 @@ class System_Controller
 
 		if (substr(BASE_URL, -1) != '/') {
 			trigger_error("Configuration file error: Your BASE_URL must end with a slash", E_USER_ERROR);
+		}
+	}
+
+	public function setGlobalHeaders()
+	{
+        	if (session_id()) {
+			// log just a subset for security
+			header('X-Jethro-Session: '.substr(session_id(), 0, 5));
+		}
+		if (!empty($_SESSION['user'])) {
+			header('X-Jethro-User: '.array_get($_SESSION['user'], 'username'));
+			header('X-Jethro-UID: '.array_get($_SESSION['user'], 'username'));
+		} elseif (!empty($_SESSION['member'])) {
+			header('X-Jethro-User: '.array_get($_SESSION['member'], 'email'));
+			header('X-Jethro-UID: '.array_get($_SESSION['member'], 'id'));
 		}
 	}
 }

--- a/include/system_controller.class.php
+++ b/include/system_controller.class.php
@@ -391,7 +391,7 @@ class System_Controller
 		}
 		if (!empty($_SESSION['user'])) {
 			header('X-Jethro-User: '.array_get($_SESSION['user'], 'username'));
-			header('X-Jethro-UID: '.array_get($_SESSION['user'], 'username'));
+			header('X-Jethro-UID: '.array_get($_SESSION['user'], 'id'));
 		} elseif (!empty($_SESSION['member'])) {
 			header('X-Jethro-User: '.array_get($_SESSION['member'], 'email'));
 			header('X-Jethro-UID: '.array_get($_SESSION['member'], 'id'));


### PR DESCRIPTION
In webserver access logs, it is useful to see which Jethro user made each request. This patch makes that possible to adding 3 new HTTP response headers:

- `X-Jethro-User` is the username (for staff) or email (for members)
- `X-Jethro-UID` is the internal ID. This is consistent across staff/member logins which might make it preferable to `X-Jethro-User` (also avoids logging PII).
- `X-Jethro-Session` is a subset (for privacy) of the session id

These could be used in an Apache `LogFormat` directive as follows:

```
LogFormat "%v:%p %a %{X-Jethro-Session}o %{X-Jethro-User}o %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %D uid=%{X-Jethro-UID}o" vhost_combined_timed
```

Note: it is also possible to pass 'notes' from PHP to Apache:
```
apache_note('jethrouser', array_get($_SESSION['user'], 'username'));
```
then logged with `%{jethrouser}n`. However `apache_note()` doesn't work with php-fpm, or other webservers like nginx, so headers are better.