### PR TITLE
#940 - recreate deleted congregations to keep the foreign key constraint happy

### DIFF
--- a/upgrades/2023-upgrade-to-2.34.sql
+++ b/upgrades/2023-upgrade-to-2.34.sql
@@ -41,11 +41,15 @@ where volunteer_group NOT IN (select id from _person_group);
 ALTER TABLE roster_role
 ADD CONSTRAINT `rr_groupid` FOREIGN KEY (volunteer_group) REFERENCES _person_group(id) ON DELETE RESTRICT;
 
-ALTER TABLE service
-ADD CONSTRAINT `service_congregationid` FOREIGN KEY (congregationid) REFERENCES congregation(id) ON DELETE RESTRICT;
-
 ALTER TABLE congregation
 DROP column print_quantity;
 
 ALTER TABLE congregation
 ADD COLUMN holds_persons VARCHAR(255) NOT NULL DEFAULT '1';
+
+-- Recreate deleted congregations referred to be services, so our new foreign key (added in next line) works
+INSERT INTO congregation (id, long_name, name, meeting_time, attendance_recording_days, holds_persons)
+SELECT DISTINCT congregationid, concat('Deleted Congregation ', congregationid), concat('Deleted Congregation ', congregationid), '', 0, 0 FROM service WHERE NOT EXISTS (SELECT * FROM congregation WHERE id=service.congregationid);
+
+ALTER TABLE service
+ADD CONSTRAINT `service_congregationid` FOREIGN KEY (congregationid) REFERENCES congregation(id) ON DELETE RESTRICT;


### PR DESCRIPTION
Since 2.34 and #834 it is no longer possible to delete a congregation without first deleting it's services. But existing databases may well have orphan `service`s, and we need to deal with them during the upgrade.

This patch recreates the deleted `congregation` rows ,so the orphaned `service`s are orphaned no longer, and the foreign key can be enforced. We use the new `holds_persons` flag to mark them inactive. In Jethro's UI the resurrected congregations look like this:

![image](https://github.com/tbar0970/jethro-pmm/assets/205995/ebfe5dd4-4058-4ca9-8047-0368da52f90d)

The alternative approach would be to just delete `service`s with no congregation, but that seems less safe - deleting services should be done by hand in the UI, as the comment in the screenshot says.
