### PR TITLE
#947 - avoid double-creating temp files

### DIFF
--- a/views/view_0_send_mc_campaign.class.php
+++ b/views/view_0_send_mc_campaign.class.php
@@ -61,7 +61,7 @@ class View__Send_MC_Campaign extends View
 			if ($attachment_error) return; // Do not send.
 
 			$zip = new ZipArchive();
-			$zip_name = str_replace('.tmp', '', tempnam(sys_get_temp_dir(), 'mailchimp_content')).'.zip';
+			$zip_name = str_replace('.tmp', '', tempnam(sys_get_temp_dir(), 'mailchimp_content-zip'));
 			if (!$zip->open($zip_name, ZipArchive::CREATE)) {
 				trigger_error("Could not create zip archive to submit to mailchimp", E_USER_ERROR);
 				exit;

--- a/views/view_2_families__4_contact_list.class.php
+++ b/views/view_2_families__4_contact_list.class.php
@@ -384,7 +384,7 @@ class View_Families__Contact_List extends View
 				$cell = $table->addCell($imageWidthTwips, $narrowCellProps);
 				$imageStyle = (count($family['all']) == 1) ? $singleImageStyle : $familyImageStyle;
 				if ($family['have_photo'] || (count($family['all']) == 1 && $family['have_person_photo'])  ) {
-					$tempfile = str_replace('.tmp', '', tempnam(sys_get_temp_dir(), 'contactlistphoto')).'.jpg';
+					$tempfile = str_replace('.tmp', '', tempnam(sys_get_temp_dir(), 'contactlistphoto-jpg'));
 					$cleanup[] = $tempfile;
 					file_put_contents($tempfile, Photo_Handler::getPhotoData('family', $family['familyid']));
 					try {
@@ -499,7 +499,7 @@ class View_Families__Contact_List extends View
 		}
 		if (file_exists($templateFilename)) {
 			require_once 'include/odf_tools.class.php';
-			$outname = tempnam(sys_get_temp_dir(), 'contactlist').'.docx';
+			$outname = tempnam(sys_get_temp_dir(), 'contactlist-docx-');
 			copy($templateFilename, $outname);
 			ODF_Tools::insertFileIntoFile($tempname, $outname, '%CONTACT_LIST%');
 			$replacements = Array('SYSTEM_NAME' => SYSTEM_NAME, 'MONTH' => date('F Y'));


### PR DESCRIPTION
The PHP `tempnam` function creates an empty file, which isn't cleaned up by code like this:
```
$tempfile = tempnam(sys_get_temp_dir(), 'contactlist').'.docx';
....
unlink($tempfile);
```