### PR TITLE
Remove underlines from action links

### DIFF
--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -567,7 +567,6 @@ ul {
 	opacity: 0.4;
 }
 #body a:not(.label), .modal a, .clickable, button.btn-link, input.btn-link {
-	text-decoration: underline;
 	color: @linkColor;
 }
 #body a.btn, .modal a.btn {


### PR DESCRIPTION
I think this UI tweak, removing underline links, makes the UI a bit cleaner. WDYT?

Before/after screenshots:

## Dashboard
#### Before
![image](https://github.com/tbar0970/jethro-pmm/assets/205995/99931474-15a6-454d-a4de-87975a9cff19)
#### After
![image](https://github.com/tbar0970/jethro-pmm/assets/205995/cddf7d36-4bfd-4b44-9a96-6233afae6ad2)

## Person action links
#### Before
![image](https://github.com/tbar0970/jethro-pmm/assets/205995/d5b4c213-04d6-4605-88dd-fc0555c50dc3)
#### After
![image](https://github.com/tbar0970/jethro-pmm/assets/205995/0c538fbb-d192-46b3-909f-93cd30036403)


## Groups
#### Before
![image](https://github.com/tbar0970/jethro-pmm/assets/205995/60379850-bad1-4ea7-bab0-24decaf22565)
#### After
![image](https://github.com/tbar0970/jethro-pmm/assets/205995/42ed2d4d-8d4a-45f7-bf1b-bd73f3e8231c)

