### PR TITLE
Avoid showing duplicate groups and group statuses when a multi-value …

### DIFF
--- a/db_objects/person_query.class.php
+++ b/db_objects/person_query.class.php
@@ -1246,10 +1246,10 @@ class Person_Query extends DB_Object
 								$joined_groups = TRUE;
 							}
 							if ($field == 'groups') {
-								$query['select'][] = 'GROUP_CONCAT(pg.name ORDER BY pg.name SEPARATOR "\n") as person_groups';
+								$query['select'][] = 'GROUP_CONCAT(DISTINCT pg.name ORDER BY pg.name SEPARATOR "\n") as person_groups';
 							} else if ($field == 'membershipstatus') {
 								$query['from'] .= ' LEFT JOIN person_group_membership_status pgms ON pgms.id = pgm.membership_status';
-								$query['select'][] = 'GROUP_CONCAT(pgms.label ORDER BY pg.name SEPARATOR "\n") as `Membership Status`';
+								$query['select'][] = 'GROUP_CONCAT(DISTINCT pgms.label ORDER BY pg.name SEPARATOR "\n") as `Membership Status`';
 							}
 						}
 


### PR DESCRIPTION
…custom field is being shown. Fixes #960

Once the fix is applied, the example report described on #960 shows:
![image](https://github.com/tbar0970/jethro-pmm/assets/205995/41acc5fc-e515-4555-915e-73504600c713)