### PR TITLE
mailchimp_sync.php shouldn't break on 'permanently deleted' users.

### DIFF
--- a/scripts/mailchimp_sync.php
+++ b/scripts/mailchimp_sync.php
@@ -273,7 +273,7 @@ function run_mc_sync($mc, $report_id, $list_id)
                                                                         $resp->response = json_decode($resp->response);
                                                                         // Special handling for 'member in compliance state' unavoidable error
                                                                         // See https://github.com/tbar0970/jethro-pmm/issues/656
-                                                                        if (is_object($resp->response) && ($resp->response->status == 400) && ($resp->response->title == 'Member In Compliance State')) {
+                                                                        if (is_object($resp->response) && ($resp->response->status == 400) && ($resp->response->title == 'Member In Compliance State' || $resp->response->title == 'Forgotten Email Not Subscribed')) {
                                                                                 $pemail = substr($resp->operation_id, 4); // chop of 'add-'
                                                                                 $bpersons = $GLOBALS['system']->getDBObjectData('person', Array('email' => $pemail));
                                                                                 foreach ($bpersons as $pid => $pdetail) {


### PR DESCRIPTION
Fixes #982