### PR TITLE
Clean up /tmp/jethro-mc-TSTAMP directories that mailchimp_sync.php

### DIFF
--- a/scripts/mailchimp_sync.php
+++ b/scripts/mailchimp_sync.php
@@ -291,6 +291,7 @@ function run_mc_sync($mc, $report_id, $list_id)
                                                                 }
                                                         }
                         }
+                                                rmdir_recursive($dir);
                                                 if ($all_failures) {
                                                         trigger_error("[Syncing report $report_id to list $list_id] ".$batch_res_summary['errored_operations']." mailchimp operations failed.");
                                                         bam($all_failures);
@@ -344,6 +345,16 @@ function extract_tgz_to_dir($tgzfile, $dir) {
         }
 
         $zip->close();
+}
+
+function rmdir_recursive($dir) {
+        $it = new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS);
+        $it = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::CHILD_FIRST);
+        foreach($it as $file) {
+                if ($file->isDir()) rmdir($file->getPathname());
+                else unlink($file->getPathname());
+        }
+        rmdir($dir);
 }
 
 function needsUpdate($jethroData, $mcData)


### PR DESCRIPTION
leaves around if any sync errors are encountered, or DEBUG=1 is set. Partially fixes #947
As PHP lacks a recursive `rm` I've had to write my own. Perhaps it should be moved to `include/general.php`, but it isn't used anywhere else just yet.