### PR TITLE
Fix #994 where yearless date custom fields would break in newer Jethro instances

### DIFF
--- a/db_objects/custom_field_value.class.php
+++ b/db_objects/custom_field_value.class.php
@@ -9,7 +9,7 @@ class Custom_Field_Value extends db_object
 				personid INT(11) NOT NULL,
 				fieldid INT(11) NOT NULL,
 				value_text VARCHAR(255) DEFAULT NULL,
-				value_date DATE DEFAULT NULL,
+				value_date CHAR(10) DEFAULT NULL,
 				value_optionid INT(11) DEFAULT NULL
 			) Engine=InnoDB;';
 	}

--- a/upgrades/2024-upgrade-to-2.34.2.sql
+++ b/upgrades/2024-upgrade-to-2.34.2.sql
@@ -1,0 +1,2 @@
+-- https://github.com/tbar0970/jethro-pmm/issues/994
+alter table custom_field_value modify value_date char(10);


### PR DESCRIPTION
To support yearless dates, the `custom_field_value.value_date` database field was changed from `DATE` to `char(10)`. This was done in an upgrade script, `upgrades/2015-upgrade-to-2.14.sql`, but the `getInitSQL` SQL was not also altered as it should have been:

in https://github.com/tbar0970/jethro-pmm/blob/52785b391ecf5d807742caccadf944bce453d0c8/db_objects/custom_field_value.class.php#L12 

This meant that new, post-2015 Jethro instances have a `DATE` `value_date`, and break as above with 'Allow blank year' selected. Older Jethro instances that had `upgrades/2015-upgrade-to-2.14.sql` have a `char(10)` `value_date`, and work correctly.

This PR fixes the `getInitSQL` SQL, and adds an upgrade script to change `DATE` to `char(10)`. The SQL does nothing if the field is already `char(10)`. 
