### PR TITLE
Improve error message if conf.php has wrong permissions

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,11 +28,20 @@ define('JETHRO_ROOT', dirname(__FILE__));
 define('TEMPLATE_DIR', JETHRO_ROOT.'/templates/');
 
 // Load configuration
-if (!is_readable(JETHRO_ROOT.'/conf.php')) {
-	trigger_error('Jethro configuration file not found.  You need to copy conf.php.sample to conf.php and edit it before Jethro can run', E_USER_ERROR);
+$conf=JETHRO_ROOT.'/conf.php';
+if (!file_exists($conf)) {
+	$errmsg = "Jethro configuration file not found.  You need to copy $conf.sample to $conf and edit it before Jethro can run";
+	echo $errmsg;
+	trigger_error($errmsg, E_USER_ERROR);
 	exit();
 }
-require_once JETHRO_ROOT.'/conf.php';
+if (!is_readable($conf)) {
+	$errmsg = "$conf not readable by user ".$_SERVER["USER"].".";
+	echo $errmsg;
+	trigger_error($errmsg, E_USER_ERROR);
+	exit();
+}
+require_once $conf;
 
 define('DB_MODE', 'PRIVATE');
 require_once JETHRO_ROOT.'/include/init.php';


### PR DESCRIPTION
When setting up Jethro, if `conf.php` exists but is not readable by the runtime PHP user, the browser returns a generic 500 error:

![image](https://github.com/tbar0970/jethro-pmm/assets/205995/c173b671-3e36-4bf2-837e-85979782590d)

and in the Apache error log we get this (incorrect) error message:

`
[Sat Jan 20 16:15:10.546667 2024] [proxy_fcgi:error] [pid 1746389:tid 140317700662848] [remote 100.94.18.157:48972] AH01071: Got error 'PHP message: PHP Fatal error:  Jethro configuration file not found.  You need to copy conf.php.sample to conf.php and edit it before Jethro can run in /home/jethro/code/2.34.1/app/index.php on line 32'
`

The attached patch to `index.php` improves error messages so that both the web browser and Apache logs see the message, and
- if `conf.php` does not exist, the user sees:
 `Jethro configuration file not found. You need to copy /home/jethro/code/2.34.1/app/conf.php.sample to /home/jethro/code/2.34.1/app/conf.php and edit it before Jethro can run`
- if `conf.php` exists but is not readable, the runtime user is mentioned in the error message:
  `/home/jethro/code/2.34.1/app/conf.php not readable by user www-data.`


