### PR TITLE
Fix cleanup when there isn't an error

### DIFF
--- a/scripts/mailchimp_sync.php
+++ b/scripts/mailchimp_sync.php
@@ -290,8 +290,8 @@ function run_mc_sync($mc, $report_id, $list_id)
                                                                         }
                                                                 }
                                                         }
-                        }
-                                                rmdir_recursive($dir);
+                                                        rmdir_recursive($dir);
+                                                }
                                                 if ($all_failures) {
                                                         trigger_error("[Syncing report $report_id to list $list_id] ".$batch_res_summary['errored_operations']." mailchimp operations failed.");
                                                         bam($all_failures);


### PR DESCRIPTION
My last Mailchimp PR https://github.com/tbar0970/jethro-pmm/pull/984 introduced a bug. The script would break (after successfully syncing) if debug=0 and there _weren't_ any sync errors:
```
PHP Fatal error:  Uncaught RuntimeException: Directory name must not be empty. in /home/jethro/code/2.34.1/app/scripts/mailchimp_sync.php:351
```
Fixed by moving the cleanup line into the correct code block.