### PR TITLE
Fix #1052 by handling the case when no select-list options were picked in the filter

### DIFF
--- a/db_objects/person_query.class.php
+++ b/db_objects/person_query.class.php
@@ -1059,21 +1059,26 @@ class Person_Query extends DB_Object
 				case 'select':
 					switch (array_get($values, 'criteria', 'contains')) {
 						case 'contains':
-							$ids = implode(',', array_map(Array($db, 'quote'), $values['val']));
-							$xrule = '(pd'.$fieldid.'.value_optionid IN ('.$ids.'))';
-							if (in_array(0, $values['val'])) {
-								// 'other' option
-								$xrule = '('.$xrule.' OR (pd'.$fieldid.'.value_text IS NOT NULL))';
+							if ($values['val']) {
+								$ids = implode(',', array_map(Array($db, 'quote'), $values['val']));
+								$xrule = '(pd'.$fieldid.'.value_optionid IN ('.$ids.'))';
+								if (in_array(0, $values['val'])) {
+									// 'other' option
+									$xrule = '('.$xrule.' OR (pd'.$fieldid.'.value_text IS NOT NULL))';
+								}
+								$customFieldWheres[] = $xrule;
+							} else {
+								// No options were picked for a select list custom field. Same as 'empty' ('not filled in')
+								$customFieldWheres[] = '(pd'.$fieldid.'.value_optionid IS NULL AND pd'.$fieldid.'.value_text IS NULL)';
 							}
-							$customFieldWheres[] = $xrule;
-							break;
-						case 'any':
-							$customFieldWheres[] = '(pd'.$fieldid.'.value_optionid IS NOT NULL OR pd'.$fieldid.'.value_text IS NOT NULL)';
-							break;
-						case 'empty':
-							$customFieldWheres[] = '(pd'.$fieldid.'.value_optionid IS NULL AND pd'.$fieldid.'.value_text IS NULL)';
-							break;
-					}
+								break;
+							case 'any':
+								$customFieldWheres[] = '(pd'.$fieldid.'.value_optionid IS NOT NULL OR pd'.$fieldid.'.value_text IS NOT NULL)';
+								break;
+							case 'empty':
+								$customFieldWheres[] = '(pd'.$fieldid.'.value_optionid IS NULL AND pd'.$fieldid.'.value_text IS NULL)';
+								break;
+						}
 					break;
 
 				case 'text':


### PR DESCRIPTION
You might wonder, should we not just prevent this situation in the UI?

![image](https://github.com/tbar0970/jethro-pmm/assets/205995/55c6320d-83b8-4a5d-acfe-a17f50db4a92)

Perhaps yes, but the code has to handle this case anyway, e.g. when a custom field option referenced by person reports is deleted.