### PR TITLE
Re-rank roster role assignments to fix symptom of #1078

### DIFF
--- a/upgrades/2024-upgrade-to-2.36.sql
+++ b/upgrades/2024-upgrade-to-2.36.sql
@@ -126,3 +126,6 @@ AND rra.roster_role_id = a.roster_role_id
 AND rra.personid = a.personid
 SET rra.rank = a.correctrank
 WHERE rra.rank != a.correctrank;
+
+-- Relating to the #1078 fix above: ensure that every role (roster_role_id) assigned on a given date (assignment_date) has a distinct rank.
+ALTER TABLE roster_role_assignment ADD CONSTRAINT unique_role_assignment UNIQUE (assignment_date, roster_role_id, rank);

--- a/upgrades/2024-upgrade-to-2.36.sql
+++ b/upgrades/2024-upgrade-to-2.36.sql
@@ -112,4 +112,17 @@ WHERE
    /* archived persons can only see themselves, not any family members */
 ;
 
-
+-- Fix duplicate roster role assignment ranks (https://github.com/tbar0970/jethro-pmm/issues/1078).
+UPDATE roster_role_assignment rra
+INNER JOIN
+  -- Use row_number() window function to compute the correct rank
+  (SELECT *,
+          (row_number() OVER (PARTITION BY assignment_date,
+                                           roster_role_id
+                              ORDER BY rank ASC) - 1) AS correctrank
+   FROM roster_role_assignment
+   ) a ON rra.assignment_date = a.assignment_date
+AND rra.roster_role_id = a.roster_role_id
+AND rra.personid = a.personid
+SET rra.rank = a.correctrank
+WHERE rra.rank != a.correctrank;


### PR DESCRIPTION
It's a small bit of SQL, but here is the explanation of what it does:

For some reason (https://github.com/tbar0970/jethro-pmm/issues/1078), `roster_role_assignment.rank` is sometimes duplicated when it should be unique within each `{assignment_date, roster_role_id}`:

```sql
select * from roster_role_assignment rra where assignment_date='2024-09-22' and roster_role_id=46;
+-----------------+----------------+----------+------+----------+---------------------+
| assignment_date | roster_role_id | personid | rank | assigner | assignedon          |
+-----------------+----------------+----------+------+----------+---------------------+
| 2024-09-22      |             46 |      253 |    1 |      295 | 2024-06-27 15:09:43 |
| 2024-09-22      |             46 |      297 |    0 |      295 | 2024-06-27 15:09:43 |
| 2024-09-22      |             46 |      321 |    1 |      295 | 2024-06-27 14:45:18 |
+-----------------+----------------+----------+------+----------+---------------------+
3 rows in set (0.000 sec)
```
We can identify these problem rows by checking directly for duplicated `rank` rows:
```sql
SELECT * 
FROM roster_role_assignment rra1
JOIN roster_role_assignment rra2 USING (assignment_date,
                                        roster_role_id)
WHERE rra1.personid<rra2.personid
  AND rra1.rank = rra2.rank;
+-----------------+----------------+----------+------+----------+---------------------+----------+------+----------+---------------------+
| assignment_date | roster_role_id | personid | rank | assigner | assignedon          | personid | rank | assigner | assignedon          |
+-----------------+----------------+----------+------+----------+---------------------+----------+------+----------+---------------------+
| 2024-09-22      |             46 |      253 |    1 |      295 | 2024-06-27 15:09:43 |      321 |    1 |      295 | 2024-06-27 14:45:18 |
| 2024-06-09      |             62 |        1 |    3 |        1 | 2024-06-07 15:39:35 |      348 |    3 |        1 | 2024-05-01 12:27:48 |
+-----------------+----------------+----------+------+----------+---------------------+----------+------+----------+---------------------+
2 rows in set (0.021 sec)
```

But to actually fix the values, we need to know what `rank` should be. This can be computed with a `row_number()` window function:
```sql
SELECT (row_number() OVER (PARTITION BY assignment_date,
                                        roster_role_id
                           ORDER BY rank ASC))-1 AS correctrank,
       rra.*
FROM roster_role_assignment rra
WHERE assignment_date='2024-09-22'
  AND roster_role_id=46
+-------------+-----------------+----------------+----------+------+----------+---------------------+
| correctrank | assignment_date | roster_role_id | personid | rank | assigner | assignedon          |
+-------------+-----------------+----------------+----------+------+----------+---------------------+
|           0 | 2024-09-22      |             46 |      297 |    0 |      295 | 2024-06-27 15:09:43 |
|           1 | 2024-09-22      |             46 |      321 |    1 |      295 | 2024-06-27 14:45:18 |
|           2 | 2024-09-22      |             46 |      253 |    1 |      295 | 2024-06-27 15:09:43 |
+-------------+-----------------+----------------+----------+------+----------+---------------------+
```
Then isolate just the incorrect rows:
```sql
SELECT * 
FROM
  (SELECT (row_number() OVER (PARTITION BY assignment_date,
                                           roster_role_id
                              ORDER BY rank ASC))-1 AS correctrank,
          rra.*
   FROM roster_role_assignment rra
   WHERE assignment_date='2024-09-22'
     AND roster_role_id=46 ) a
WHERE rank!=correctrank;
+-------------+-----------------+----------------+----------+------+----------+---------------------+
| correctrank | assignment_date | roster_role_id | personid | rank | assigner | assignedon          |
+-------------+-----------------+----------------+----------+------+----------+---------------------+
|           2 | 2024-09-22      |             46 |      253 |    1 |      295 | 2024-06-27 15:09:43 |
+-------------+-----------------+----------------+----------+------+----------+---------------------+
```
Removing the `WHERE` to see results across the whole database:

```sql
SELECT *
FROM
  (SELECT (row_number() OVER (PARTITION BY assignment_date,
                                           roster_role_id
                              ORDER BY rank ASC))-1 AS correctrank,
          rra.*
   FROM roster_role_assignment rra) a
WHERE rank!=correctrank;
+-------------+-----------------+----------------+----------+------+----------+---------------------+
| correctrank | assignment_date | roster_role_id | personid | rank | assigner | assignedon          |
+-------------+-----------------+----------------+----------+------+----------+---------------------+
|           0 | 2021-06-27      |             20 |      196 |    1 |        1 | 2021-06-25 12:00:48 |
|           0 | 2021-10-31      |              9 |       40 |    1 |        1 | 2021-12-01 23:35:23 |
|           0 | 2023-04-02      |             59 |      622 |    1 |      178 | 2023-03-21 09:09:05 |
|           0 | 2023-12-17      |             66 |       32 |    1 |      178 | 2023-12-04 14:11:43 |
|           1 | 2023-12-17      |             66 |       71 |    2 |      178 | 2023-12-04 14:11:43 |
|           2 | 2023-12-17      |             66 |      125 |    3 |      178 | 2023-12-04 14:11:43 |
|           3 | 2023-12-17      |             66 |      210 |    4 |      178 | 2023-12-04 14:11:43 |
|           4 | 2023-12-17      |             66 |      296 |    5 |      178 | 2023-12-04 14:11:43 |
|           5 | 2023-12-17      |             66 |      315 |    6 |      178 | 2023-12-04 14:11:43 |
|           6 | 2023-12-17      |             66 |      313 |    7 |      178 | 2023-12-04 14:11:43 |
|           7 | 2023-12-17      |             66 |      608 |    8 |      178 | 2023-12-04 14:11:43 |
|           8 | 2023-12-17      |             66 |      623 |    9 |      178 | 2023-12-04 14:11:43 |
|           9 | 2023-12-17      |             66 |      622 |   10 |      178 | 2023-12-04 14:11:43 |
|           1 | 2024-04-07      |             66 |       32 |    2 |      178 | 2024-03-20 14:20:47 |
|           2 | 2024-04-07      |             66 |      608 |    3 |      178 | 2024-03-20 14:20:47 |
|           3 | 2024-04-07      |             66 |      296 |    4 |      178 | 2024-03-20 14:20:47 |
|           0 | 2024-05-19      |             62 |      294 |    1 |        1 | 2024-05-01 12:27:48 |
|           1 | 2024-05-19      |             62 |       40 |    2 |        1 | 2024-05-01 12:27:48 |
|           2 | 2024-05-19      |             62 |      240 |    3 |        1 | 2024-05-16 09:59:10 |
|           2 | 2024-06-09      |             62 |        1 |    3 |        1 | 2024-06-07 15:39:35 |
|           2 | 2024-09-22      |             46 |      253 |    1 |      295 | 2024-06-27 15:09:43 |
+-------------+-----------------+----------------+----------+------+----------+---------------------+
```
Compared to our first query, this catches the same `2024-09-22` and `2024-06-09` instances, but also a lot more. What is wrong with `2024-05-19`, for example?

```sql
select * from roster_role_assignment where assignment_date='2024-05-19' and roster_role_id=62 order by rank;
+-----------------+----------------+----------+------+----------+---------------------+
| assignment_date | roster_role_id | personid | rank | assigner | assignedon          |
+-----------------+----------------+----------+------+----------+---------------------+
| 2024-05-19      |             62 |      294 |    1 |        1 | 2024-05-01 12:27:48 |
| 2024-05-19      |             62 |       40 |    2 |        1 | 2024-05-01 12:27:48 |
| 2024-05-19      |             62 |      240 |    3 |        1 | 2024-05-16 09:59:10 |
+-----------------+----------------+----------+------+----------+---------------------+
3 rows in set (0.000 sec)
```
The 'problem' here is just that the rank starts with 1, whereas our `row_number()` function expects `rank` to start at 0., i.e. we expect 0,1,2 where we find 1,2,3. Either will work, but for the sake of consistency, and to make the fix work, it won't hurt to re-rank these.

So wrapping up, all we need to do is set `rank` to `correctrank`:

```sql
UPDATE roster_role_assignment rra
INNER JOIN
  -- Use row_number() window function to compute the correct rank
  (SELECT *,
          (row_number() OVER (PARTITION BY assignment_date,
                                           roster_role_id
                              ORDER BY rank ASC) - 1) AS correctrank
   FROM roster_role_assignment
   ) a ON rra.assignment_date = a.assignment_date
AND rra.roster_role_id = a.roster_role_id
AND rra.personid = a.personid
SET rra.rank = a.correctrank
WHERE rra.rank != a.correctrank;
```
and our problems are fixed:

```sql
select * from roster_role_assignment where assignment_date='2024-09-22' and roster_role_id=46 order by rank;
+-----------------+----------------+----------+------+----------+---------------------+
| assignment_date | roster_role_id | personid | rank | assigner | assignedon          |
+-----------------+----------------+----------+------+----------+---------------------+
| 2024-09-22      |             46 |      297 |    0 |      295 | 2024-06-27 15:09:43 |
| 2024-09-22      |             46 |      253 |    1 |      295 | 2024-06-27 15:09:43 |
| 2024-09-22      |             46 |      321 |    2 |      295 | 2024-09-12 16:18:38 |
+-----------------+----------------+----------+------+----------+---------------------+

select * from roster_role_assignment where assignment_date='2024-06-09' and roster_role_id=62 order by rank;
+-----------------+----------------+----------+------+----------+---------------------+
| assignment_date | roster_role_id | personid | rank | assigner | assignedon          |
+-----------------+----------------+----------+------+----------+---------------------+
| 2024-06-09      |             62 |      294 |    0 |        1 | 2024-05-01 12:27:48 |
| 2024-06-09      |             62 |     1278 |    1 |        1 | 2024-05-01 12:27:48 |
| 2024-06-09      |             62 |        1 |    2 |        1 | 2024-09-12 16:18:38 |
| 2024-06-09      |             62 |      348 |    3 |        1 | 2024-05-01 12:27:48 |
+-----------------+----------------+----------+------+----------+---------------------+
4 rows in set (0.000 sec)
```
Our asymptomatic cases are also re-ranked to begin from 0:
```sql
select * from roster_role_assignment where assignment_date='2024-05-19' and roster_role_id=62 order by rank;
+-----------------+----------------+----------+------+----------+---------------------+
| assignment_date | roster_role_id | personid | rank | assigner | assignedon          |
+-----------------+----------------+----------+------+----------+---------------------+
| 2024-05-19      |             62 |      294 |    0 |        1 | 2024-09-12 16:18:38 |
| 2024-05-19      |             62 |       40 |    1 |        1 | 2024-09-12 16:18:38 |
| 2024-05-19      |             62 |      240 |    2 |        1 | 2024-09-12 16:18:38 |
+-----------------+----------------+----------+------+----------+---------------------+
