### PR TITLE
Fixes the effects of #1086, where person Age Brackets may have inadvertently be changed

### DIFF
--- a/upgrades/2024-upgrade-to-2.36-report-if-agebrackets-are-broken.php
+++ b/upgrades/2024-upgrade-to-2.36-report-if-agebrackets-are-broken.php
@@ -1,0 +1,59 @@
+<?php
+/*****************************************************************
+ * This script will report if any Persons have been incorrectly had their Age Bracket set to 'Adult',
+ * as a result of a Jethro 2.35.1 bug https://github.com/tbar0970/jethro-pmm/issues/1086
+ * If affected persons are found, the script points people to a new Jethro page which will fix the problem.
+ * This script makes no changes directly, as user input is required.
+ ******************************************************************/
+
+const SINGLE_PERSON = "single person affected";
+const MULTIPLE_PERSONS = "multiple persons affected";
+ini_set('display_errors', 1);
+error_reporting(E_ALL);
+
+define('JETHRO_ROOT', dirname(dirname(__FILE__)));
+set_include_path(get_include_path().PATH_SEPARATOR.JETHRO_ROOT);
+require_once JETHRO_ROOT.'/conf.php';
+define('DB_MODE', 'private');
+require_once JETHRO_ROOT.'/include/init.php';
+require_once JETHRO_ROOT.'/upgrades/upgradefixes/2.5.1_fix_agebrackets/AgeBracketChangesFixer.php';
+require_once JETHRO_ROOT.'/include/user_system.class.php';
+
+$GLOBALS['user_system'] = new User_System();
+$GLOBALS['user_system']->setCLIScript();
+
+require_once JETHRO_ROOT.'/include/system_controller.class.php';
+$GLOBALS['system'] = System_Controller::get();
+
+$badchangegroups = AgeBracketChangesFixer::getBadChangeGroups();
+
+// We're interested if any of our BadChangeGroups affect >1 user. If so that's a very likely indication of problems.
+// Partition our BadChangeGroups into $groupedchanges[1] (single-person affected) and $groupedchanges['n'] (multiple persons affected).
+$groupedchanges = array_reduce($badchangegroups, function ($carry, $cg) {
+	if ($cg->isBulkEdit()) {
+		$carry[MULTIPLE_PERSONS][] = $cg;
+	} else {
+		$carry[SINGLE_PERSON][] = $cg;
+	}
+	return $carry;
+}, []);
+
+if (!empty($groupedchanges)) {
+	if (array_key_exists(MULTIPLE_PERSONS, $groupedchanges)) {
+		// Bulk edit definitely caused problems. Report affected persons by name.
+		$allaffected = array_map(fn($gc) => $gc->getAffectedPersons(), $groupedchanges[MULTIPLE_PERSONS]);
+		$allaffected = array_unique(array_merge(...$allaffected));
+		print("Warning: ".count($allaffected)." people have been incorrectly turned into Adults by bug https://github.com/tbar0970/jethro-pmm/issues/1086:".PHP_EOL);
+	} elseif (array_key_exists(SINGLE_PERSON, $groupedchanges)) {
+		$allaffected = array_map(fn($gc) => $gc->getAffectedPersons(), $groupedchanges[SINGLE_PERSON]);
+		$allaffected = array_unique(array_merge(...$allaffected));
+		print("Warning: ".count($allaffected)." people MAY have been incorrectly turned into Adults by bug https://github.com/tbar0970/jethro-pmm/issues/1086:".PHP_EOL);
+	}
+	foreach ($allaffected as $affected) {
+		print($affected.PHP_EOL);
+	}
+	print("Please go to Admin -> Fix Broken Age Brackets to fix this".PHP_EOL);
+}
+//AgeBracketChangesFixer::printBadChanges($badchanges);
+//AgeBracketChangesFixer::fix($badChanges);
+exit(0);

--- a/upgrades/upgradefixes/2.5.1_fix_agebrackets/AgeBracketChangesFixer.php
+++ b/upgrades/upgradefixes/2.5.1_fix_agebrackets/AgeBracketChangesFixer.php
@@ -1,0 +1,345 @@
+<?php
+
+/**
+ * Static functions for identifying and fixing incorrect person Age Brackets caused by https://github.com/tbar0970/jethro-pmm/issues/1086
+ * This is used as an upgrade report (upgrades/2024-upgrades-to-2.36-report-if-agebrackets-are-broken.php)
+ * and by the interactive view (views/view_10_admin__10_fix_broken_age_brackets.class.php).
+ */
+class AgeBracketChangesFixer
+{
+	/**
+	 * Identify persons that may have been incorrectly set to age bracket 'Adult' during a bulk edit.
+	 * @return BadChangeGroup[]  An array of instances where Age Bracket may have gone wrong, each grouped by bulk edit.
+	 */
+	public static function getBadChangeGroups(): array
+	{
+		$adult = self::getDefaultAgeBracketLabel(); // usually 'Adult' - this is what the edit form defaulted to
+		$sql = 'SELECT _person.* from _person 
+			 JOIN age_bracket ON _person.age_bracketid = age_bracket.id
+			 WHERE age_bracket.is_default=1 AND history like \'%Age bracket changed from "%" to "'.$adult.'"%\';';
+		// _person db records, indexed by id
+		$persons = array_reduce(
+			$GLOBALS['db']->queryAll($sql),
+			function ($all, $row) {
+				$all[$row['id']] = $row;
+				return $all;
+			},
+			[]);
+		$dateBuggyJethroReleased = strtotime("2024-05-30");
+
+		// The fact that N changes were made 'together' is an important indicator that bulk change (and hence the bug)
+		// was involved. So our first step is to group likely problems by time.
+		// $tstamp_to_affectedpersons is an array of [quantizedtimestamp -> [personid -> BadChange]]
+		$tstamp_to_affectedpersons = [];
+		foreach ($persons as $personid => $persondetails) {
+			$hist = unserialize($persondetails['history']);
+			if (!$hist) {
+				echo "Could not unserialize person $personid history";
+				continue;
+			}
+			foreach (array_reverse($hist, true) as $time => $histrecord) {
+				if ($time < $dateBuggyJethroReleased) break; // Ignore history record that happened before the buggy Jethro was released
+				$histlines = explode(PHP_EOL, $histrecord); // Separate lines of history record
+				if (count($histlines) <= 2) continue; // Besides the 'Updated by' and 'Age bracket changed from ..' line, there must be some other change for the Age bracket change to have been accidental
+				$oldAgeBrackets = array_filter(array_map(function ($line) use ($adult) {
+					if (preg_match('/Age bracket changed from "(.*)" to "'.$adult.'"/', $line, $match)) {
+						return $match[1];
+					} else return null;
+				}, $histlines));
+				if (empty($oldAgeBrackets)) continue;  // This change doesn't change 'Age Bracket'.
+				$oldagebracket = array_values($oldAgeBrackets)[0];
+				$badchange = new BadChange($time, $personid, $oldagebracket, $adult, $persondetails, $histlines);
+				$quantized_timestamp = intval($time / 10) * 10; // Group by 10s intervals in case a bulk edit took more than 1s
+				$tstamp_to_affectedpersons[$quantized_timestamp][$personid] = $badchange;
+				break; // We've found the most recent 'Age bracket changed' history item; older ones are irrelevant, so finish with this person.
+			}
+		}
+
+		// Iterate through person changes grouped by time. Confirm the grouped changes were bulk edits, i.e. the changes were made by the same person
+		$badchangegroups = [];
+		foreach ($tstamp_to_affectedpersons as $time => $badchange) {
+			$firstlines = array_map(function ($changeinfo) {
+				return $changeinfo->getHistLines()[0];
+			}, $badchange);
+			if (count(array_unique($firstlines)) != 1) trigger_error("First lines in history are expected to always be 'Updated by ...", E_USER_ERROR);
+			$oldagebracket = array_values(array_unique($firstlines))[0];
+			if (preg_match('/Updated by ([\w\s]+) \(#(\d+)\)/', $oldagebracket, $matches)) {
+				$updater = $matches[1];
+				$updaterid = $matches[2];
+			} else {
+				trigger_error('First line of change, '.$firstlines[1].' does not match expected /Updated by ... (#...)/ regex.', E_USER_ERROR);
+			}
+			// Get the other fields changed (e.g. 'Status'), that the user was trying to set, when they accidentally set 'Age bracket'
+			$other_changed_fieldnames = array_values(array_map(function ($personinfo) use ($adult) {
+				return array_values(array_map(function ($histline) {
+					return preg_replace('/(.+) changed from "(.*)" to "(.*)"/', '\1', $histline);
+				}, array_filter($personinfo->getHistLines(), function ($histline) use ($adult) {
+					return !preg_match('/^Updated by /', $histline) &&
+						!preg_match('/Age bracket changed from ".+" to "'.$adult.'"/', $histline);
+				})));
+			}, $badchange));
+			$other_changed_fieldnames = array_unique(array_merge(...$other_changed_fieldnames));
+
+			$badchangegroup = new BadChangeGroup($time, $updater, $updaterid, $other_changed_fieldnames, $badchange);
+			$badchangegroups[$time] = $badchangegroup;
+		}
+		// Sort by the number of persons affected, ascending. The low-count changes are more likely to not be buggy.
+		uasort($badchangegroups, fn($a, $b) => ($a->count() <=> $b->count()));
+		return $badchangegroups;
+	}
+
+	/**
+	 * @param BadChangeGroup[] $badchangegroups
+	 * @return BadChangeFixInfo[]
+	 *
+	 */
+	public static function fix($badchangegroups): array
+	{
+		$results = [];
+		foreach ($badchangegroups as $id => $cg) {
+			foreach ($cg->getBadChanges() as $badchange) {
+				$results[] = self::fixBadChange($badchange);
+			}
+		}
+		return $results;
+	}
+
+	/**
+	 * Fix the 'Age Bracket' of all persons in a BadChange. The change will be recorded in the person's history as done by user 'system'.
+	 * @param BadChange $badchange
+	 * @return BadChangeFixInfo
+	 */
+	public static function fixBadChange(BadChange $badchange): BadChangeFixInfo
+	{
+		$GLOBALS['system']->includeDBClass('person');
+		$person = new Person();
+		$person->load($badchange->getPersonId());
+		$person->setValue('age_bracketid', self::_getAgeBracketIdByLabel($badchange->getOldagebracket()));
+
+		// We don't want the current user recorded in the issue history as the 'fixer', as this is conceptually something Jethro would fix itself.
+		$_SESSION['user']['first_name'] = 'system';
+		$_SESSION['user']['last_name'] = '';
+		$_SESSION['id']['id'] = -1;
+		$person->save();
+		return new BadChangeFixInfo($person->id, $person->toString(), $person->getValue('history'), $badchange->getOldAgebracket());
+}
+
+	/**
+	 * Return the default Age Bracket name, usually 'Adult'.
+	 * @return string
+	 */
+	static function getDefaultAgeBracketLabel(): string
+	{
+		return $GLOBALS['db']->queryOne("select label from age_bracket where is_default=1;");
+	}
+
+	/**
+	 * Return the database id of the given Age Bracket. If $label isn't found an error is triggered.
+	 * @param $label e.g. 'Adult'
+	 * @return int e.g. 1
+	 */
+	private static function _getAgeBracketIdByLabel($label) : int
+	{
+		$id = $GLOBALS['db']->queryOne("select id from age_bracket where label=".$GLOBALS['db']->quote($label));
+		if (is_null($id)) trigger_error("No age bracket '$label'.");
+		return $id;
+	}
+}
+
+/**
+ * A collection of BadChanges that happened at (roughly) the same time, by the same person.
+ * If a BadChangeGroup contains more than one BadChange, that indicates a Bulk Edit happened and the Age Bracket changes are likely wrong.
+ * If the BadChangeGroup contains just one BadChange, it might be a bulk edit (affected by the bug) or a regular edit (not affected).
+ **/
+class BadChangeGroup
+{
+	private int $quantized_time;
+	private string $updater;
+	private int $updaterid;
+	/**
+	 * @var array<string>
+	 */
+	private array $other_changed_fieldnames;
+	/** @var BadChange[] $changes */
+	private array $changes;
+
+	public function __construct(int $quantized_time, string $updater, int $updaterid, array $other_changed_fieldnames, array $agebracket_change_info)
+	{
+		$this->quantized_time = $quantized_time;
+		$this->updater = $updater;
+		$this->updaterid = $updaterid;
+		$this->other_changed_fieldnames = $other_changed_fieldnames;
+		$this->changes = $agebracket_change_info;
+	}
+
+	public function getId(): int
+	{
+		return $this->quantized_time;
+	}
+
+	public function getUpdater(): string
+	{
+		return $this->updater;
+	}
+
+	public function getUpdaterid(): int
+	{
+		return $this->updaterid;
+	}
+
+	public function getQuantizedTimestamp(): string
+	{
+		return $this->quantized_time;
+	}
+
+	public function getQuantizedTime(): string
+	{
+		return format_datetime($this->quantized_time);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getOtherChangedFieldNames(): array
+	{
+		return $this->other_changed_fieldnames;
+	}
+
+	/** More than one change at the same time, i.e. a bulk edit. */
+	public function isBulkEdit(): bool
+	{
+		return count($this->changes) > 1;
+	}
+	/**
+	 * Number of persons changed. If only one, this might not have been a bulk edit affected by the bug!
+	 * @return int
+	 */
+	public function count(): int
+	{
+		return count($this->changes);
+	}
+
+	/**
+	 * @return BadChange[]
+	 */
+	public function getBadChanges(): array
+	{
+		return $this->changes;
+	}
+
+	public function getAffectedPersons(): array
+	{
+		return array_unique(array_map(fn($c) => $c->getPersonName(), $this->changes));
+	}
+
+	public function toString(): string
+	{
+		return "On ".$this->getQuantizedTime().", ".$this->getUpdater()." changed ".$this->count()." ".($this->count() == 1 ? "person" : "people")." to '".AgeBracketChangesFixer::getDefaultAgeBracketLabel()."', when changing other fields ".(implode(', ', array_map(fn($s) => "'".$s."'", $this->other_changed_fieldnames))).PHP_EOL;
+	}
+}
+
+/**
+ * Information about a single point in time when Age Bracket changed (possibly incorrectly) to Adult.
+ */
+class BadChange
+{
+	/**
+	 * @param int $time
+	 * @param int $personid
+	 * @param string $oldagebracket
+	 * @param array $persondetail
+	 * @param array $histlines
+	 */
+	public function __construct(int $time, int $personid, string $oldagebracket, string $newagebracket, array $persondetail, array $histlines)
+	{
+		$this->time = $time;
+		$this->personid = $personid;
+		$this->oldagebracket = $oldagebracket;
+		$this->newagebracket = $newagebracket;
+		$this->histlines = $histlines;
+		$this->persondetail = $persondetail;
+	}
+
+	public function getTime(): int
+	{
+		return $this->time;
+	}
+
+	public function getPersonid(): int
+	{
+		return $this->personid;
+	}
+
+	public function getPersonName(): string
+	{
+		return $this->persondetail['first_name'].' '.$this->persondetail['last_name'];
+	}
+
+	public function getHistlines(): array
+	{
+		return $this->histlines;
+	}
+
+	public function getPersondetail(): array
+	{
+		return $this->persondetail;
+	}
+
+	public function getNewagebracket(): string
+	{
+		return $this->newagebracket;
+	}
+
+	public function getOldagebracket(): string
+	{
+		return $this->oldagebracket;
+	}
+}
+class BadChangeFixInfo
+{
+	private $personid;
+	private $personname;
+	private $history;
+	private $agebracket;
+
+	/**
+	 * @return mixed
+	 */
+	public function getPersonid()
+	{
+		return $this->personid;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getPersonName()
+	{
+		return $this->personname;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getHistory()
+	{
+		return $this->history;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getAgebracket()
+	{
+		return $this->agebracket;
+	}
+
+	public function __construct($personid, $personname, $history, $agebracket)
+	{
+
+		$this->personid = $personid;
+		$this->personname = $personname;
+		$this->history = $history;
+		$this->agebracket = $agebracket;
+	}
+}

--- a/upgrades/upgradefixes/2.5.1_fix_agebrackets/AgeBracketChangesFixer.php
+++ b/upgrades/upgradefixes/2.5.1_fix_agebrackets/AgeBracketChangesFixer.php
@@ -63,7 +63,7 @@ class AgeBracketChangesFixer
 			}, $badchange);
 			if (count(array_unique($firstlines)) != 1) trigger_error("First lines in history are expected to always be 'Updated by ...", E_USER_ERROR);
 			$oldagebracket = array_values(array_unique($firstlines))[0];
-			if (preg_match('/Updated by ([\w\s]+) \(#(\d+)\)/', $oldagebracket, $matches)) {
+			if (preg_match('/Updated by (.+) \(#(\d+)\)/', $oldagebracket, $matches)) {
 				$updater = $matches[1];
 				$updaterid = $matches[2];
 			} else {

--- a/views/view_10_admin__10_fix_broken_age_brackets.class.php
+++ b/views/view_10_admin__10_fix_broken_age_brackets.class.php
@@ -1,0 +1,176 @@
+<?php
+require_once JETHRO_ROOT.'/upgrades/upgradefixes/2.5.1_fix_agebrackets/AgeBracketChangesFixer.php';
+
+/**
+ * Shows bulk edits that incorrectly set 'Age Bracket' (https://github.com/tbar0970/jethro-pmm/issues/108), and fixes the changes that the user indicates are incorrect.
+ */
+class View_Admin__Fix_Broken_Age_brackets extends View
+{
+	private $_stage = 'begin';
+	/**
+	 * @var BadChangeGroup[]
+	 */
+	private array $_affectedpersons;
+	/**
+	 * @var BadChangeFixInfo[]
+	 */
+	private $_fixresults;
+
+	static function getMenuPermissionLevel()
+	{
+		return PERM_SYSADMIN;
+	}
+
+	function getTitle()
+	{
+		return 'Fix Broken Age Brackets';
+	}
+
+	function printView()
+	{
+		switch ($this->_stage) {
+			case 'begin':
+				$this->_printBeginView();
+				break;
+
+			case 'done':
+				$this->_printDoneView();
+				break;
+		}
+	}
+
+	function processView()
+	{
+		if (!empty($_REQUEST['done'])) {
+			$this->_stage = 'done';
+		} else if (!empty($_POST['confirm_fix'])) {
+			$this->_processFix();
+		} else {
+			$this->_findAffectedPersons();
+		}
+	}
+
+
+	private function _printBeginView()
+	{
+		$text = "Jethro 2.35.1 had a bug <a href='https://github.com/tbar0970/jethro-pmm/issues/1086'>(#1086)</a> where bulk editing persons would reset people's Age Bracket to '".AgeBracketChangesFixer::getDefaultAgeBracketLabel()."'. This page lets you revert 'Age Bracket' to the original value for  affected persons.
+		Note:  If a change affected just one person, we can't tell if it was a bulk edit, or a regular edit where Age Bracket was deliberately changed. Please review the single-person changes carefully. The multi-person changes are more likely to be incorrect, and these ticked by default.";
+		$text = '<p class="text">'.str_replace("\n", '</p><p class="text">', $text);
+		print_message($text, 'info', true);
+		?>
+        <form method="post" enctype="multipart/form-data">
+            <table>
+				<?php
+				/** @var BadChangeGroup $changegroup */
+				foreach ($this->_affectedpersons as $changegroup) {
+					?>
+                    <tr>
+                        <td></td>
+                        <td colspan="6"><?= $changegroup->toString() ?>
+							<?= ($changegroup->isBulkEdit() ? "" : "<br><small>Warning: this may have been deliberate, and not be from a bulk change!</small>") ?>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="vertical-align: center; min-width: 2em">
+                            <input type="checkbox" name='time[]'
+                                   value="<?= $changegroup->getId() ?>"
+							<?= ($changegroup->isBulkEdit()  ? "checked" : "unchecked") ?>
+                        </td>
+                        <td>
+                            <table class="table table-striped table-condensed table-hover table-min-width clickable-rows query-results">
+                                <thead>
+                                <tr>
+                                    <th>Person</th>
+                                    <th>Previous Age Bracket</th>
+                                    <th>Current Age Bracket</th>
+                                    <th>Related Changes</th>
+                                    <th>Proposed Fix</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+								<?php
+								foreach ($changegroup->getBadChanges() as $change) {
+									?>
+                                    <tr>
+                                        <td>
+                                            <a href="/?view=persons&personid=<?= $change->getPersonid() ?>"><?= $change->getPersonName() ?></a>
+                                        </td>
+                                        <td><?= $change->getOldagebracket() ?></td>
+                                        <td><?= $change->getNewagebracket() ?></td>
+                                        <td><?= array_reduce($change->getHistlines(), fn($s, $line) => $s .= $line.'</br>', '') ?></td>
+                                        <td><?= $change->getNewagebracket() ?> → <?= $change->getOldagebracket() ?></td>
+                                    </tr>
+									<?php
+								}
+								?>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+				<?php }
+				if (count($this->_affectedpersons) > 0) { ?>
+                    <tr>
+                        <td>&nbsp;</td>
+                        <td class="compulsory"><input type="submit" name="confirm_fix" class="btn"
+                                                      value="Fix all ticked items"/></td>
+                    </tr>
+				<?php } else { ?>
+                    <tr>
+                        <td>No affected persons!</td>
+                    </tr>
+				<?php } ?>
+            </table>
+        </form>
+		<?php
+	}
+
+	private
+	function _printDoneView()
+	{
+		?><h3>Fix completed</h3>
+		<?php
+		if (!is_null($this->_fixresults)) {
+			echo '<table class="table table-striped table-condensed table-hover table-min-width clickable-rows query-results">';
+			echo '<tr><th>Person</th><th>Age Bracket</th></tr>';
+			foreach ($this->_fixresults as $fixresult) {
+				echo "<tr>";
+				echo "<td><a href='/?view=persons&personid=".$fixresult->getPersonid()."'>".$fixresult->getPersonName()."</a></td>";
+				echo "<td>".$fixresult->getAgebracket();
+				echo "</td>";
+				echo "</tr>";
+			}
+			echo "</table>";
+		} else {
+			echo "No fix results??";
+		}
+	}
+
+	function _processFix()
+	{
+		$GLOBALS['system']->doTransaction('BEGIN');
+		$changes = [];
+		foreach (AgeBracketChangesFixer::getBadChangeGroups() as $id => $change) {
+			if (in_array($id, $_REQUEST['time'])) {
+				$changes[$id] = $change;
+			}
+		}
+		$this->_fixresults = AgeBracketChangesFixer::fix($changes);
+		$GLOBALS['system']->doTransaction('COMMIT');
+		$this->_stage = 'done';
+	}
+
+	/**
+	 * @return stdClass
+	 */
+
+	private
+	function _getAffectedPersons()
+	{
+	}
+
+	private
+	function _findAffectedPersons()
+	{
+		$this->_affectedpersons = AgeBracketChangesFixer::getBadChangeGroups();
+	}
+}


### PR DESCRIPTION
Jethro 2.35.1 introduced a bug (https://github.com/tbar0970/jethro-pmm/issues/1086) where bulk edits would change people's `Age Bracket` to 'Adult' inadvertently.  The bug is fixed (in 2.36-dev), but the effects (incorrectly Adult'ed persons) remain in the database.  My own Jethro had people about 10 times in total. Examining EJ instances, 20% of databases have persons (likely) incorrectly turned into Adults.

This is a real pain to fix. One has to examine every Adult person's history, find where 'Age Bracket' was set to 'Adult', see if other fields were changed too, and deduce whether the change was intentional.

I have developed a tool, under Admin -> Fix Broken Age Brackets, which goes through all person histories looking for  'Age bracket' changes. Changes are grouped by the time they occurred. Simultaneous edits of more than one person indicate a bulk edit, and are thus more likely to have inadvertently changed 'Age bracket':

![image](https://github.com/user-attachments/assets/b9662391-164e-4f7c-bd82-8cb1534227f0)

Here, for instance:
 - it is unlikely Lynette has gotten younger, so the change from 'Senior' to 'Adult' is probably incorrect.
 - Janet - who knows. Let's say it was a legitimate change.
 - Sam and Kaitlyn were probably inadvertently changed to Adult while adjusting their Status.

So one would tick the first and third blocks, and click 'Fix all ticked items', and the persons are fixed:

![image](https://github.com/user-attachments/assets/59d716f2-3d22-4676-90b6-2d108a3b2305)

Each person's age bracket is fixed, and the change history records it; e.g. Lynette:

![image](https://github.com/user-attachments/assets/764a71c3-662c-4d23-9d62-c05940029b41)

There is also a command-line script, intended to be run at upgrade time, which identifies whether any person records are affected:
```
$ upgrades/2024-upgrade-to-2.36-report-if-agebrackets-are-broken.php
Warning: 2 people have been incorrectly turned into Adults by bug https://github.com/tbar0970/jethro-pmm/issues/1086:
Sam xxxx
Kaitlyn xxx
Please go to Admin -> Fix Broken Age Brackets to fix this
```

I suggest the upgrade process be included to run upgrades/*.php files such as this, and the script from https://github.com/tbar0970/jethro-pmm/pull/1083