### PR TITLE
Prevent zero-byte /tmp/jethrozipXXXX files being created.

### DIFF
--- a/views/view_9_documents.class.php
+++ b/views/view_9_documents.class.php
@@ -546,7 +546,9 @@ class View_Documents extends View
 		$downloadFilename = array_get($_REQUEST, 'zipname', 'JethroFiles');
 		if (substr($downloadFilename, -4) != '.zip') $downloadFilename .= '.zip';
 		$zip = new ZipArchive();
-		$zipFilename = tempnam(sys_get_temp_dir(), 'jethrozip').'.zip';
+		$zipFilename = tempnam(sys_get_temp_dir(), 'jethrozip');
+		rename($zipFilename, $zipFilename.".zip");
+		$zipFilename .= ".zip";
 		if ($zip->open($zipFilename, ZipArchive::CREATE)!==TRUE) {
 			exit("cannot open <$zipFilename>\n");
 		}


### PR DESCRIPTION
Code like this which appends an extension to `tempnam()` is always bad:
```
$zipFilename = tempnam(sys_get_temp_dir(), 'jethrozip').'.zip';
```
because:

1.  `tempnam()` actually creates a file `/tmp/jethrozipXXXX`
2. `$zipFilename` is set to `/tmp/jethrozipXXXX.zip`
3. `$zipFilename` is used
4. `$zipFilename is unlinked to delete it
5. `/tmp/jethrozipXXXX` is still there