### PR TITLE
Fix #1091 by having congregation delete cascade to its foreign key on 'congregation_headcount'.

### DIFF
--- a/upgrades/2024-upgrade-to-2.36.sql
+++ b/upgrades/2024-upgrade-to-2.36.sql
@@ -142,3 +142,8 @@ SELECT `rank`+1, NULL, 'ATTENDANCE_ORDER_DEFAULT', 'Default order for recording/
 'status'
 FROM setting
 WHERE symbol = 'ATTENDANCE_DEFAULT_DAY';
+
+
+-- Deleting a congregation should delete associated headcounts. Fixes https://github.com/tbar0970/jethro-pmm/issues/1091
+ALTER TABLE `congregation_headcount` DROP FOREIGN KEY `congregation_headcount_congid2`;
+ALTER TABLE `congregation_headcount` ADD CONSTRAINT `congregation_headcount_congid2` FOREIGN KEY (`congregationid`) REFERENCES `congregation` (`id`) ON DELETE CASCADE;


### PR DESCRIPTION
As per Tom's suggestion on https://github.com/tbar0970/jethro-pmm/issues/1091