### PR TITLE
Fix php 8.x problem when rendering person details

### DIFF
--- a/include/db_object.class.php
+++ b/include/db_object.class.php
@@ -507,7 +507,7 @@ class db_object
 			return;
 		}
 		if (array_get($this->fields[$name], 'initial_cap')) {
-			$value = ucfirst($value);
+			$value = ucfirst($value ?? '');
 		}
 		// Force initial cap only if value is a single world
 		if (array_get($this->fields[$name], 'initial_cap_singleword') && (false === strpos($value, ' '))) {


### PR DESCRIPTION
The 'Person Detail' section of Jethro breaks under PHP 8.3.14.

![image](https://github.com/user-attachments/assets/9dcccb89-d780-4dea-973e-10bfaed24849)
