### PR TITLE
Remove quote characters from internationalized strings, and put them in the HTML where they belong.

### DIFF
--- a/locale/es/LC_MESSAGES/messages - copia.po
+++ b/locale/es/LC_MESSAGES/messages - copia.po
@@ -387,9 +387,8 @@ msgid "Log out"
 msgstr "Salir"
 
 #: templates/main.template.php:44
-msgid ""
-"\"This user account can only see persons in certain congregations or groups\""
-msgstr "\"Este usuario solo puede ver personas de ciertos grupos\""
+msgid "This user account can only see persons in certain congregations or groups"
+msgstr "Este usuario solo puede ver personas de ciertos grupos"
 
 #: templates/main.template.php:44
 msgid "Restrictions in effect"
@@ -435,8 +434,8 @@ msgstr "Grupos"
 
 #: templates/person_list_header_footer.template.php:23
 #: views/view_6_attendance__2_display.class.php:405
-msgid "\"Select all\""
-msgstr "\"Seleccionar todos\""
+msgid "Select all"
+msgstr "Seleccionar todos"
 
 #: templates/single_note.template.php:18
 msgid "Edit original note"
@@ -447,7 +446,7 @@ msgid "Added by"
 msgstr "Agregado por"
 
 #: templates/single_note.template.php:40
-msgid "\". Edited by \""
+msgid ". Edited by "
 msgstr "\".Editada por \""
 
 #: templates/single_note.template.php:79
@@ -515,7 +514,7 @@ msgid " of "
 msgstr " de"
 
 #: templates/view_person.template.php:55
-msgid "\"Choose a group first\""
+msgid "Choose a group first"
 msgstr "\"Elegir un grupo primero\""
 
 #: templates/view_person.template.php:78
@@ -830,7 +829,7 @@ msgid "System-Wide Search"
 msgstr "Búsqueda en todo el sistema"
 
 #: views/view_1_home.class.php:36
-msgid "\"Name, Phone or Email\""
+msgid "Name, Phone or Email"
 msgstr "Nombre, Teléfono o Email"
 
 #: views/view_1_home.class.php:48
@@ -1110,11 +1109,11 @@ msgid "Person Reports"
 msgstr "Reportes de personas"
 
 #: views/view_3_persons__3_reports.class.php:85
-msgid "\"Save and view results\""
+msgid "Save and view results"
 msgstr "\"Guardar y ver resultados\""
 
 #: views/view_3_persons__3_reports.class.php:86
-msgid "\"Save and return to report list\""
+msgid "Save and return to report list"
 msgstr "\"Grabar y volver a la lista\""
 
 #: views/view_3_persons__3_reports.class.php:87
@@ -1181,7 +1180,7 @@ msgid "Delete"
 msgstr "Borrar"
 
 #: views/view_3_persons__3_reports.class.php:200
-msgid "\"Show result counts for selected reports\""
+msgid "Show result counts for selected reports"
 msgstr "\"Mostrar resultados para el informe seleccionado\""
 
 #: views/view_3_persons__4_statistics.class.php:12
@@ -1334,19 +1333,19 @@ msgid "Record Attendance"
 msgstr "Registrar asistencia"
 
 #: views/view_6_attendance__1_record.class.php:80
-msgid "\"Attendance for \""
+msgid "Attendance for "
 msgstr "\"Asistencia para \""
 
 #: views/view_6_attendance__1_record.class.php:80
-msgid "\" cannot be recorded on a \""
+msgid " cannot be recorded on a "
 msgstr "\" no puede registrarse sobre \""
 
 #: views/view_6_attendance__1_record.class.php:87
-msgid "\"Another user is currently recording attendance for \""
+msgid "Another user is currently recording attendance for "
 msgstr "\"Otro usuario esta tomando asistencia para \""
 
 #: views/view_6_attendance__1_record.class.php:87
-msgid "\".  Please wait until they finish then try again.\""
+msgid ".  Please wait until they finish then try again."
 msgstr "\". Por favor espere hasta que terminen e intente nuevamente.\" "
 
 #: views/view_6_attendance__1_record.class.php:158
@@ -1508,7 +1507,7 @@ msgid "Segment"
 msgstr "Segmento"
 
 #: views/view_6_attendance__3_statistics.class.php:125
-msgid "\"Percentage of dates marked present rather than absent\""
+msgid "Percentage of dates marked present rather than absent"
 msgstr "\"Porcentaje de presentes contra ausentes\""
 
 #: views/view_6_attendance__3_statistics.class.php:125
@@ -1516,7 +1515,7 @@ msgid "Rate"
 msgstr "Tasa"
 
 #: views/view_6_attendance__3_statistics.class.php:126
-msgid "\"Average number marked present per date\""
+msgid "Average number marked present per date"
 msgstr "\"Promedio de presentes por fecha\""
 
 #: views/view_6_attendance__3_statistics.class.php:126

--- a/locale/es/LC_MESSAGES/messages.po
+++ b/locale/es/LC_MESSAGES/messages.po
@@ -453,8 +453,8 @@ msgid "Added by"
 msgstr "Agregado por"
 
 #: templates/single_note.template.php:40
-msgid "1"
-msgstr "\".Editada por \""
+msgid "Edited by"
+msgstr "Editada por"
 
 #: templates/single_note.template.php:79
 msgid "Edit / Comment"
@@ -521,8 +521,8 @@ msgid " of "
 msgstr " de"
 
 #: templates/view_person.template.php:55
-msgid "1"
-msgstr "\"Elegir un grupo primero\""
+msgid "Choose a group first"
+msgstr "Elegir un grupo primero"
 
 #: templates/view_person.template.php:78
 msgid "Attendance"
@@ -916,8 +916,8 @@ msgid "Parameters"
 msgstr "Parametros"
 
 #: views/view_10_admin__3_custom_fields.class.php:130
-msgid "1"
-msgstr "\"Click para borrar este campo\""
+msgid "Click to delete this field"
+msgstr "Click para borrar este campo"
 
 #: views/view_10_admin__3_custom_fields.class.php:142
 #: views/view_10_admin__3_date_types.class.php:85

--- a/locale/es/LC_MESSAGES/messages.po
+++ b/locale/es/LC_MESSAGES/messages.po
@@ -392,9 +392,8 @@ msgid "Log out"
 msgstr "Salir"
 
 #: templates/main.template.php:44
-msgid ""
-"\"This user account can only see persons in certain congregations or groups\""
-msgstr "\"Este usuario solo puede ver personas de ciertos grupos\""
+msgid "This user account can only see persons in certain congregations or groups"
+msgstr "Este usuario solo puede ver personas de ciertos grupos"
 
 #: templates/main.template.php:44
 msgid "Restrictions in effect"
@@ -442,8 +441,8 @@ msgstr "Grupos"
 
 #: templates/person_list_header_footer.template.php:23
 #: views/view_6_attendance__2_display.class.php:405
-msgid "\"Select all\""
-msgstr "\"Seleccionar todos\""
+msgid "Select all"
+msgstr "Seleccionar todos"
 
 #: templates/single_note.template.php:18
 msgid "Edit original note"
@@ -454,7 +453,7 @@ msgid "Added by"
 msgstr "Agregado por"
 
 #: templates/single_note.template.php:40
-msgid "\". Edited by \""
+msgid "1"
 msgstr "\".Editada por \""
 
 #: templates/single_note.template.php:79
@@ -522,7 +521,7 @@ msgid " of "
 msgstr " de"
 
 #: templates/view_person.template.php:55
-msgid "\"Choose a group first\""
+msgid "1"
 msgstr "\"Elegir un grupo primero\""
 
 #: templates/view_person.template.php:78
@@ -917,12 +916,12 @@ msgid "Parameters"
 msgstr "Parametros"
 
 #: views/view_10_admin__3_custom_fields.class.php:130
-msgid "\"Click to delete this field\""
+msgid "1"
 msgstr "\"Click para borrar este campo\""
 
 #: views/view_10_admin__3_custom_fields.class.php:142
 #: views/view_10_admin__3_date_types.class.php:85
-msgid "\"Save\""
+msgid "Save"
 msgstr "\"Grabar\""
 
 #: views/view_10_admin__3_date_types.class.php:16
@@ -971,7 +970,7 @@ msgid "Action plans"
 msgstr "Planes de accion"
 
 #: views/view_10_admin__4_action_plans.class.php:68
-msgid "\"Save Action Plan\""
+msgid "Save Action Plan"
 msgstr ""
 
 #: views/view_10_admin__4_action_plans.class.php:77
@@ -987,7 +986,7 @@ msgid "Last modified"
 msgstr ""
 
 #: views/view_10_admin__4_action_plans.class.php:107
-msgid "\"Delete this action plan\""
+msgid "Delete this action plan"
 msgstr ""
 
 #: views/view_10_admin__5_import.class.php:13
@@ -1019,7 +1018,7 @@ msgid "System-Wide Search"
 msgstr "Búsqueda en todo el sistema"
 
 #: views/view_1_home.class.php:36
-msgid "\"Name, Phone or Email\""
+msgid "Name, Phone or Email"
 msgstr "Nombre, Teléfono o Email"
 
 #: views/view_1_home.class.php:48
@@ -1295,11 +1294,11 @@ msgid "Person Reports"
 msgstr "Reportes de personas"
 
 #: views/view_3_persons__3_reports.class.php:85
-msgid "\"Save and view results\""
+msgid "Save and view results"
 msgstr "\"Guardar y ver resultados\""
 
 #: views/view_3_persons__3_reports.class.php:86
-msgid "\"Save and return to report list\""
+msgid "Save and return to report list"
 msgstr "\"Grabar y volver a la lista\""
 
 #: views/view_3_persons__3_reports.class.php:87
@@ -1360,7 +1359,7 @@ msgid "Only Me"
 msgstr "Solo yo"
 
 #: views/view_3_persons__3_reports.class.php:200
-msgid "\"Show result counts for selected reports\""
+msgid "Show result counts for selected reports"
 msgstr "\"Mostrar resultados para el informe seleccionado\""
 
 #: views/view_3_persons__4_statistics.class.php:12
@@ -1513,19 +1512,19 @@ msgid "Record Attendance"
 msgstr "Registrar asistencia"
 
 #: views/view_6_attendance__1_record.class.php:80
-msgid "\"Attendance for \""
+msgid "Attendance for "
 msgstr "\"Asistencia para \""
 
 #: views/view_6_attendance__1_record.class.php:80
-msgid "\" cannot be recorded on a \""
+msgid " cannot be recorded on a "
 msgstr "\" no puede registrarse sobre \""
 
 #: views/view_6_attendance__1_record.class.php:87
-msgid "\"Another user is currently recording attendance for \""
+msgid "Another user is currently recording attendance for "
 msgstr "\"Otro usuario esta tomando asistencia para \""
 
 #: views/view_6_attendance__1_record.class.php:87
-msgid "\".  Please wait until they finish then try again.\""
+msgid ".  Please wait until they finish then try again."
 msgstr "\". Por favor espere hasta que terminen e intente nuevamente.\" "
 
 #: views/view_6_attendance__1_record.class.php:158
@@ -1683,7 +1682,7 @@ msgid "Segment"
 msgstr "Segmento"
 
 #: views/view_6_attendance__3_statistics.class.php:125
-msgid "\"Percentage of dates marked present rather than absent\""
+msgid "Percentage of dates marked present rather than absent"
 msgstr "\"Porcentaje de presentes contra ausentes\""
 
 #: views/view_6_attendance__3_statistics.class.php:125
@@ -1691,7 +1690,7 @@ msgid "Rate"
 msgstr "Tasa"
 
 #: views/view_6_attendance__3_statistics.class.php:126
-msgid "\"Average number marked present per date\""
+msgid "Average number marked present per date"
 msgstr "\"Promedio de presentes por fecha\""
 
 #: views/view_6_attendance__3_statistics.class.php:126

--- a/templates/person_list_header_footer.template.php
+++ b/templates/person_list_header_footer.template.php
@@ -33,7 +33,7 @@
 		if ($show_actions) {
 			?>
 			<th><?php echo _('Actions')?></th>
-			<th class="narrow selector form-inline"><input type="checkbox" class="select-all" title=<?php echo _('"Select all"')?> /></th>
+			<th class="narrow selector form-inline"><input type="checkbox" class="select-all" title="<?php echo _('Select all')?>" /></th>
 			<?php
 		}
 		?>

--- a/views/view_0_add_note_to_person.class.php
+++ b/views/view_0_add_note_to_person.class.php
@@ -98,7 +98,7 @@ class View__Add_Note_To_Person extends View
 
 			?>	
 			<div class="controls">
-				<input type="submit" name="new_note_submitted" class="btn" value=<?php echo _('Add Note to Person')?> />
+				<input type="submit" name="new_note_submitted" class="btn" value="<?php echo _('Add Note to Person')?>" />
 				<a class="btn" href="<?php echo build_url(Array('view' => 'persons', 'personid' => $this->_person->id)); ?>">Cancel</a>
 		</form>
 		<?php

--- a/views/view_0_mixed_search.class.php
+++ b/views/view_0_mixed_search.class.php
@@ -213,7 +213,7 @@ class View__Mixed_Search extends View
 				<input type="text" 
 					   name="search" 
 					   value="<?php echo ents(array_get($_GET, 'search')); ?>" 
-					   placeholder=<?php echo _('"Name, phone or email"');?> 
+					   placeholder="<?php echo _("Name, phone or email");?>"
 					   <?php if (array_get($_GET, 'search')) echo 'autoselect="autoselect"'; ?>
 				/>
 				<button type="submit" class="btn"><i class="icon-search"></i></button>

--- a/views/view_2_families__3_add.class.php
+++ b/views/view_2_families__3_add.class.php
@@ -152,11 +152,11 @@ class View_Families__Add extends View
 
 		<form method="post" class="min">
 		<?php print_hidden_fields($_POST); ?>
-		<input type="submit" class="btn" name="override_dup_check" value=<?php echo _('Create new family anyway');?> />
+		<input type="submit" class="btn" name="override_dup_check" value="<?php echo _('Create new family anyway');?>" />
 		</form>
 
 		<form method="get" class="min">
-		<input type="submit" class="btn" value=<?php echo _('Cancel family creation');?> />
+		<input type="submit" class="btn" value="<?php echo _('Cancel family creation');?>" />
 		</form>
 		<?php
 	}
@@ -320,8 +320,8 @@ class View_Families__Add extends View
 		?>
 		<h3><?php echo _('Create');?></h3>
 			<div class="align-right">
-				<input type="submit" class="btn" value=<?php echo _('Create Family');?> />
-				<input type="button" class="back btn" value=<?php echo _('Cancel');?> />
+				<input type="submit" class="btn" value="<?php echo _('Create Family');?>" />
+				<input type="button" class="back btn" value="<?php echo _('Cancel');?>" />
 			</div>
 		</form>
 		<?php

--- a/views/view_3_persons__3_reports.class.php
+++ b/views/view_3_persons__3_reports.class.php
@@ -76,8 +76,8 @@ class View_Persons__Reports extends View
 				$this->_query->printForm();
 				?>
 				<h3>&nbsp</h3>
-				<input type="submit" class="btn" value=<?php echo _('"Save and view results"');?> />
-				<input type="submit" class="btn" name="return" value=<?php echo _('"Save and return to report list"');?> />
+				<input type="submit" class="btn" value="<?php echo _('Save and view results');?>" />
+				<input type="submit" class="btn" name="return" value="<?php echo _('Save and return to report list');?>" />
 				<a class="btn" href="?view=<?php echo ents($_REQUEST['view']); ?>"><?php echo _('Cancel and return to report list');?></a>
 
 			</form>

--- a/views/view_5_groups.class.php
+++ b/views/view_5_groups.class.php
@@ -243,7 +243,7 @@ class View_Groups extends View
 					}
 					?>
 						<th>&nbsp;</th>
-						<th class="narrow selector form-inline"><input type="checkbox" class="select-all" title=<?php echo _('"Select all"')?> /></th>
+						<th class="narrow selector form-inline"><input type="checkbox" class="select-all" title="<?php echo _('Select all')?>" /></th>
 					</tr>
 
 				</thead>

--- a/views/view_6_attendance__1_record.class.php
+++ b/views/view_6_attendance__1_record.class.php
@@ -84,14 +84,14 @@ class View_Attendance__Record extends View
 		} else if (!empty($_REQUEST['params_submitted'])) {
 			foreach ($this->_record_sets as $cohortid => $set) {
 				if (!$set->checkAllowedDate()) {
-					add_message(_('"Attendance for "').$set->getCohortName()._('" cannot be recorded on a "').date('l', strtotime($this->_attendance_date)), 'error');
+					add_message(_('Attendance for "').$set->getCohortName()._('" cannot be recorded on a ').date('l', strtotime($this->_attendance_date)), 'error');
 					unset($this->_record_sets[$cohortid]);
 					$this->_cohortids = array_diff($this->_cohortids, Array($cohortid));
 					continue;
 				}
 
 				if (!$set->acquireLock()) {
-					add_message(_('"Another user is currently recording attendance for "').$set->getCohortName()._('".  Please wait until they finish then try again."'), 'error');
+					add_message(_('Another user is currently recording attendance for "').$set->getCohortName()._('".  Please wait until they finish then try again.'), 'error');
 					unset($this->_record_sets[$cohortid]);
 					$this->_cohortids = array_diff($this->_cohortids, Array($cohortid));
 				}

--- a/views/view_6_attendance__2_display.class.php
+++ b/views/view_6_attendance__2_display.class.php
@@ -189,7 +189,7 @@ class View_Attendance__Display extends View
 		
 		foreach ($this->statuses as $status) {
 			if ($status && ($status[0] == 'g') && empty($groupid)) {
-				print_message(_('"Congregational attendance cannot be filtered by a group membership status. Please clear the status filter to display attendance for this congregation."'), 'error');
+				print_message(_('Congregational attendance cannot be filtered by a group membership status. Please clear the status filter to display attendance for this congregation.'), 'error');
 				return;
 			}
 		}
@@ -428,7 +428,7 @@ class View_Attendance__Display extends View
 				}
 				?>
 					<th <?php if ($this->format != 'totals') echo 'rowspan="2"'; ?>></th>
-					<th class="narrow selector form-inline" rowspan="2"><input type="checkbox" class="select-all" title=<?php echo _('"Select all"');?> /></th>					
+					<th class="narrow selector form-inline" rowspan="2"><input type="checkbox" class="select-all" title="<?php echo _('Select all');?>" /></th>
 				</tr>
 
 			<?php

--- a/views/view_6_attendance__3_statistics.class.php
+++ b/views/view_6_attendance__3_statistics.class.php
@@ -140,7 +140,7 @@ class View_Attendance__Statistics extends View
 				</tr>
 				<tr>
 					<th><?php echo _('Segment');?></th>
-					<th title=<?php echo _('"Ratio of present to absent per person, averaged across all persons in segment"');?>><?php echo _('Rate');?></th>
+					<th title="<?php echo _('Ratio of present to absent per person, averaged across all persons in segment');?>"><?php echo _('Rate');?></th>
 					<th class="present" title="<?php echo _('Total number marked present, averaged across all dates in the range');?>"><?php echo _('Avg&nbsp;P');?></th>
 					<th class="absent" title="<?php echo _('Total number marked absent, averaged across all dates in the range');?>"><?php echo _('Avg&nbsp;A');?></th>
 			</thead>


### PR DESCRIPTION
There are places where internationalized text is shown in HTML attributes, where the quote is part of the i18n text rather than the HTML:

https://github.com/tbar0970/jethro-pmm/blob/51cb841600fd322d42b63ae10293a9773ce0fc7b/views/view_6_attendance__1_record.class.php#L94

This sometimes leaks through into the UI:

![image](https://github.com/user-attachments/assets/aa22fca4-1a27-4cde-a6fb-b74b4bece259)


This patch cleans up the mess so quotes are in the HTML, not the i18n text.