### PR TITLE
Improve the "locked out" message shown when someone tries to edit a roster or mark attendance

### DIFF
--- a/db_objects/attendance_record_set.class.php
+++ b/db_objects/attendance_record_set.class.php
@@ -65,6 +65,17 @@ class Attendance_Record_Set
 		return $obj->releaseLock('att-'.$this->date);
 	}
 
+	public function getLockHolder()
+	{
+		$obj = $this->_getCohortObject();
+		if (!$obj) {
+			trigger_error("Could not get cohort object for lock");
+			return FALSE;
+		}
+		return $obj->getLockHolder('att-'.$this->date);
+
+	}
+
 	function create()
 	{
 	}

--- a/db_objects/roster_view.class.php
+++ b/db_objects/roster_view.class.php
@@ -532,7 +532,7 @@ class roster_view extends db_object
 		$showBlanks = ($this->getValue('show_on_run_sheet') == 1);
 		$asns = $this->getAssignments($service->getValue('date'), $service->getValue('date'));
 		$asns = empty($asns) ? Array() : reset($asns);
-		
+
 		$ourMembers = Array();
 		foreach ($this->_members as $member) {
 			if (empty($member['role_id']) && !$includeServiceFields) continue;
@@ -629,7 +629,7 @@ class roster_view extends db_object
 		if (empty($this->_members)) return;
 		$GLOBALS['system']->includeDBClass('service');
 		$dummy_service = new Service();
-	
+
 		if (is_null($start_date)) $start_date = date('Y-m-d');
 		$service_params = Array('congregationid' => $this->getCongregations(), '>date' => date('Y-m-d', strtotime($start_date.' -1 day')));
 		if (!is_null($end_date)) $service_params['<date'] = date('Y-m-d', strtotime($end_date.' +1 day'));
@@ -646,7 +646,7 @@ class roster_view extends db_object
 																),
 																'AND');
 		}
-		
+
 		$to_print = Array();
 		foreach ($services as $id => $service_details) {
 			$service_details['id'] = $id;
@@ -689,13 +689,15 @@ class roster_view extends db_object
 		if ($editing) {
 			$show_lock_fail_msg = false;
 			$show_group_denied_msg = false;
+			$lockholders = Array(); // Array mapping personid of lock holders to info about them and their lock, for later display. Typically there will be N identical locks for N roles edited. We only store the first, assuming it is representative.
 			foreach ($this->_members as $id => &$details) {
 				if (!empty($details['role_id'])) {
 					$role = $GLOBALS['system']->getDBObject('roster_role', $details['role_id']);
-
 					if (!($role->canAcquireLock('assignments') && $role->acquireLock('assignments'))) {
 						$details['readonly'] = true;
 						$show_lock_fail_msg = true;
+						$lockHolder = $role->getLockHolder('assignments');
+						$lockholders[$lockHolder['userid']] ??= $lockHolder;
 					}
 					if (!$role->canEditAssignments()) {
 						$details['readonly'] = true;
@@ -704,7 +706,7 @@ class roster_view extends db_object
 				}
 			}
 			if ($show_lock_fail_msg) {
-				print_message("Some of the roles in this roster are currently being edited by another user.  To edit assignments for these roles, wait until the other user finishes then try again.", 'failure');
+				$this->printLockHoldMessage($lockholders);
 			}
 			if ($show_group_denied_msg) {
 				print_message("There are some roles in this roster which you are not able to edit because they refer to a volunteer group you do not have access to.");
@@ -756,7 +758,7 @@ class roster_view extends db_object
 				}
 				$class_clause = ($date == $this_sunday) ? 'class="roster-next"' : '';
 				?>
-				
+
 				<tr <?php echo $class_clause; ?>>
 					<th class="roster-date nowrap">
 						<?php
@@ -1156,5 +1158,38 @@ class roster_view extends db_object
 		<?php
 
 	}
+
+	public function releaseLocks()
+	{
+		$roles = $this->getRoleIds();
+		foreach ($roles as $i => $roleid) {
+			$role = $GLOBALS['system']->getDBObject('roster_role', $roleid);
+			$role->releaseLock('assignments');
+		}
+	}
+
+	/**
+	 * Print an error explaining which other user has the roster edit lock, and for how long.
+	 * @param array{userid: int, array{userid: int, expires: string, first_name: ?string, last_name: ?string}} $lockholders Array mapping lock holder userids to info about them and their lock.
+	 *
+	 * @return void
+	 * @throws DateMalformedStringException
+	 */
+	public function printLockHoldMessage(array $lockholders): void
+	{
+		$lockHoldersStr =
+			implode(' and ', array_map(
+				fn($lockowner, $userid) => $lockowner['first_name'] !== null ? "{$lockowner['first_name']} {$lockowner['last_name']} ({$userid})" : "user $userid",
+				$lockholders,
+				array_keys($lockholders)
+			));
+        // If more than one person holds locks of differing expiries, the longest expiry is most relevant.
+		$maxLockExpiry = array_reduce($lockholders, function ($carry, $lockholder) {
+			return $lockholder['expires'] > $carry ? $lockholder['expires'] : $carry;
+		}, PHP_INT_MIN);
+		$lockExpiresStr = (new DateTime($maxLockExpiry))->format('H:i');
+		print_message("Some of the roles in this roster are currently being edited by $lockHoldersStr.  To edit assignments for these roles, wait until the other user finishes or their lock expires (at $lockExpiresStr), then try again.", 'failure');
+	}
 }
+
 ?>

--- a/include/db_object.class.php
+++ b/include/db_object.class.php
@@ -971,6 +971,26 @@ class db_object
 		return TRUE;
 	}
 
+    /**
+     * Get the id and name of the $type lock holder.
+     * If the user lacks permission to see the lock holder's details, first_name and last_name will be null.
+     *  @return array{userid: int, expires: string, first_name: ?string, last_name: ?string}
+     */
+    public function getLockHolder($type='') : array
+    {
+		if (!empty($GLOBALS['JETHRO_INSTALLING'])) return -1;
+        $db =& $GLOBALS['db'];
+			$sql = 'SELECT userid, expires, first_name, last_name
+					FROM  db_object_lock
+					LEFT JOIN person p ON p.id=db_object_lock.userid
+					WHERE object_type = '.$db->quote(strtolower(get_class($this))).'
+						AND lock_type = '.$db->quote($type).'
+						AND objectid = '.$db->quote($this->id).'
+						AND expires > NOW()';
+			$res = $db->queryRow($sql);
+            return $res;
+    }
+
 	/**
 	 * Release all locks held by the specified user.
 	 * (Called at logout)

--- a/views/view_6_attendance__1_record.class.php
+++ b/views/view_6_attendance__1_record.class.php
@@ -91,7 +91,9 @@ class View_Attendance__Record extends View
 				}
 
 				if (!$set->acquireLock()) {
-					add_message(_('"Another user is currently recording attendance for "').$set->getCohortName()._('".  Please wait until they finish then try again."'), 'error');
+					$lockHolder = $set->getLockHolder();
+					$lockHolderStr = $lockHolder['first_name'] !== null ? "{$lockHolder['first_name']} {$lockHolder['last_name']} ({$lockHolder['userid']})" : "User {$lockHolder['userid']}";
+					add_message($lockHolderStr._(' is currently recording attendance for ').$set->getCohortName()._('.  Please wait until they finish then try again.'), 'error');
 					unset($this->_record_sets[$cohortid]);
 					$this->_cohortids = array_diff($this->_cohortids, Array($cohortid));
 				}


### PR DESCRIPTION
At our church, we often have situations where someone has a lock on something, but we don't know who to tell them to Get On With It. This patch improves the locked-out message to say who has the lock, and for how long.

The code handles the situation where multiple users have locks for different sets of roster roles. It also handles the situation where the lock requester doesn't have permission to see the lock holder (their `person` view doesn't have the lock-holder). 

Old:

![image](https://github.com/user-attachments/assets/d77b091a-fdb2-4923-9012-905934dd8049)

New:

![image](https://github.com/user-attachments/assets/f3115a9c-480d-49f7-8956-4db2ad97e8e3)


Old:
![image](https://github.com/user-attachments/assets/ec28ac40-b04b-4ed3-8691-f14228dc3855)


New: 

![image](https://github.com/user-attachments/assets/577f186a-00ac-4641-928c-f844778f84cc)
