### PR TITLE
Fix #1118 by rewriting upgrade SQL that populates person_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Jethro PMM is the software that powers online services such as [Easy Jethro](htt
 Download the latest version of Jethro from the [releases page](https://github.com/tbar0970/jethro-pmm/releases)
 
 System requirements are:
-* MySQL 5.1 or above
+* MySQL 8.0 or above
 * PHP 5.3.0 or above
     * with [gettext extension](https://www.php.net/manual/en/book.gettext.php) enabled
     * [GD library](https://www.php.net/manual/en/book.image.php) recommended, to manage the size of uploaded photos


### PR DESCRIPTION
As discussed on #1118: in the old approach, "used statuses" was considered to be "statuses referred to by the `person` table:

```sql
CREATE TEMPORARY TABLE temp_statuses
SELECT distinct (status+1) as id, "TBA", 0
 FROM _person
WHERE status NOT IN ('archived', 'contact');
```

But that doesn't work, because there could be person statuses referred to in serialized structures in person reports, and action reports.

So I have rewritten the SQL entirely, to derive `person_status` entirely from `PERSON_STATUS_OPTIONS`. This requires MySQL 8.0 `json_table()` but I think we rely on MySQL 8.x features anyway.

This SQL incorporates the bugfix from #1114, i.e. where a user has defined their own 'Contact' in addition to the built-in one.

I have tested it against 3 Jethro instances so far, and everything seems to work.