### PR TITLE
The Age Bracket fixer shouldn't break if no options are selected

### DIFF
--- a/views/view_0_fix_age_brackets.class.php
+++ b/views/view_0_fix_age_brackets.class.php
@@ -149,11 +149,13 @@ class View__Fix_Age_Brackets extends View
 	{
 		$GLOBALS['system']->doTransaction('BEGIN');
 		$changes = [];
-		foreach (AgeBracketChangesFixer::getBadChangeGroups() as $id => $change) {
-			if (in_array($id, $_REQUEST['time'])) {
-				$changes[$id] = $change;
+		if (array_key_exists('time', $_REQUEST)) { // 'time' is an array of timestamps of changes deemed to be in error. Null if none were picked.
+			foreach (AgeBracketChangesFixer::getBadChangeGroups() as $id => $change) {
+				if (in_array($id, $_REQUEST['time'])) {
+					$changes[$id] = $change;
+				}
 			}
-		}
+	    }
 		$this->_fixresults = AgeBracketChangesFixer::fix($changes);
 		Config_Manager::deleteSetting('NEEDS_1086_CHECK');
 		$GLOBALS['system']->doTransaction('COMMIT');


### PR DESCRIPTION
A small fix to the 2.36.0 Age Bracket fixer (#1086 / PR #1095). If the user select none of the presented age bracket changes (or unselected all of them), the code before would break, with log error `Undefined index: time
Line 153 of /home/jethro/code/2.36.0/app/views/view_0_fix_age_brackets.class.php`

![image](https://github.com/user-attachments/assets/12d1fd2b-8a42-4d2e-bff2-3fdf857917b5)


Now it succeeds.

![image](https://github.com/user-attachments/assets/94fb34ca-d4cc-424c-9559-2b94c1ac6952)
