### PR TITLE
Replace UNION with LEFT JOINs to fix query in ONLY_FULL_GROUP_BY mode

### DIFF
--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -502,39 +502,31 @@ class Person extends DB_Object
 	{
 		$db = $GLOBALS['db'];
 		$SQL = '
-			SELECT pp.id, pp.*
-			FROM (
-				SELECT p.*
-				FROM person p
-				WHERE (
-					(first_name LIKE '.$db->quote($searchTerm.'%').')
-					OR (last_name LIKE '.$db->quote($searchTerm.'%').')
-					OR (first_name LIKE '.$db->quote('% '.$searchTerm.'%').')
-					OR (last_name LIKE '.$db->quote('% '.$searchTerm.'%').')
-					OR (CONCAT(first_name, " ", last_name) LIKE '.$db->quote($searchTerm.'%').')
+			SELECT p.*
+			FROM person p
+			JOIN person_status ps ON ps.id = p.status
+			LEFT JOIN custom_field_value cfv ON cfv.personid = p.id
+			LEFT JOIN custom_field cf ON cfv.fieldid = cf.id
+			WHERE (
+				(first_name LIKE '.$db->quote($searchTerm.'%').')
+				OR (last_name LIKE '.$db->quote($searchTerm.'%').')
+				OR (first_name LIKE '.$db->quote('% '.$searchTerm.'%').')
+				OR (last_name LIKE '.$db->quote('% '.$searchTerm.'%').')
+				OR (CONCAT(first_name, " ", last_name) LIKE '.$db->quote($searchTerm.'%').')
+				OR (
+					cf.searchable AND (
+						(cfv.value_text LIKE '.$db->quote($searchTerm.'%').')
+						OR (cfv.value_text LIKE '.$db->quote('% '.$searchTerm.'%').' )
+					)
 				)
-
-				UNION
-
-				SELECT p.*
-				FROM person p
-				JOIN custom_field_value cfv ON cfv.personid = p.id
-				JOIN custom_field cf ON cfv.fieldid = cf.id
-				WHERE cf.searchable
-				AND (
-					(cfv.value_text LIKE '.$db->quote($searchTerm.'%').')
-					OR (cfv.value_text LIKE '.$db->quote('% '.$searchTerm.'%').' )
-				)
-			) pp
-			JOIN person_status ps ON ps.id = pp.status
+			)
 		';
 		if (!$includeArchived) {
 			$SQL .= '
-			WHERE (NOT ps.is_archived)
+			AND NOT ps.is_archived
 			';
 		}
 		$SQL .= '
-			GROUP BY pp.id
 			ORDER BY status
 			';
 		$res = $db->queryAll($SQL, null, null, true, true); // 5th param forces array even if one col


### PR DESCRIPTION
Searching for a person (/?call=find_person_json&show-absence-date=&search=test) with Jethro and MySQL 8.4.2, I received an error
> SQLSTATE[42000]: Syntax error or access violation: 1055 Expression 3 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'pp.first_name' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by

See https://dev.mysql.com/doc/refman/8.4/en/group-by-handling.html
> MySQL implements detection of functional dependence. If the [ONLY_FULL_GROUP_BY](https://dev.mysql.com/doc/refman/8.4/en/sql-mode.html#sqlmode_only_full_group_by) SQL mode is enabled (which it is by default), MySQL rejects queries for which the select list, HAVING condition, or ORDER BY list refer to nonaggregated columns that are neither named in the GROUP BY clause nor are functionally dependent on them.

Looking at the query, I think a simple solution is to remove the GROUP BY altogether - the UNION can be replaced with LEFT JOINs.