### PR TITLE
Add 'Contact Remarks' when adding people as part of a family. Fixes #1131

### DIFF
--- a/views/view_2_families__3_add.class.php
+++ b/views/view_2_families__3_add.class.php
@@ -241,6 +241,8 @@ class View_Families__Add extends View
 							<div><?php $person->printFieldInterface('mobile_tel', 'members_0_'); ?></div>
 							<div><?php $person->printFieldInterface('email', 'members_0_'); ?></div>
 
+                            <label class="fullwidth"><?php echo _('Contact Remarks');?></label>
+                            <div class="fullwidth"><?php $person->printFieldInterface('remarks', 'members_0_'); ?></div>
 						<?php
 						$field = new Custom_Field();
 						foreach ($customFields as $fieldID => $fDetails) {


### PR DESCRIPTION
Add 'Contact Remarks' field to each person added in a family:

![image](https://github.com/user-attachments/assets/763f2f61-068c-41c6-a915-7e18f5062b83)

The 40 column width is unfortunately not easily adjustable.

Note that 'Contact Remarks' it not shown in the simplfied/space-constrained variant (same as with custom fields):

![image](https://github.com/user-attachments/assets/4abda397-4da9-4350-ae53-b42a4670d401)
