### PR TITLE
Declare class property

### DIFF
--- a/views/view_2_families__3_add.class.php
+++ b/views/view_2_families__3_add.class.php
@@ -3,6 +3,7 @@ include_once 'db_objects/action_plan.class.php';
 class View_Families__Add extends View
 {
 	var $_family;
+	protected $_similar_families;
 
 	static function getMenuPermissionLevel()
 	{


### PR DESCRIPTION
When adding a family in PHP 8.3, I see in the error log
> Creation of dynamic property View_Families__Add::$_similar_families is deprecated - Line 99 of views/view_2_families__3_add.class.php

This PR declares the class property to remove the warning.