### PR TITLE
Removed deprecated auto_detect_line_endings directive

### DIFF
--- a/views/view_0_import_service_components.class.php
+++ b/views/view_0_import_service_components.class.php
@@ -18,7 +18,6 @@ class View__Import_Service_Components extends View
 			$GLOBALS['system']->doTransaction('BEGIN');
 			$GLOBALS['system']->includeDBClass('service_component');
 			$comp = new Service_Component();
-			ini_set("auto_detect_line_endings", "1");
 			$fp = fopen($_FILES['datafile']['tmp_name'], 'r');
 			if (!$fp) {
 				trigger_error("Your data file could not be read.  Please check the file and try again");


### PR DESCRIPTION
In PHP 8.1, 'auto_detect_line_endings' was deprecated - https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.standard

https://wiki.php.net/rfc/deprecations_php_8_1#auto_detect_line_endings_ini_setting describes this as
> The auto_detect_line_endings ini setting modifies the behavior of file() and fgets() to support an isolated \r (as opposed to \n or \r\n) as a newline character. These newlines were used by “Classic” Mac OS, a system which has been discontinued in 2001, nearly two decades ago. Interoperability with such systems is no longer relevant.