### PR TITLE
Declare class property

### DIFF
--- a/views/view_0_import_service_components.class.php
+++ b/views/view_0_import_service_components.class.php
@@ -4,6 +4,7 @@ class View__Import_Service_Components extends View
 {
 	private $errors = Array();
 	private $category = null;
+	protected $_captured_errors;
 
 	static function getMenuPermissionLevel()
 	{


### PR DESCRIPTION
When importing songs at /?view=_import_service_components&categoryid=1, I found a warning
> Creation of dynamic property View__Import_Service_Components::$_captured_errors is deprecated - Line 167 of views/view_0_import_service_components.class.php

This PR declares the class property to remove the warning.