### PR TITLE
Updated URL

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 /**
  * JETHRO PMM
  *
- * This file is part of Jethro PMM - http://jethro-pmm.sourceforge.net
+ * This file is part of Jethro PMM - https://github.com/tbar0970/jethro-pmm
  *
  * Jethro PMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/members/index.php
+++ b/members/index.php
@@ -2,7 +2,7 @@
 /*
  * JETHRO PMM
  *
- * This file is part of Jethro PMM - http://jethro-pmm.sourceforge.net
+ * This file is part of Jethro PMM - https://github.com/tbar0970/jethro-pmm
  *
  * Jethro PMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/public/index.php
+++ b/public/index.php
@@ -2,7 +2,7 @@
 /*
  * JETHRO PMM
  *
- * This file is part of Jethro PMM - http://jethro-pmm.sourceforge.net
+ * This file is part of Jethro PMM - https://github.com/tbar0970/jethro-pmm
  *
  * Jethro PMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Replaces the URL in
https://github.com/tbar0970/jethro-pmm/blob/d47be606bde1c355586cb9a1270e2fc9ff32efbc/index.php#L5
and two other locations, with https://github.com/tbar0970/jethro-pmm