### PR TITLE
Record creator in history

### DIFF
--- a/include/db_object.class.php
+++ b/include/db_object.class.php
@@ -191,7 +191,12 @@ class db_object
 			}
 		}
 		if (isset($this->fields['history'])) {
-			$this->values['history'] = Array(time() => 'Created');
+			$created = 'Created';
+			$user = $GLOBALS['user_system']->getCurrentPerson();
+			if ($user) {
+				$created .= ' by '.$user['first_name'].' '.$user['last_name'].' (#'.$user['id'].')';
+			}
+			$this->values['history'] = Array(time() => $created);
 		}
 
 		$parent_class =  strtolower(get_parent_class($this));


### PR DESCRIPTION
#1087 reports that a person's creator is not displayed anywhere.

This PR suggests extending the 'Created' entry in the 'History' tab to 'Created by John Smith (#1)', like the 'Updated by' entries.

https://github.com/tbar0970/jethro-pmm/blob/d47be606bde1c355586cb9a1270e2fc9ff32efbc/include/db_object.class.php#L366-L368

This wouldn't change anything for entities already created, but it would show the information for entities created moving forward.