### PR TITLE
Hide redundant move arrows

### DIFF
--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -667,6 +667,10 @@ input[type="radio"] {
 	width: auto !important;
 	min-width: 50ex;
 }
+tr:first-child > td > .move-row-up,
+tr:last-child > td > .move-row-down {
+  visibility: hidden;
+}
 /* nested tables - see list of family members within single person view */
 .table td table {
 	width: 100%;


### PR DESCRIPTION
![before](https://github.com/user-attachments/assets/1c0463c5-b5ff-4120-a3cd-c04d78deae2c)

Moving a text up from the top row or down from the last row has no effect. So I suggest hiding them.

![after](https://github.com/user-attachments/assets/1cd108e3-e56f-4d6d-a961-1357c8e7a7d8)