### PR TITLE
Fixed sorting future notes by date

### DIFF
--- a/views/abstract_view_notes_list.class.php
+++ b/views/abstract_view_notes_list.class.php
@@ -4,9 +4,33 @@ class Abstract_View_Notes_List extends View
 	var $_reassigning = FALSE;
 	var $_notes = Array();
 
+	static function getMenuPermissionLevel()
+	{
+		return PERM_VIEWMYNOTES;
+	}
+
 	function _compareNoteDates($a, $b)
 	{
 		return $a['action_date'] > $b['action_date'] ? 1 : -1;
+	}
+	
+	protected function _getNotes($conds)
+	{
+		$conds['status'] = 'pending';
+
+		$assigneeID = array_get($_REQUEST, 'assignee');
+		if ($assigneeID) {
+			$conds['assignee'] = $assigneeID;
+		}
+
+		$search = array_get($_REQUEST, 'search');
+		if ($search) {
+			$conds['subject'] = '%'.$search.'%';
+		}
+
+		$res = $GLOBALS['system']->getDBObjectData('person_note', $conds, 'AND', '', TRUE) + $GLOBALS['system']->getDBObjectData('family_note', $conds, 'AND', '', TRUE);
+		uasort($res, Array($this, '_compareNoteDates'));
+		return $res;
 	}
 
 	function processView()

--- a/views/abstract_view_notes_list.class.php
+++ b/views/abstract_view_notes_list.class.php
@@ -1,5 +1,5 @@
 <?php
-class Abstract_View_Notes_List extends View
+abstract class Abstract_View_Notes_List extends View
 {
 	var $_reassigning = FALSE;
 	var $_notes = Array();
@@ -52,12 +52,6 @@ class Abstract_View_Notes_List extends View
 		}
 		// these will have changed
 		$this->_notes = $this->_getNotesToShow(array_get($_REQUEST, 'assignee'), array_get($_REQUEST, 'search'));
-	}
-
-
-	function getTitle()
-	{
-		return '';
 	}
 
 

--- a/views/view_4_notes__1_for_immediate_action.class.php
+++ b/views/view_4_notes__1_for_immediate_action.class.php
@@ -2,26 +2,11 @@
 require_once 'views/abstract_view_notes_list.class.php';
 class View_Notes__For_Immediate_Action extends Abstract_View_Notes_List
 {
-	static function getMenuPermissionLevel()
+	function _getNotesToShow()
 	{
-		return PERM_VIEWMYNOTES;
-	}
-
-	function _getNotesToShow($assigneeID=NULL, $search=NULL)
-	{
-		$conds = Array(
-			'status' => 'pending',
+		return $this->_getNotes(Array(
 			'<action_date' => date('Y-m-d', strtotime('tomorrow'))
-		);
-		if ($assigneeID) {
-			$conds['assignee'] = $assigneeID;
-		}
-		if ($search) {
-			$conds['subject'] = '%'.$search.'%';
-		}
-		$res = $GLOBALS['system']->getDBObjectData('person_note', $conds, 'AND', '', TRUE) + $GLOBALS['system']->getDBObjectData('family_note', $conds, 'AND', '', TRUE);
-		uasort($res, Array($this, '_compareNoteDates'));
-		return $res;
+		));
 	}
 
 

--- a/views/view_4_notes__2_for_future_action.class.php
+++ b/views/view_4_notes__2_for_future_action.class.php
@@ -14,8 +14,9 @@ class View_Notes__For_Future_Action extends Abstract_View_Notes_List
 			$conds['subject'] = '%'.$search.'%';
 		}
 		if ($assigneeID) $conds['assignee'] = $assigneeID;
-		return $GLOBALS['system']->getDBObjectData('person_note', $conds, 'AND', '', TRUE) + $GLOBALS['system']->getDBObjectData('family_note', $conds, 'AND', '', TRUE);
-		uasort($notes, Array($this, '_compareNoteDates'));
+		$res = $GLOBALS['system']->getDBObjectData('person_note', $conds, 'AND', '', TRUE) + $GLOBALS['system']->getDBObjectData('family_note', $conds, 'AND', '', TRUE);
+		uasort($res, Array($this, '_compareNoteDates'));
+		return $res;
 	}
 
 

--- a/views/view_4_notes__2_for_future_action.class.php
+++ b/views/view_4_notes__2_for_future_action.class.php
@@ -2,21 +2,11 @@
 require_once 'views/abstract_view_notes_list.class.php';
 class View_Notes__For_Future_Action extends Abstract_View_Notes_List
 {
-	static function getMenuPermissionLevel()
+	function _getNotesToShow()
 	{
-		return PERM_VIEWMYNOTES;
-	}
-
-	function _getNotesToShow($assigneeID=NULL, $search=NULL)
-	{
-		$conds = Array('status' => 'pending', '>action_date' => date('Y-m-d'));
-		if ($search) {
-			$conds['subject'] = '%'.$search.'%';
-		}
-		if ($assigneeID) $conds['assignee'] = $assigneeID;
-		$res = $GLOBALS['system']->getDBObjectData('person_note', $conds, 'AND', '', TRUE) + $GLOBALS['system']->getDBObjectData('family_note', $conds, 'AND', '', TRUE);
-		uasort($res, Array($this, '_compareNoteDates'));
-		return $res;
+		return $this->_getNotes(Array(
+			'>action_date' => date('Y-m-d')
+		));
 	}
 
 


### PR DESCRIPTION
https://github.com/tbar0970/jethro-pmm/blob/d47be606bde1c355586cb9a1270e2fc9ff32efbc/views/view_4_notes__2_for_future_action.class.php#L17-L19

There are two problems here.
1. There is code that would sort the notes by date, except it will never execute because it is after a `return` statement.
2. `$notes` is undefined.

I imagine that the future notes should be sorted by date like the immediate notes are.

https://github.com/tbar0970/jethro-pmm/blob/d47be606bde1c355586cb9a1270e2fc9ff32efbc/views/view_4_notes__1_for_immediate_action.class.php#L22-L25