### PR TITLE
Save attendance record set even if all are unknown

### DIFF
--- a/views/view_6_attendance__1_record.class.php
+++ b/views/view_6_attendance__1_record.class.php
@@ -114,9 +114,9 @@ class View_Attendance__Record extends View
 					if (!$set->haveLock() && !$set->acquireLock()) {
 						add_message("Unfortunately your lock on '".$set->getCohortName()."' has expired and been acquired by another user.  Please wait until they finish and try again.", 'error');
 					} else {
-						if ($set->processForm($i)) {
-							$set->save();
-						}
+						$set->processForm($i);
+						$set->save();
+
 						if ((int)$set->congregationid) {
 							Headcount::save('congregation', $this->_attendance_date, $set->congregationid, $_REQUEST['headcount']['congregation'][$set->congregationid]);
 						} else {


### PR DESCRIPTION
Resolves #1042

An attendance record set is only saved when is not empty - in other words, when at least one person is not 'unknown'.

https://github.com/tbar0970/jethro-pmm/blob/d47be606bde1c355586cb9a1270e2fc9ff32efbc/views/view_6_attendance__1_record.class.php#L117-L119

https://github.com/tbar0970/jethro-pmm/blob/d47be606bde1c355586cb9a1270e2fc9ff32efbc/db_objects/attendance_record_set.class.php#L373-L384

However, the issue requests that it still save in that situation. This PR changes the behaviour to always save.