### PR TITLE
Trim end of HTML widget

### DIFF
--- a/include/general.php
+++ b/include/general.php
@@ -687,6 +687,15 @@ function process_widget($name, $params, $index=NULL, $preserveEmpties=FALSE)
 			if (isset($rawVal)) {
 				require_once 'htmLawed.php';
 				$value = htmLawed($rawVal, array('deny_attribute' => '* -href', 'safe'=>1));
+
+				while (true) {
+					// Trim whitespace and paragraphs with a space from end
+					$trimmedValue = preg_replace('/<p>&nbsp;<\/p>$/', '', rtrim($value));
+					if ($trimmedValue == $value) {
+						break;
+					}
+					$value = $trimmedValue;
+				}
 			}
 			break;
 		case 'reference':


### PR DESCRIPTION
Resolves #353

The issue suggests trimming 'empty paragraphs' from the Service Component 'Content' field. Testing, I find that blank lines in the rich text editor become '<p>&nbsp;</p>'. I presume this is what is meant.

This PR trims whitespace, and paragraphs with &nbsp; from the end of all HTML fields on save - I see no reason why that wouldn't also be helpful in other places.