### PR TITLE
Don't try to print a table if we have no results. Fixes #1158

### DIFF
--- a/views/view_3_persons__3_reports.class.php
+++ b/views/view_3_persons__3_reports.class.php
@@ -276,6 +276,7 @@ class View_Persons__Reports extends View
 		}
 
 		$res = $GLOBALS['db']->queryAll($sql);
+		if (empty($res)) return;
 
 		?>
 		<table class="table table-bordered table-condensed table-auto-width">


### PR DESCRIPTION
A zero-row-returning SQL query now prints nothing (just the report title)

![image](https://github.com/user-attachments/assets/abdfa0d8-a35a-4a70-8f12-1a64fc951b41)
