### PR TITLE
Encode Document filenames which may contain ']', thus breaking PHP  array syntax

### DIFF
--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -196,7 +196,7 @@ $(document).ready(function() {
 				.modal('show')
 				.on('shown', function() {
 					$(this).find('input#rename-file')
-								.attr('name', 'renamefile['+filename+']')
+								.attr('name', 'renamefile['+encodeURIComponent(filename)+']')
 								.attr('value', filename);
 					TBLib.selectBasename.apply($(this).find('input#rename-file').get(0));
 			});
@@ -206,7 +206,7 @@ $(document).ready(function() {
 			$('#replace-file-modal')
 				.modal('show')
 				.find('input#replace-file')
-					.attr('name', 'replacefile['+filename+']')
+					.attr('name', 'replacefile['+encodeURIComponent(filename)+']')
 				.end()
 				.find('span#replaced-filename')
 					.html(filename)
@@ -233,7 +233,7 @@ $(document).ready(function() {
 				.modal('show')
 				.on('shown', function() {
 							$(this).find('select#move-file')
-								.attr('name', 'movefile['+filename+']')
+								.attr('name', 'movefile['+encodeURIComponent(filename)+']')
 								.focus();
 			});
 		});

--- a/views/view_9_documents.class.php
+++ b/views/view_9_documents.class.php
@@ -85,6 +85,7 @@ class View_Documents extends View
 				foreach ($_FILES['replacefile']['error'] as $origname => $error) {
 					if (($error == UPLOAD_ERR_OK) && ($origname = Documents_Manager::validateFileName($origname))) {
 						$tmp_name = $_FILES["replacefile"]["tmp_name"][$origname];
+						$origname = urldecode($origname);
 						if (file_exists($this->_realdir.'/'.$origname)) {
 							if (move_uploaded_file($tmp_name, $this->_realdir.'/'.$origname)) {
 								if ($p = fileperms($this->_rootpath)) chmod($this->_realdir.'/'.$origname, $p);
@@ -105,6 +106,7 @@ class View_Documents extends View
 			}
 			if (!empty($_POST['renamefile'])) {
 				foreach ($_POST['renamefile'] as $origname => $newname) {
+					$origname = urldecode($origname);
 					if (($newname = Documents_Manager::validateFileName($newname)) && ($origname = Documents_Manager::validateFileName($origname))) {
 						if (file_exists($this->_realdir.'/'.$origname) && rename($this->_realdir.'/'.$origname, $this->_realdir.'/'.$newname)) {
 							$this->_addMessage("$origname renamed to $newname");
@@ -114,6 +116,7 @@ class View_Documents extends View
 			}
 			if (!empty($_POST['movefile'])) {
 				foreach ($_POST['movefile'] as $filename => $newdir) {
+					$filename = urldecode($filename);
 					if (($filename = Documents_Manager::validateFileName($filename)) && ($fulldir = Documents_Manager::validateDirPath($newdir))) {
 						if (rename($this->_realdir.'/'.$filename, $fulldir.'/'.$filename)) {
 							$this->_addMessage("\"$filename\" moved to folder \"$newdir\"");


### PR DESCRIPTION
Fixes #1161 

Move:

![image](https://github.com/user-attachments/assets/b6718bbd-40c7-4bf8-8aac-de61a5771f7b)

Rename:

![image](https://github.com/user-attachments/assets/f8eb8b5a-6e03-405e-8986-bfc4819d3ee2)

Replace:

![image](https://github.com/user-attachments/assets/2f7226c1-6137-4688-bd09-e7a91aca67e4)
