### PR TITLE
Added PHP lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [8.3, 8.4]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.version }}
+          extensions: gd, gettext, curl
+
+      - name: Lint
+        run: php -l *.php calls/*.php db_objects/*.php hooks/**/*.php include/*.php members/*.php members/**/*.php public/*.php public/**/*.php scripts/*.php templates/*.php upgrades/*.php upgrades/**/*.php views/*.php


### PR DESCRIPTION
Here's an idea - by running the PHP linter on pull requests with GitHub Actions, you could quickly see if there are any syntax errors in a script.

I've started the version matrix at 8.3 just to use glob patterns. See https://php.watch/versions/8.3/cli-lint-multiple-files