### PR TITLE
Corrected quote return type

### DIFF
--- a/include/jethrodb.php
+++ b/include/jethrodb.php
@@ -89,7 +89,7 @@ class JethroDB extends PDO
 	 * Quote and escape a value ready for use in SQL
 	 * @param string$string
 	 * @param mixed $paramtype
-	 * @return string
+	 * @return string|false
 	 */
 	public function quote($string, $paramtype = NULL)
 	{


### PR DESCRIPTION
`JethroDB::quote` may call `PDO::quote`

https://github.com/tbar0970/jethro-pmm/blob/b2316d0c84e840b0b512bc70667454b32f200651/include/jethrodb.php#L18
https://github.com/tbar0970/jethro-pmm/blob/b2316d0c84e840b0b512bc70667454b32f200651/include/jethrodb.php#L88-L105

Looking at https://www.php.net/manual/en/pdo.quote.php, this means that it may return false, not just string.