### PR TITLE
Removed semicolon

### DIFF
--- a/views/view_5_groups__1_list_all.class.php
+++ b/views/view_5_groups__1_list_all.class.php
@@ -139,7 +139,7 @@ class View_Groups__List_All extends View
 				<?php
 			} else {
 				?>
-				<a class="soft pull-right hidden-phone" href="<?php echo build_url(Array('show_archived' => 0)); ?>"><i class="icon-eye-close"></i><?php echo _('Exclude Archived')?>;</a>
+				<a class="soft pull-right hidden-phone" href="<?php echo build_url(Array('show_archived' => 0)); ?>"><i class="icon-eye-close"></i><?php echo _('Exclude Archived')?></a>
 				<?php
 			}
 


### PR DESCRIPTION
'Include Archived' does not have a semicolon afterwards.
'Exclude Archived' does, and it appears to the user as text. Looking at 'Add a new group', I think this is just a typo - it would have been intended as PHP syntax rather than text. But as you can see from 'Include Archived', it's not required as PHP syntax either, so I suggest just removing it.

https://github.com/tbar0970/jethro-pmm/blob/b2316d0c84e840b0b512bc70667454b32f200651/views/view_5_groups__1_list_all.class.php#L138-L148