### PR TITLE
Added checkboxes to remove photo from person or family

### DIFF
--- a/db_objects/family.class.php
+++ b/db_objects/family.class.php
@@ -244,6 +244,14 @@ class family extends db_object
 	function printFieldInterface($name, $prefix='')
 	{
 		if ($name == 'photo') {
+			if ($this->id && $GLOBALS['db']->queryOne('SELECT 1 FROM family_photo WHERE familyid = '.(int)$this->id)) {
+				?>
+				<label class="checkbox remove-photo" title="Remove photo">
+					<input type="checkbox" name="photo_remove">
+					Remove photo
+				</label>
+				<?php
+			}
 			?>
 			<input type="file" accept="image/*" name="photo" />
 			<?php
@@ -479,10 +487,12 @@ class family extends db_object
 
 	private function savePhoto() {
 		$db =& $GLOBALS['db'];
-		if ($this->_photo_data) {
+		if ($this->_photo_data === FALSE) {
+			$this->clearPhoto();
+		} else if ($this->_photo_data) {
 			$SQL = 'REPLACE INTO family_photo (familyid, photodata)
 					VALUES ('.(int)$this->id.', '.$db->quote($this->_photo_data).')';
-			$res = $db->query($SQL);
+			$db->query($SQL);
 		}
 	}
 

--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -632,10 +632,12 @@ class Person extends DB_Object
 	private function _savePhoto()
 	{
 		$db =& $GLOBALS['db'];
-		if ($this->_photo_data) {
+		if ($this->_photo_data === FALSE) {
+			$this->_clearPhoto();
+		} else if ($this->_photo_data) {
 			$SQL = 'REPLACE INTO person_photo (personid, photodata)
 					VALUES ('.(int)$this->id.', '.$db->quote($this->_photo_data).')';
-			$res = $db->query($SQL);
+			$db->query($SQL);
 		}
 	}
 
@@ -960,6 +962,14 @@ class Person extends DB_Object
 	{
 		switch ($name) {
 			case 'photo':
+				if ($this->id && $GLOBALS['db']->queryOne('SELECT 1 FROM person_photo WHERE personid = '.(int)$this->id)) {
+					?>
+					<label class="checkbox remove-photo" title="Remove photo">
+						<input type="checkbox" name="<?php echo $prefix; ?>photo_remove">
+						Remove photo
+					</label>
+					<?php
+				}
 				?>
 				<input type="file" accept="image/*" max-bytes="<?php echo file_upload_max_size(); ?>" name="<?php echo $prefix; ?>photo" />
 				<?php

--- a/include/photo_handler.class.php
+++ b/include/photo_handler.class.php
@@ -10,6 +10,9 @@ Class Photo_Handler {
 
 	public static function getUploadedPhotoData($fieldName, $crop=NULL)
 	{
+		if (array_key_exists($fieldName.'_remove', $_POST)) {
+			return FALSE;
+		}
 		if ($crop === NULL) $crop = self::CROP_WIDTH;
 		if (!empty($_FILES[$fieldName]) && !empty($_FILES[$fieldName]['name'])) {
 			if (!empty($_FILES[$fieldName]['error'])) {

--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -1113,6 +1113,9 @@ img.person-photo {
 	width: 170px;
 }
 
+.remove-photo:has(input:checked) + input {
+	display: none;
+}
 
 /************** VIEW FAMILY ****************/
 .details-box form {


### PR DESCRIPTION
Resolves #602

If a photo is present on a family or person, adds a checkbox to 'Photo'.

![Screenshot 2025-03-08 at 4 14 02 pm](https://github.com/user-attachments/assets/dc4bf36b-717f-4dc5-8c60-f550f78bcd0c)

When checked, it will hide 'Choose file', to clarify that you should only be removing or adding a new photo, not both at once.

![Screenshot 2025-03-08 at 4 15 31 pm](https://github.com/user-attachments/assets/43f2d125-542f-4c18-aba6-0149b2011fa3)