### PR TITLE
Allow searching for dates before and after a date offset of the current day

### DIFF
--- a/db_objects/person_query.class.php
+++ b/db_objects/person_query.class.php
@@ -1108,7 +1108,7 @@ class Person_Query extends DB_Object
 						case 'anniversary':
 						    $valExp = 'pd'.$fieldid.'.value_date';
 							if (array_get($values, 'periodtype') == 'relative_directional') {
-                                // Given the current day, calculate a before/after offset, and allow dates before/after the offset
+								// Given the current day, calculate a before/after offset, and allow dates before/after the offset
 								$length = $values['periodlength'];
 								if (!preg_match('/^[0-9]+$/', $length)) $length = 0;
 
@@ -1119,7 +1119,7 @@ class Person_Query extends DB_Object
 									$offsetday = date('Y-m-d', strtotime("{$length} days"));
 								}
 								if ($values['perioddirection'] == "before") { // direction from offset to allow dates in
-                                    $condExp = '< '.$db->quote($offsetday);
+									$condExp = '< '.$db->quote($offsetday);
 								} elseif ($values['perioddirection'] == "after") {
 									$condExp = '> '.$db->quote($offsetday);
 								}
@@ -1155,8 +1155,8 @@ class Person_Query extends DB_Object
 									$qToYear = $db->quote(substr($to, 0, 4));
 
 									$w[] = "$valExp LIKE '-%' AND (
-											CONCAT($qFromYear, $valExp) $betweenExp
-											OR CONCAT($qToYear, $valExp) $betweenExp
+										CONCAT($qFromYear, $valExp) $betweenExp
+										OR CONCAT($qToYear, $valExp) $betweenExp
 										)";
 									$w[] = "$valExp NOT LIKE '-%' AND (
 											CONCAT($qFromYear, RIGHT($valExp, 6)) $betweenExp


### PR DESCRIPTION
As described on https://github.com/tbar0970/jethro-pmm/issues/1199, this adds search for dates in an offset-relative direction:
 
![image](https://github.com/user-attachments/assets/e666f6e2-ffb3-4440-adfe-890dfc6d1cc1)

Implementation notes;

## Saved reports

I don't think this breaks any saved reports. Existing relative date range filter is as saved as:
```
[211] => Array
                (
                    [criteria] => exact
                    [periodtype] => relative
                    [periodlength] => 14
                    [periodanchor] => before
                    [from] => 
                    [to] => 
                )
```
The new date filter is saved as:
```
[211] => Array
                (
                    [criteria] => exact
                    [periodtype] => relative_directional
                    [periodlength] => 10
                    [periodanchor] => before
                    [perioddirection] => after
                    [from] => 
                    [to] => 
                )
```

## Implementation alternatives

### modifying the existing option

Rather than adding a new search option, I did consider augmenting the existing relative search, so that "within" could be changed to "before" or "after":  

![image](https://github.com/user-attachments/assets/918c73cf-0507-486c-a4bc-1dc87f5782c6)

That would work, but allows for the nonsensical combination of before + after, and after + before:

![image](https://github.com/user-attachments/assets/4130f30d-375f-4733-8521-803e1ec8b766)

By having a separate line, we can show only combinations that make sense.

### anniversary

Date filters have both "with exact value" and "with exact value or anniversary":

![image](https://github.com/user-attachments/assets/27e38582-1b39-4cd1-bbc6-c390f2f23e29)

It does not make sense to show our new search options under the "anniversary" search type, but currently it does show:

![image](https://github.com/user-attachments/assets/8930e8f9-83d6-4816-abeb-3391d1eb9de1)

This can be fixed if it annoys anyone - it just requires making the PHP a bit uglier with conditional statements.
