### PR TITLE
Doc improvements to roster_reminders.php

### DIFF
--- a/scripts/roster_reminder.php
+++ b/scripts/roster_reminder.php
@@ -1,11 +1,11 @@
 <?php
 /*****************************************************************
-This script will send roster reminder emails
-set-up a cron-job to run the script ast follows
+This script will send roster reminder emails, SMSes or both, to people rostered on a configured roster in the upcoming 6 days. Typically this matches the upcoming Sunday, but if another day's allocations are found (e.g. Easter Friday), people are notified once about both.
+
+Set up a cron-job to run the script as follows:
 
 php /path/to/this/script/roster_reminder.php /path/to/ini/file/roster_reminder_sample.ini
 
-Note: This script will only work with roster views that are made public
 Where's the roster id number?  When you view a roster via the /jethro/public directory you'll see the roster id number in the url (eg. &roster_view=1)
 
 Use .ini file to set the following


### PR DESCRIPTION
It's Easter Friday coming up, and I was wondering how roster_reminders.php handled both a Friday and a Sunday service.

Turns out it works just fine, notifying everyone once, but listing first the Friday roster allocations, then Sunday roster allocations.  The email subject also has the dates `(18 Apr 2025, 20 Apr 2025)` appended to the subject.

This patch documents this behaviour.

Secondly, the script comment claims:
```
Note: This script will only work with roster views that are made public
```
I'm pretty certain this is untrue. We have been sending off a private roster view for many years.  So I have removed it.