### PR TITLE
Make SMS max length reflect the real segment limit (160 chars)

### DIFF
--- a/include/installer.class.php
+++ b/include/installer.class.php
@@ -275,7 +275,7 @@ class Installer
 			(@rank:=@rank+5, '',                         'SMTP_USERNAME','Username for SMTP server','text',''),
 			(@rank:=@rank+5, '',                         'SMTP_PASSWORD','Password for SMTP server','text',''),
 
-			(@rank:=@rank+5, 'SMS Gateway',              'SMS_MAX_LENGTH','','int','140'),
+			(@rank:=@rank+5, 'SMS Gateway',              'SMS_MAX_LENGTH','','int','160'),
 			(@rank:=@rank+5, '',                         'SMS_HTTP_URL','URL of the SMS messaging service','text',''),
 			(@rank:=@rank+5, '',                         'SMS_HTTP_HEADER_TEMPLATE','Template for the headers of a request to the SMS messaging service','text_ml',''),
 			(@rank:=@rank+5, '',                         'SMS_HTTP_POST_TEMPLATE','Template for the body of a request to the SMS messaging service','text_ml',''),

--- a/upgrades/2025-upgrade-to-2.37.sql
+++ b/upgrades/2025-upgrade-to-2.37.sql
@@ -1,0 +1,2 @@
+-- #1213 - update the installer-specified default SMS length of 140 to 160
+update setting set value=160 where symbol='SMS_MAX_LENGTH' and value=140;


### PR DESCRIPTION
Also update databases who inherited the 140 limit from the installer. Fixes #1213.