### PR TITLE
Fix relative date search (#1199) problems

### DIFF
--- a/db_objects/person_query.class.php
+++ b/db_objects/person_query.class.php
@@ -1165,8 +1165,9 @@ class Person_Query extends DB_Object
 								if ($v == '*') {
 									$$k = NULL;
 								} else if (preg_match(("/([-+])(\d+)?y(\d+)?m(\d+)?d/"), $v, $matches, PREG_UNMATCHED_AS_NULL)) {
+                                    $sym=$matches[1]; // + or -
 									// relative date - convert it to an absolute now.
-									$$k = date('Y-m-d', strtotime($matches[1].($matches[2] ?? 0).' years '.($matches[3] ?? 0).' months '.($matches[4] ?? 0).' days'));
+									$$k = date('Y-m-d', strtotime($sym.($matches[2] ?? 0).' years '.$sym.($matches[3] ?? 0).' months '.$sym.($matches[4] ?? 0).' days'));
 								} else {
 									// absolute date
 									$$k = $v;

--- a/db_objects/person_query.class.php
+++ b/db_objects/person_query.class.php
@@ -1165,7 +1165,7 @@ class Person_Query extends DB_Object
 								if ($v == '*') {
 									$$k = NULL;
 								} else if (preg_match(("/([-+])(\d+)y(\d+)m(\d+)d/"), $v, $matches)) {
-                                    $sym=$matches[1]; // + or -
+									$sym=$matches[1]; // + or -
 									// relative date - convert it to an absolute now.
 									$$k = date('Y-m-d', strtotime($sym.$matches[2].' years '.$sym.$matches[3].' months '.$sym.$matches[4].' days'));
 								} else {

--- a/db_objects/person_query.class.php
+++ b/db_objects/person_query.class.php
@@ -1164,10 +1164,10 @@ class Person_Query extends DB_Object
 								$matches = Array();
 								if ($v == '*') {
 									$$k = NULL;
-								} else if (preg_match(("/([-+])(\d+)?y(\d+)?m(\d+)?d/"), $v, $matches, PREG_UNMATCHED_AS_NULL)) {
+								} else if (preg_match(("/([-+])(\d+)y(\d+)m(\d+)d/"), $v, $matches)) {
                                     $sym=$matches[1]; // + or -
 									// relative date - convert it to an absolute now.
-									$$k = date('Y-m-d', strtotime($sym.($matches[2] ?? 0).' years '.$sym.($matches[3] ?? 0).' months '.$sym.($matches[4] ?? 0).' days'));
+									$$k = date('Y-m-d', strtotime($sym.$matches[2].' years '.$sym.$matches[3].' months '.$sym.$matches[4].' days'));
 								} else {
 									// absolute date
 									$$k = $v;

--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -189,7 +189,7 @@ $(document).ready(function() {
 				menu.find('input[name=drp_exact_y]').val(matches[1]);
 				JethroDateRangePicker.updateDisplayValue(this, 'exact');
 				break;
-			case (!!(matches = this.value.match(/([-+])(\d+)?y(\d+)?m(\d+)?d/))):
+			case (!!(matches = this.value.match(/([-+])(\d+)y(\d+)m(\d+)d/))):
 				menu.find('input[name=drp_relative_direction]').val(matches[1]);
 				menu.find('input[name=drp_relative_d]').val(matches[4]);
 				menu.find('input[name=drp_relative_m]').val(matches[3]);
@@ -246,9 +246,9 @@ $(document).ready(function() {
 				var v = {};
 				var drp = $(this).parents('.date-range-picker');
 				v['direction'] = drp.find('select[name=drp_relative_direction]').val()
-				v['y'] = drp.find('input[name=drp_relative_y]').val();
-				v['m'] = drp.find('input[name=drp_relative_m]').val();
-				v['d'] = drp.find('input[name=drp_relative_d]').val();
+				v['y'] = drp.find('input[name=drp_relative_y]').val() || "0";
+				v['m'] = drp.find('input[name=drp_relative_m]').val() || "0";
+				v['d'] = drp.find('input[name=drp_relative_d]').val() || "0";
 				toggle.options[0].value = v['direction']+v['y']+'y'+v['m']+'m'+v['d']+'d';
 				break;
 			case 'exact':
@@ -1979,7 +1979,7 @@ JethroDateRangePicker.updateDisplayValue = function(selectElt, valueType)
 			selectElt.options[0].innerHTML = d.getDate()+' '+d.toLocaleString('default', { month: 'short' })+' '+d.getFullYear();
 			break;
 		case 'relative':
-			var matches = selectElt.options[0].value.match(/([-+])(\d+)?y(\d+)?m(\d+)?d/);
+			var matches = selectElt.options[0].value.match(/([-+])(\d+)y(\d+)m(\d+)d/);
 			if (matches) {
 				var l = '';
 				if (matches[2]>0) l += matches[2]+' years ';

--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -189,7 +189,7 @@ $(document).ready(function() {
 				menu.find('input[name=drp_exact_y]').val(matches[1]);
 				JethroDateRangePicker.updateDisplayValue(this, 'exact');
 				break;
-			case (!!(matches = this.value.match(/([-+])(\d+)y(\d+)m(\d+)d/))):
+			case (!!(matches = this.value.match(/([-+])(\d+)?y(\d+)?m(\d+)?d/))):
 				menu.find('input[name=drp_relative_direction]').val(matches[1]);
 				menu.find('input[name=drp_relative_d]').val(matches[4]);
 				menu.find('input[name=drp_relative_m]').val(matches[3]);
@@ -1979,7 +1979,7 @@ JethroDateRangePicker.updateDisplayValue = function(selectElt, valueType)
 			selectElt.options[0].innerHTML = d.getDate()+' '+d.toLocaleString('default', { month: 'short' })+' '+d.getFullYear();
 			break;
 		case 'relative':
-			var matches = selectElt.options[0].value.match(/([-+])(\d+)y(\d+)m(\d+)d/);
+			var matches = selectElt.options[0].value.match(/([-+])(\d+)?y(\d+)?m(\d+)?d/);
 			if (matches) {
 				var l = '';
 				if (matches[2]>0) l += matches[2]+' years ';


### PR DESCRIPTION
Fix relative date search (#1199) problems:
 - Don't break if nothing is entered for e.g. month and year parts
  - Don't break on a relative search from 'any' to 'any'
 
  Also add a comment explaining old/new param formats.

There's a design question involved here: say the user only enter the year part of a relative period:
![image](https://github.com/user-attachments/assets/9e4311e6-747a-46c6-b1dd-2422e64918bd)

do we store this as `-1y0m0d` or `-1ymd`?

I have gone with `-1ymd` to distinguish "nothing was entered" from "0 was entered". Otherwise, after saving and re-editing the report, `months` and `days` would change from blank to `0`.

To support `-1ymd`, I changed the old regex:
```php
preg_match(("/([-+])(\d+)y(\d+)m(\d+)d/"), $v, $matches)
```
to:
```php
preg_match(("/([-+])(\d+)?y(\d+)?m(\d+)?d/"), $v, $matches, PREG_UNMATCHED_AS_NULL)
```
(The `(\d+)?` is used rather than `(\d*)` so that, in conjunction with `PREG_UNMATCHED_AS_NULL`,  I get back `null` rather than `""` and can use the snazzy `??` null coalesce operator