### PR TITLE
#1239 - Marking attendance breaks under PHP 8.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /nbproject/
 /files/
 conf.php
+.idea/
+.php-cs-fixer.cache

--- a/db_objects/attendance_record_set.class.php
+++ b/db_objects/attendance_record_set.class.php
@@ -788,7 +788,7 @@ class Attendance_Record_Set
 			$congregations = $GLOBALS['system']->getDBObjectData('congregation', Array('!attendance_recording_days' => 0), 'OR', 'meeting_time');
 			$groups = $GLOBALS['system']->getDBObjectData('person_group', Array('!attendance_recording_days' => 0, 'is_archived' => 0), 'AND', 'category, name');
 			// need to preserve category too
-			uasort($groups, function($x,$y) {$r = strnatcmp($x["category"], $y["category"]); if ($r == 0) $r = strnatcmp($x["name"], $y["name"]); return $r;}); // to ensure natural sorting
+			uasort($groups, function($x,$y) {$r = strnatcmp($x["category"] ?? '', $y["category"] ?? ''); if ($r == 0) $r = strnatcmp($x["name"], $y["name"]); return $r;}); // to ensure natural sorting
 		}
 		$lastCategory = -1;
 		?>


### PR DESCRIPTION
#1239 - The `strnatcmp` function doesn't like being fed `null`s, so add `?? ''` to keep it happy.

FYI there are no other occurrences of `strnatcmp`, but there are some of `strcmp` that might have the same problem. They're not easy to test though:

![image](https://github.com/user-attachments/assets/8cda9c97-8858-4524-a6ca-a2ed84e42484)
