### PR TITLE
#1241 - Fix attendance marking if one congregation has no persons in scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /nbproject/
 /files/
 conf.php
+.idea/
+.php-cs-fixer.cache

--- a/db_objects/attendance_record_set.class.php
+++ b/db_objects/attendance_record_set.class.php
@@ -205,20 +205,22 @@ class Attendance_Record_Set
 
 	function delete()
 	{
-		$db =& $GLOBALS['db'];
-		$sql = 'DELETE ar
+		// If group/congregation filters caused no persons to have attendance marked for this congregation, do nothing. #1241
+		if ($this->_persons) {
+			$db =& $GLOBALS['db'];
+			$sql = 'DELETE ar
 				FROM attendance_record ar
 				JOIN person p ON ar.personid = p.id
-				WHERE date = '.$db->quote($this->date).'
-					AND (ar.groupid = '.$db->quote((int)$this->groupid).')';
-		if ($this->congregationid) {
-			$sql .= '
-					AND (congregationid = '.$db->quote($this->congregationid).')
+				WHERE date = ' . $db->quote($this->date) . '
+					AND (ar.groupid = ' . $db->quote((int)$this->groupid) . ')';
+			if ($this->congregationid) {
+				$sql .= '
+					AND (congregationid = ' . $db->quote($this->congregationid) . ')
 					';
+			}
+			$sql .= '  AND personid IN (' . implode(',', array_map(array($db, 'quote'), array_keys($this->_persons))) . ')';
+			$res = $db->query($sql);
 		}
-		$sql .= '  AND personid IN ('.implode(',', array_map(Array($db, 'quote'), array_keys($this->_persons))).')';
-
-		$res = $db->query($sql);
 	}
 
 

--- a/views/view_6_attendance__1_record.class.php
+++ b/views/view_6_attendance__1_record.class.php
@@ -118,9 +118,17 @@ class View_Attendance__Record extends View
 						$set->save();
 
 						if ((int)$set->congregationid) {
-							Headcount::save('congregation', $this->_attendance_date, $set->congregationid, $_REQUEST['headcount']['congregation'][$set->congregationid]);
+							// There will be no headcount for this congregation if no persons were in the congregation's set. #1241
+							if (isset($_REQUEST['headcount']['congregation'][$set->congregationid])) {
+								$congregation_headcount = $_REQUEST['headcount']['congregation'][$set->congregationid];
+								Headcount::save('congregation', $this->_attendance_date, $set->congregationid, $congregation_headcount);
+							}
 						} else {
-							Headcount::save('person_group', $this->_attendance_date, $set->groupid, $_REQUEST['headcount']['group'][$set->groupid]);
+							// There will be no headcount for this group if no persons were in the group's set. #1241
+							if (isset($_REQUEST['headcount']['group'][$set->groupid])) {
+								$group_headcount = $_REQUEST['headcount']['group'][$set->groupid];
+								Headcount::save('person_group', $this->_attendance_date, $set->groupid, $group_headcount);
+							}
 						}
 						$set->releaseLock();
 					}


### PR DESCRIPTION
Per #1241 description - the problem is with the last `personid in ()` clause in the generated SQL:
```sql
DELETE ar
FROM attendance_record ar
         JOIN person p ON ar.personid = p.id
WHERE date = '2025-07-06'
  AND (ar.groupid = '0')
  AND (congregationid = '1')
  AND personid IN ();
```
~~We just need an `if` clause to avoid adding that if there are no persons.~~ Actually, eliminating the `AND personid in ()` clause would mean "anyone" rather than "nobody"! We must either:
 - replace `AND personid in ()` with `AND personid in (-1)`
 - just not do the DELETE altogether if there are no personids.

I have gone with the latter option.


Furthermore, if this SQL is fixed Jethro then breaks with:

```
SYSTEM ERROR (WARNING)
Undefined array key 1

Show Details
Line 123 of File /home/jethro/code/2.36.1/app/views/view_6_attendance__1_record.class.php
	Array
(
    [0] => Array
        (
            [file] => /home/jethro/code/2.36.1/app/include/system_controller.class.php
            [line] => 128
            [function] => processView
            [class] => View_Attendance__Record
            [type] => ->
            [args] => Array
                (
                )

        )

    [1] => Array
        (
            [file] => /home/jethro/code/2.36.1/app/index.php
            [line] => 67
            [function] => run
            [class] => System_Controller
            [type] => ->
            [args] => Array
                (
                )

        )

)				
```
This is because the code assumes each congregation has a headcount:

<img width="586" height="68" alt="Image" src="https://github.com/user-attachments/assets/028f70f9-0fb2-48cf-a14c-72bf215938f6" />

but there isn't a headcount shown if there are no people to record attendance for:

<img width="537" height="206" alt="Image" src="https://github.com/user-attachments/assets/73e706f6-a2ff-43f7-b25f-69636e12e6ca" />

There is an identical bug when marking >1 group attendance, where one group has no persons filtered.

This patch fixes both problems.