### PR TITLE
PHP 7.2 compatibility

### DIFF
--- a/views/view_1_home.class.php
+++ b/views/view_1_home.class.php
@@ -14,7 +14,10 @@ class View_Home extends View
 	{
 		if (ifdef('NEEDS_1086_CHECK')) {
 			if ($GLOBALS['user_system']->havePerm(PERM_SYSADMIN)) {
-				require_once 'views/view_0_fix_age_brackets.class.php';
+				if (PHP_VERSION_ID >= 70400) {
+					// This code requires php 7.4+ but isn't particularly essential, so let's not break on 7.2. Issue #1245
+					require_once 'views/view_0_fix_age_brackets.class.php';
+				}
 				$x = new View__Fix_Age_Brackets();
 				$x->printInvitation();
 			}


### PR DESCRIPTION
Fixes #1245

Here is the output of PHPStorm's Code -> Analyze Code, with `PHP language level` set to 7.2:

<img width="515" height="456" alt="image" src="https://github.com/user-attachments/assets/3e6351b5-1b9e-48a6-9157-207046d2c8ea" />

It shows two php 7.2 compatibility problems in `roster_view.class.php` (which I fixed, so are marked `No longer valid`) and a lot of problems in the age bracket fixer code.

I'm not keen on rewriting Age Bracket Fixer for an ancient PHP release, so in this patch I've just conditionally excluded it under PHP 7.2. The functionality is very unlikely to be missed.

I've tested the changes under PHP 7.2 and 8.3 and it works in both. The codepath only triggers when another user has a lock:

<img width="1232" height="431" alt="image" src="https://github.com/user-attachments/assets/f121527e-84bd-4bbc-bf3c-73514e999f68" />
