### PR TITLE
Handle deprecations by logging only. #1250

### DIFF
--- a/include/system_controller.class.php
+++ b/include/system_controller.class.php
@@ -72,9 +72,6 @@ class System_Controller
 
 	public function initErrorHandler()
 	{
-		$error_level = defined('E_DEPRECATED') ? (E_ALL & ~constant('E_DEPRECATED') /*& ~constant('E_STRICT')*/) : E_ALL;
-		error_reporting($error_level);
-
 		set_error_handler(Array($this, '_handleError'));
 		set_exception_handler(Array($this, '_handleException'));
 	}
@@ -284,6 +281,10 @@ class System_Controller
 				$bg = 'warning';
 				$title = 'NOTICE';
 				break;
+			case E_DEPRECATED:
+				// Log deprecations, but don't print anything to the browser. #1250
+				error_log("$errstr - Line $errline of $errfile");
+				return;
 			default:
 				$bg = 'info';
 				$title = 'SYSTEM ERROR';


### PR DESCRIPTION
Fixes #1250 

Jethro's error handling works as follows:

Initially in `init.php`, we tell PHP's default error handler to ignore `E_DEPRECATED`:

https://github.com/tbar0970/jethro-pmm/blob/792d22e6e32bed38602b09c904e332584e1f3456/include/init.php#L23-L25

(that horrible first line should be rewritten to `$error_level = E_ALL & E_DEPRECATED;` now we're not supporting PHP 5)

This is good, because there are indeed deprecated APIs used in general.php, and we can't let the default error handling print anything to the browser yet, because we haven't sent the HTTP headers yet.

Then later in `system_controller.class.php`, we again tinker with error handling:

https://github.com/tbar0970/jethro-pmm/blob/792d22e6e32bed38602b09c904e332584e1f3456/include/system_controller.class.php#L73-L80

We set the error level with `error_reporting()`. This is both redundant (it was done in init.php) and pointless, because we also now define a custom error handler function, `_handleError`, that (unlike the default) does not care [1], so I have removed it.

Then we set `_handleError` as the error handling function.

In `_handleError` I've added custom code to just log a message, and return:
```
			case E_DEPRECATED:
				// Log deprecations, but don't print anything to the browser. #1250
				error_log("$errstr - Line $errline of $errfile");
				return;
```
Previously the `E_DEPRECATED` case was unhandled - I suspect because Tom thought it would never be called [1].


[1] 
In PHP, if one sets a custom error handler:
```php
set_error_handler(Array($this, '_handleError'));
```
then the custom error handler is _always_ called. It is up to the error handler (`_handleError()`) to check `error_reporting()` to see if the app has set a preference for how to handle a particular error type.

Alternatively, one can now set:

```php
set_error_handler(Array($this, '_handleError'), error_reporting());
```
Here, `error_reporting()` is more like a gate. PHP will only invoke `_handleError` if the error matches the `error_reporting()` criteria.

We do want to do something (log) rather than nothing, so I've kept the first invocation type, and just added `E_DEPRECATED` handling.