### PR TITLE
In an action plan, don't break if asked to remove a deleted group

### DIFF
--- a/db_objects/action_plan.class.php
+++ b/db_objects/action_plan.class.php
@@ -538,7 +538,7 @@ class Action_Plan extends DB_Object
 		}
 		foreach (array_get($actions, 'groups_remove', Array()) as $groupid) {
 			$group = $GLOBALS['system']->getDBObject('person_group', $groupid);
-			$group->removeMembers($personids);
+			if ($group) $group->removeMembers($personids);
 		}
 
 		$note_type = $subject_type.'_note';


### PR DESCRIPTION
Silently succeed instead. Fixes #1252.

The stacktrace is:
```
Call to a member function removeMembers() on null
Show Details
Line 541 of File /home/jethro/code/2.36.1/app/db_objects/action_plan.class.php
```


