### PR TITLE
Break nicely (and early) if e.g. due to timeout, our request has lost the ID of the to-be-edited object. 

### DIFF
--- a/views/abstract_view_edit_object.class.php
+++ b/views/abstract_view_edit_object.class.php
@@ -19,6 +19,10 @@ class Abstract_View_Edit_Object extends View
 	function _initEditedObject()
 	{
 		if (empty($this->_object_id_field)) $this->_object_id_field = $this->_editing_type.'id';
+		if (!array_key_exists($this->_object_id_field, $_REQUEST)) {
+			trigger_error('Lost track of which '.$this->getEditingTypeFriendly().' is to be edited', E_USER_WARNING);
+			return false;
+		}
 		$this->_edited_object = $GLOBALS['system']->getDBObject($this->_editing_type, (int)$_REQUEST[$this->_object_id_field]);
 		if (is_null($this->_edited_object)) {
 			trigger_error($this->getEditingTypeFriendly().' #'.(int)$_REQUEST[$this->_object_id_field].' does not exist', E_USER_WARNING);


### PR DESCRIPTION
Fixes #1235.  The request still breaks because it's an irredeemable error situation, but at least processing is halted cleanly.  

I suspect that without this early halt, the trainwreck might continue until actual damage is done, like with #1243.

<img width="1079" height="308" alt="image" src="https://github.com/user-attachments/assets/e81e898a-e8fa-4c25-9fc3-0497e3e4d6c6" />


<img width="901" height="243" alt="image" src="https://github.com/user-attachments/assets/6880cb16-3f54-481d-a702-05f730d904d4" />

