### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/db_objects/service.class.php
+++ b/db_objects/service.class.php
@@ -387,7 +387,7 @@ class service extends db_object
 					$res = Array();
 					foreach ($this->getItems(FALSE, $compCatID) as $item) {
 						$line = nbsp(ents($item['title']));
-						if (!$printableMode && (strlen($item['ccli_number']) + strlen($item['comments']) > 0)) {
+						if (!$printableMode && (strlen($item['ccli_number'] ?? '') + strlen($item['comments'] ?? '') > 0)) {
 							
 							// yuck, but oh well...
 							ob_start();
@@ -401,7 +401,7 @@ class service extends db_object
 							$line .= ' <i class="clickable icon-info-sign" data-toggle="visible" data-target="#compdetail'.$compid.'-'.$this->id.'"></i>';
 							$line .= '<table class="help-block custom-field-tooltip" id="compdetail'.$compid.'-'.$this->id.'"><tr><td class="narrow">CCLI #:</td><td>'.$ccli_code.'</td>';
 							$line .= '<td class="narrow"><a title="Edit this component" href="'.BASE_URL.'?view=_edit_service_component&service_componentid='.$compid.'"><i class="icon-wrench"></i></a></td></tr>';
-							$line .= '<tr><td>Comments:</td><td colspan="2">'.linkUrlsInTrustedHtml(nl2br($item['comments'])).'</td></tr></table>';
+							$line .= '<tr><td>Comments:</td><td colspan="2">'.linkUrlsInTrustedHtml(nl2br($item['comments'] ?? '')).'</td></tr></table>';
 						}
 						$res[] = $line;
 					}


### PR DESCRIPTION
These deprecations show up very visibly (without #1251) when running under 8.4:

<img width="236" height="501" alt="image" src="https://github.com/user-attachments/assets/82f441e0-35d0-4320-9e21-22422b2a9178" />

Changes are compatible with PHP 7.0+