### PR TITLE
Only use exif extension if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ System requirements are:
     * with [xmlwriter extension](https://www.php.net/manual/en/book.xmlwriter.php) enabled, to create DOCX files
     * [GD library](https://www.php.net/manual/en/book.image.php) recommended, to manage the size of uploaded photos
     * with [curl extension](https://www.php.net/manual/en/book.curl.php) enabled, if you intend to use the Mailchimp integration
+    * with [exif extension](https://www.php.net/manual/en/book.exif.php) enabled, if you would like to automatically rotate images
 
 The steps to install are:
 1. Unzip the files into a web-accessible folder on your web server

--- a/include/photo_handler.class.php
+++ b/include/photo_handler.class.php
@@ -43,19 +43,21 @@ Class Photo_Handler {
 					$fn = 'imagecreatefrom'.$ext;
 					$input_img = $fn($_FILES[$fieldName]['tmp_name']);
 					if (!$input_img) exit;
-					// Rotate the image as necessary - thanks https://www.php.net/manual/en/function.exif-read-data.php#110894
-					$exif = @exif_read_data($_FILES[$fieldName]['tmp_name']);
-					if (!empty($exif['Orientation'])) {
-						switch($exif['Orientation']) {
-							case 8:
-								$input_img = imagerotate($input_img,90,0);
-								break;
-							case 3:
-								$input_img = imagerotate($input_img,180,0);
-								break;
-							case 6:
-								$input_img = imagerotate($input_img,-90,0);
-								break;
+					if (function_exists('exif_read_data')) {
+						// Rotate the image as necessary - thanks https://www.php.net/manual/en/function.exif-read-data.php#110894
+						$exif = @exif_read_data($_FILES[$fieldName]['tmp_name']);
+						if (!empty($exif['Orientation'])) {
+							switch($exif['Orientation']) {
+								case 8:
+									$input_img = imagerotate($input_img,90,0);
+									break;
+								case 3:
+									$input_img = imagerotate($input_img,180,0);
+									break;
+								case 6:
+									$input_img = imagerotate($input_img,-90,0);
+									break;
+							}
 						}
 					}
 					$orig_width = imagesx($input_img);


### PR DESCRIPTION
If I try and upload an image without the exif extension, I get
```
Fatal Error (Exception)

Call to undefined function exif_read_data()
```

I suggest only using `exif_read_data` if the extension is present, and adding a note to the README.