### PR TITLE
Fix a PHP 8.4+ CSV deprecation warnings

### DIFF
--- a/calls/call_csv.class.php
+++ b/calls/call_csv.class.php
@@ -40,7 +40,7 @@ class Call_csv extends Call
 			if ($header == 'feed_uuid') continue;
 			$headerrow[] = strtoupper($dummy->getFieldLabel($header));
 		}
-		fputcsv($fp, $headerrow);
+		fputcsv($fp, $headerrow, ",", '"', "");
 
 
 		foreach ($merge_data as $id => $row) {
@@ -58,7 +58,7 @@ class Call_csv extends Call
 					$outputrow[] = $v;
 				}
 			}
-			fputcsv($fp, $outputrow);
+			fputcsv($fp, $outputrow, ",", '"', "");
 		}
 		fclose($fp);
 	}

--- a/calls/call_sample_import.class.php
+++ b/calls/call_sample_import.class.php
@@ -13,7 +13,7 @@ class Call_Sample_Import extends Call
 
 		require_once JETHRO_ROOT.'/views/view_10_admin__7_import.class.php';
 		$header = View_Admin__Import::getSampleHeader();
-		fputcsv($fp, $header);
+		fputcsv($fp, $header, ",", '"', "");
 
 		$congs = $GLOBALS['system']->getDBObjectData('congregation');
 		foreach ($congs as $id => $detail) {
@@ -180,7 +180,7 @@ class Call_Sample_Import extends Call
 			foreach (Array_get($row, 'groups', Array()) as $g) {
 				$out[] = $g;
 			}
-			fputcsv($fp, $out);
+			fputcsv($fp, $out, ",", '"', "");
 		}
 
 

--- a/db_objects/person_query.class.php
+++ b/db_objects/person_query.class.php
@@ -1776,7 +1776,7 @@ class Person_Query extends DB_Object
 			}
 			if ($groupingname) $hr[] = 'GROUPING';
 
-			fputcsv($fp, $hr);
+			fputcsv($fp, $hr, ",", '"', "");
 			$headerprinted = TRUE;
 		}
 		foreach ($x as $row) {
@@ -1798,7 +1798,7 @@ class Person_Query extends DB_Object
 				}
 			}
 			if ($groupingname) $r[] = str_replace('"', '""', $groupingname);
-			fputcsv($fp, $r);
+			fputcsv($fp, $r, ",", '"', "");
 		}
 		fclose($fp);
 	}

--- a/include/installer.class.php
+++ b/include/installer.class.php
@@ -336,7 +336,7 @@ class Installer
 				$fn = JETHRO_ROOT.'/locale/settings/'.$_REQUEST['locale'].'.csv';
 				if (file_exists($fn)) {
 					$fp = fopen($fn, 'r');
-					while ($row = fgetcsv($fp)) {
+					while ($row = fgetcsv($fp, 0, ",", '"', "")) {
 						Config_Manager::saveSetting($row[0], $row[1]);
 					}
 					fclose($fp);

--- a/scripts/email_report.php
+++ b/scripts/email_report.php
@@ -91,7 +91,7 @@ $table_rows = explode(PHP_EOL, $csv_string);
 //covert each row into an array
 $table_array = array();
 foreach ($table_rows as $line) {
-    $table_array[] = str_getcsv($line);
+    $table_array[] = str_getcsv($line, ",", '"', "");
 }
     $rows = (count($table_array)-1);
     $columns = count($table_array[0]);

--- a/scripts/roster_reminder.php
+++ b/scripts/roster_reminder.php
@@ -128,7 +128,7 @@ ob_end_clean();
 $roster_lines = preg_split('/(?=\n")/',$roster_csv);
 $roster_array = array();
 foreach ($roster_lines as $line) {
-	$roster_array[] = str_getcsv($line);
+	$roster_array[] = str_getcsv($line, ",", '"', "");
 }
 $roster_date = '';
 if (count($roster_array) > 2) {

--- a/views/view_0_export_checkins.class.php
+++ b/views/view_0_export_checkins.class.php
@@ -22,10 +22,10 @@ class View__Export_Checkins extends View
 				header("Content-Disposition: attachment; filename=checkins.csv");
 				$fp = fopen('php://output', 'w');
 				$firstRow = reset($this->data);
-				fputcsv($fp, array_keys($firstRow));
+				fputcsv($fp, array_keys($firstRow), ",", '"', "");
 				foreach ($this->data as $d) {
 					$d['venueid'] = $this->venue->getValue('name');
-					fputcsv($fp, $d);
+					fputcsv($fp, $d, ",", '"', "");
 				}
 				fclose($fp);
 				exit;

--- a/views/view_0_import_service_components.class.php
+++ b/views/view_0_import_service_components.class.php
@@ -24,10 +24,10 @@ class View__Import_Service_Components extends View
 				trigger_error("Your data file could not be read.  Please check the file and try again");
 				return;
 			}
-			$toprow = fgetcsv($fp, 0, ",", '"');
+			$toprow = fgetcsv($fp, 0, ",", '"', "");
 			$rowNum = 1;
 			$all_ccli = Service_Component::getAllByCCLINumber();
-			while ($row = fgetcsv($fp, 0, ",", '"')) {
+			while ($row = fgetcsv($fp, 0, ",", '"', "")) {
 				$comp->populate(0, Array());
 				$this->_captureErrors();
 				$data = Array();

--- a/views/view_10_admin__7_import.class.php
+++ b/views/view_10_admin__7_import.class.php
@@ -250,7 +250,7 @@ class View_Admin__Import extends View
 			$this->stage = 'begin';
 			return;
 		}
-		$map = fgetcsv($fp, 0, $separator, '"');
+		$map = fgetcsv($fp, 0, $separator, '"', "");
 		$sample_header = self::getSampleHeader();
 		foreach ($map as $k => $v) {
 			if ($v == '') continue;
@@ -280,7 +280,7 @@ class View_Admin__Import extends View
 		$current_existing_family_data = NULL;
 
 		$i = 0;
-		while ($rawrow = fgetcsv($fp, 0, $separator, '"')) {
+		while ($rawrow = fgetcsv($fp, 0, $separator, '"', "")) {
 			$i++;
 			$row = Array();
 			foreach ($map as $index => $fieldname) {


### PR DESCRIPTION
As mentioned on #1250, person report CSV exports print a deprecation warning under PHP 8.4:

```
fputcsv(): the $escape parameter must be provided as its default value will change - Line 1801 of /srv/www/jethro/2.36.1/app/db_objects/person_query.class.php
```
A similar warning is printed when parsing 'service component' (e.g. songs) CSV.

This patch fixes the deprecation warning in a way backwards-compatible down to 7.0.

[Apparently](https://php.watch/versions/8.4/csv-functions-escape-parameter) PHP 9+ is going to enforce a blank (`""`) escape parameter, as the current default `"\\"` can generate non-compliant CSV. This patch follows the upstream recommendation by setting the escape character to `""` now, i.e. disabling escapes. We have no reason to keep the old behaviour.