### PR TITLE
If an entered field is an int, validate it and return a user-level error

### DIFF
--- a/include/db_object.class.php
+++ b/include/db_object.class.php
@@ -549,12 +549,9 @@ class db_object
 		if ($this->fields[$name]['type'] == 'int') {
 			if (!array_get($this->fields[$name], 'allow_empty', true) || ($value !== '')) {
 				$strval = (string)$value;
-				for ($i=0; $i < strlen($strval); $i++) {
-					$char = $strval[$i];
-					if ((int)$char != $char) {
-						trigger_error(ents($value).' is not a valid value for integer field "'.$name.'" and has not been set', E_USER_NOTICE);
-						return;
-					}
+				if (!filter_var($strval, FILTER_VALIDATE_INT)) {
+					trigger_error(ents($value).' is not a valid value for integer field "'.$name.'" and has not been set', E_USER_NOTICE);
+					return;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #1265

The validation happens way down in the DB_Object class. That is also where `allow_empty` and `max_length` constraints are checked, so why not basic type checking too.

Perhaps other types besides 'int' should be validated in the same place, like 'datetime'. However I don't know how to trigger saving of a datetime. Without knowing how to trigger that codepath, I wouldn't want to risk breaking stuff. So validation is for int only.