### PR TITLE
Correctly identify whether a service has runsheet items. 

### DIFF
--- a/db_objects/service.class.php
+++ b/db_objects/service.class.php
@@ -469,8 +469,7 @@ class service extends db_object
 		$res = parent::getInstancesQueryComps($params, $logic, $order);
 		$res['select'][] = 'GROUP_CONCAT(CONCAT(sbr.bible_ref, "=", sbr.to_read, "=", sbr.to_preach) ORDER BY sbr.order_num SEPARATOR ";") as readings';
 		$res['from'] .= ' LEFT JOIN service_bible_reading sbr ON service.id = sbr.service_id';
-		$res['select'][] = 'IF (si.id IS NULL, 0, 1) as has_items';
-		$res['from'] .= ' LEFT JOIN service_item si ON si.serviceid = service.id AND si.`rank` = 0 ';
+		$res['select'][] = 'IF (EXISTS (SELECT 1 FROM service_item WHERE serviceid=service.id), 1, 0) AS has_items';
 		$res['group_by'] = 'service.id';
 		return $res;
 	}


### PR DESCRIPTION
Fixes #1272

The code's task here is to identify whether a `service` has any associated `service_item`'s.

The old code did this in SQL:
```sql
SELECT
...
   IF (si.id IS NULL, 0, 1) as has_items
FROM service
   LEFT JOIN service_item si ON si.serviceid = service.id AND si.`rank` = 0`
```
The logic is: "join `service` on the first (`rank=0`) `service_item`. If that exists, we've got at least one runsheet item, so `has_items` is true"

But because service_items can be re-ranked, the first item may not have `rank=0`. It may be `rank=1`.

It's better to ignore `rank` and just check for the existence of any associated `service_item`. That's what my fix does.