### PR TITLE
Fix bug where ad-hoc runsheet items weren't copied by 'Copy from previous'

### DIFF
--- a/views/view_8_services.class.php
+++ b/views/view_8_services.class.php
@@ -59,7 +59,7 @@ class View_services extends View
 								}
 							}
 
-							if (!in_array($v['categoryid'], $_REQUEST['copy_category_ids'])) {
+							if (isset($v['categoryid']) && !in_array($v['categoryid'], $_REQUEST['copy_category_ids'])) {
 								unset($newItems[$k]);
 							}
 						}


### PR DESCRIPTION
Fixes #1271

As a design choice: I initially considered adding a new "Ad-hoc Items" to the list of "things to copy":

<img width="577" height="318" alt="image" src="https://github.com/user-attachments/assets/69dd41eb-b0d5-4cad-b575-3d043326cd80" />


But this isn't possible easily. The 'Items to copy' list is generated by `print_widget`, which only prints referenced service component categories, and won't let me inject "Ad-hoc Items":

https://github.com/tbar0970/jethro-pmm/blob/c0b3bc2efe75d0a1735188d7b5963308121e9d15/views/view_8_services.class.php#L435-L440

So copying ad-hoc items by default is the pragmatic choice. In the code that's done by _not_ excluding items with a null `categoryid`.