### PR TITLE
Allow %alt_title% and %ccli_number% in runsheet and handout templates for service components

### DIFF
--- a/db_objects/service.class.php
+++ b/db_objects/service.class.php
@@ -491,6 +491,19 @@ class service extends db_object
 		return $res;
 	}
 
+	/** Replaces service item keywords in a string, currently %title%, %alt_title% and %ccli_number%.
+	 * @param string $title
+	 * @param string[] $iteminfo Array of service item fields, populated by getItems()
+	 * @return string
+	 */
+	public function replaceItemKeywords($title, $iteminfo)
+	{
+		$title = str_replace('%title%', $iteminfo['title'], $title);
+		$title = str_replace('%alt_title%', $iteminfo['alt_title'], $title);
+		$title = str_replace('%ccli_number%', $iteminfo['ccli_number'], $title);
+		return $title;
+	}
+
 	public function replaceKeywords($text)
 	{
 		$matches = Array();
@@ -730,7 +743,7 @@ class service extends db_object
 					<td>
 						<?php
 						$title = $item['runsheet_title_format'];
-						$title = str_replace('%title%', $item['title'], $title);
+						$title = $this->replaceItemKeywords($title, $item);
 						$title = $this->replaceKeywords($title);
 						echo ents($title);
 						if ($item['note']) echo '<div class="smallprint"><small><i>'.nl2br(ents($item['note'])).'</i></small></div>';
@@ -774,7 +787,7 @@ class service extends db_object
 				<?php
 				echo ($num++).'. ';
 				$title = $i['handout_title_format'];
-				$title = str_replace('%title%', $i['title'], $title);
+				$title = $this->replaceItemKeywords($title, $i);
 				$title = $this->replaceKeywords($title);
 				echo ents($title);
 				?>
@@ -799,7 +812,7 @@ class service extends db_object
 		foreach ($items as $k => $i) {
 			if ($i['show_in_handout'] == '0') continue;
 				$title = $i['handout_title_format'];
-				$title = str_replace('%title%', $i['title'], $title);
+				$title = $this->replaceItemKeywords($title, $i);
 				$title = $this->replaceKeywords($title);
 				//$serviceContent[] = ents($title);
 			if ($i['show_in_handout'] == 'full') {
@@ -898,4 +911,5 @@ class service extends db_object
 		}
 		return strtotime($dateString);
 	}
+
 }

--- a/db_objects/service_component.class.php
+++ b/db_objects/service_component.class.php
@@ -59,7 +59,7 @@ class Service_Component extends db_object
 									'width'		=> 80,
 									'initial_cap'	=> TRUE,
 									'placeholder' => '(Optional)',
-									'note' => 'How should this component be shown on the run sheet.  Can include replacements such as the component\'s %title%, %SERVICE_TOPIC% or %NAME_OF_SOMEROSTERROLE%.  Leave blank to use the category\'s default.',
+									'note' => 'How should this component be shown on the run sheet.  Can include replacements such as the component\'s %title%, %alt_title%, %ccli_number%, %SERVICE_TOPIC% or %NAME_OF_SOMEROSTERROLE%.  Leave blank to use the category\'s default.',
 									'heading_before' => 'Run Sheet Appearance',
 									'divider_before' => TRUE,
 									'label' => 'Run sheet format'
@@ -96,7 +96,7 @@ class Service_Component extends db_object
 									'width'		=> 80,
 									'initial_cap'	=> TRUE,
 									'placeholder' => '(Optional)',
-									'note' => 'How should this component be listed in the service handout.  Can include replacements such as the component\'s %title%, %SERVICE_TOPIC% or %NAME_OF_SOMEROSTERROLE%.  Leave blank to use the category\'s default.',
+									'note' => 'How should this component be listed in the service handout.  Can include replacements such as the component\'s %title%, %alt_title%, %ccli_number%, %SERVICE_TOPIC% or %NAME_OF_SOMEROSTERROLE%.  Leave blank to use the category\'s default.',
 
 								   ),
 			'show_on_slide'		=> Array(

--- a/views/view_8_services.class.php
+++ b/views/view_8_services.class.php
@@ -259,7 +259,7 @@ class View_services extends View
 							<?php
 							if (!empty($item['runsheet_title_format'])) {
 								$title = $item['runsheet_title_format'];
-								$title = str_replace('%title%', $item['title'], $title);
+								$title = $this->service->replaceItemKeywords($title, $item);
 								$title = $this->service->replaceKeywords($title);
 							} else {
 								$title = $item['title'];
@@ -541,7 +541,7 @@ class View_services extends View
 							foreach ($comps as $compid => $comp) {
 								$runsheetTitle = $comp['runsheet_title_format'];
 								if (strlen($runsheetTitle)) {
-									$runsheetTitle = str_replace('%title%', $comp['title'], $runsheetTitle);
+									$runsheetTitle = $this->service->replaceItemKeywords($runsheetTitle, $comp);
 									$runsheetTitle = $this->service->replaceKeywords($runsheetTitle);
 								}
 								$comp['personnel'] = $this->service->replaceKeywords($comp['personnel']);


### PR DESCRIPTION
Fixes #1270

For example, here is a Song in the component library, whose templates demonstrate all the new fields:

<img width="486" height="526" alt="image" src="https://github.com/user-attachments/assets/4464c81f-0770-416a-9535-da4a3db57601" />



It's rendering in a service runsheet:

<img width="270" height="52" alt="image" src="https://github.com/user-attachments/assets/2f1b504b-f52e-4844-b613-076ee0187458" />

and in the handout:

<img width="390" height="34" alt="image" src="https://github.com/user-attachments/assets/69bc2b83-3120-4dc1-aa90-cc847bbe5c71" />
