### PR TITLE
Allow searching Service Components by CCLI Number

### DIFF
--- a/db_objects/service_component.class.php
+++ b/db_objects/service_component.class.php
@@ -194,7 +194,7 @@ class Service_Component extends db_object
 		}
 		if ($keyword) {
 			$qk = $GLOBALS['db']->quote("%{$keyword}%");
-			$res['where'] .= ' '.$logic.' (service_component.title LIKE '.$qk.' OR alt_title LIKE '.$qk.' OR content_html LIKE '.$qk.')';
+			$res['where'] .= ' '.$logic.' (service_component.title LIKE '.$qk.' OR alt_title LIKE '.$qk.' OR service_component.ccli_number = '.$GLOBALS['db']->quote($keyword).' OR content_html LIKE '.$qk.')';
 		}
 
 		return $res;


### PR DESCRIPTION
Fixes #1276.

Afterwards, searching for CCLI works:

<img width="531" height="376" alt="image" src="https://github.com/user-attachments/assets/4496eefe-feef-490b-8004-c54740bc18fb" />

Search is exact, not %partial%, because I can't think why one would search for a partial CCLI