### PR TITLE
Avoid deprecation warnings in PHP 8.4 introduced in code for #1270

### DIFF
--- a/db_objects/service.class.php
+++ b/db_objects/service.class.php
@@ -499,8 +499,8 @@ class service extends db_object
 	public function replaceItemKeywords($title, $iteminfo)
 	{
 		$title = str_replace('%title%', $iteminfo['title'], $title);
-		$title = str_replace('%alt_title%', $iteminfo['alt_title'], $title);
-		$title = str_replace('%ccli_number%', $iteminfo['ccli_number'], $title);
+        $title = str_replace('%alt_title%', $iteminfo['alt_title'] ?? "", $title);
+        $title = str_replace('%ccli_number%', $iteminfo['ccli_number'] ?? "", $title);
 		return $title;
 	}
 


### PR DESCRIPTION
My PR #1275 fixing #1270 introduced deprecation warnings under PHP 8.4:

```
str_replace(): Passing null to parameter #2 ($replace) of type array|string is 
deprecated - Line 502 of /home/jethro/code/latest/app/db_objects/service.class.php
```
because alt_title and ccli_number may be null.  If they are null, we want that to be equivalent to "" - hence the null coalescing operator (supported in 7.0).