### PR TITLE
Remove whitespace around song CSV import row fields

### DIFF
--- a/views/view_0_import_service_components.class.php
+++ b/views/view_0_import_service_components.class.php
@@ -210,7 +210,7 @@ class View__Import_Service_Components extends View
 		}
 		$data = [];
 		for ($i=0; $i<min($rowlen, $headerlen); $i++) {
-			$data[strtolower($toprow[$i])] = $row[$i];
+			$data[strtolower($toprow[$i])] = trim($row[$i]);
 		}
 		return $data;
 	}


### PR DESCRIPTION
When importing songs from CSV, Jethro currently doesn't trim whitespace around fields. This means e.g. a search by CCLI (#1276) will not match a song imported from:

```csv
Title,CCLI_Number,Content
1,000 Names, 7176517,
```
I can't see why leading/trailing whitespace could ever be significant, but if it is, just quote the whole field.