### PR TITLE
If a song already exists, update it rather than creating a duplicate.

### DIFF
--- a/db_objects/service_component.class.php
+++ b/db_objects/service_component.class.php
@@ -208,6 +208,14 @@ class Service_Component extends db_object
 		return $res;
 	}
 
+	public static function getAllByTitle()
+	{
+		$SQL = "SELECT title, alt_title, id
+				FROM service_component";
+		$res = $GLOBALS['db']->queryAll($SQL, null, null, true, false);
+		return $res;
+	}
+
 	protected function _printSummaryRows()
 	{
 		$oldFields = $this->fields;

--- a/views/view_0_import_service_components.class.php
+++ b/views/view_0_import_service_components.class.php
@@ -5,6 +5,8 @@ class View__Import_Service_Components extends View
 	private $errors = Array();
 	private $category = null;
 	protected $_captured_errors;
+	private $all_by_ccli;
+	private $all_by_title;
 
 	static function getMenuPermissionLevel()
 	{
@@ -18,7 +20,6 @@ class View__Import_Service_Components extends View
 		if (!empty($_FILES['datafile']) && !empty($_FILES['datafile']['tmp_name'])) {
 			$GLOBALS['system']->doTransaction('BEGIN');
 			$GLOBALS['system']->includeDBClass('service_component');
-			$comp = new Service_Component();
 			$fp = fopen($_FILES['datafile']['tmp_name'], 'r');
 			if (!$fp) {
 				trigger_error("Your data file could not be read.  Please check the file and try again");
@@ -26,9 +27,9 @@ class View__Import_Service_Components extends View
 			}
 			$toprow = fgetcsv($fp, 0, ",", '"', "");
 			$rowNum = 1;
-			$all_ccli = Service_Component::getAllByCCLINumber();
+			$updatedCount = 0;
+			$createdCount = 0;
 			while ($row = fgetcsv($fp, 0, ",", '"', "")) {
-				$comp->populate(0, Array());
 				$this->_captureErrors();
 				$data = $this->getLabelledRow($toprow, $row);
 
@@ -54,19 +55,19 @@ class View__Import_Service_Components extends View
 					}
 					$data['show_in_handout'] = $val;
 				}
-	
-				if (!empty($_REQUEST['dupe-match'])
-					&& !empty($data['ccli_number'])
-					&& isset($all_ccli[$data['ccli_number']])
+
+				if (($comp = $this->maybeLoadFromCCLINumber($data)) ||
+					($comp = $this->maybeLoadFromExistingIfTitleMatches($data))
 				) {
-					$comp->load($all_ccli[$data['ccli_number']]);
 					$comp->fromCSVRow($data);
 					foreach ($_REQUEST['congregationids'] as $congid) {
 						$comp->addCongregation($congid);
 					}
 					$comp->save();
-
+					$updatedCount++;
 				} else {
+					$comp = new Service_Component();
+					$comp->populate(0, Array());
 					$data['categoryid'] = (int)$_REQUEST['categoryid'];
 					$comp->fromCSVRow($data);
 					if ($errors = $this->_getErrors()) {
@@ -76,13 +77,17 @@ class View__Import_Service_Components extends View
 							$comp->addCongregation($congid);
 						}
 						$comp->create();
+						$createdCount++;
 					}
 				}
 				$rowNum++;
 			}
 			if (empty($this->errors)) {
 				$GLOBALS['system']->doTransaction('COMMIT');
-				add_message(($rowNum-1).' rows imported successfully');
+				add_message($createdCount.' songs created<br>'.
+					$updatedCount.' songs updated<br>'.
+					($rowNum-1).' CSV rows processed',
+					'success', true);
 				redirect('services__component_library'); // exits
 			} else {
 				add_message("Errors were found in the CSV file.  Import has not been performed.  Please correct the errors and try again", 'error');
@@ -144,8 +149,13 @@ class View__Import_Service_Components extends View
 					</label>
 					<div class="controls">
 						<label class="checkbox">
-							<input type="checkbox" checked="checked" name="dupe-match" value="1">Re-use existing components with matching CCLI numbers</label>
-							<p class="help-inline">This option means that when a row's CCLI number matches an existing component, a new component will not be created.  Instead, the existing component will be updated from the CSV and will be linked to the congregations selected above.</p>
+							<input type="checkbox" checked="checked" name="dupe-ccli-match" value="1">Re-use existing components with matching CCLI numbers</label>
+							<p class="help-inline">When a row's CCLI number matches an existing component, a new component will not be created.  Instead, the existing component will be updated from the CSV and will be linked to the congregations selected above.</p>
+						</label>
+
+						<label class="checkbox">
+							<input type="checkbox" checked="checked" name="dupe-title-match" value="1">Re-use existing components with matching song titles</label>
+							<p class="help-inline">When a row's Title (and if set, Alt_Title) matches an existing component, a new component will not be created.  Instead, the existing component will be updated from the CSV and will be linked to the congregations selected above.</p>
 						</label>
 					</div>
 				</div>
@@ -213,5 +223,58 @@ class View__Import_Service_Components extends View
 			$data[strtolower($toprow[$i])] = $row[$i];
 		}
 		return $data;
+	}
+
+	/**
+	 * Return a Service_Component loaded with an existing Song's data, if the CSV row ($data) matches the CCLI.
+	 * @param array $data CSV row data
+	 * @return Service_Component|null Null if we don't have a CCLI-matched song
+	 */
+	private function maybeLoadFromCCLINumber(array $data)
+	{
+		if ($this->all_by_ccli === null) {
+			$this->all_by_ccli = Service_Component::getAllByCCLINumber();
+		}
+		if (!empty($_REQUEST['dupe-ccli-match'])
+			&& !empty($data['ccli_number'])
+			&& isset($all_by_ccli[$data['ccli_number']])
+		) {
+			$matchedid = $all_by_ccli[$data['ccli_number']];
+			return new Service_Component($matchedid);
+		}
+		return null;
+	}
+
+	/**
+	 * Return a Service_Component loaded with an existing Song's data, if the CSV row ($data) matches.
+	 * @param array $data CSV row data
+	 * @return Service_Component|null Null if we don't have a title-matched song.
+	 */
+	private function maybeLoadFromExistingIfTitleMatches(array $data)
+	{
+		if ($this->all_by_title === null) {
+			$this->all_by_title = Service_Component::getAllByTitle();
+		}
+		if (!empty($_REQUEST['dupe-title-match'])
+			&& !empty($data['title'])
+			&& isset($all_by_title[$data['title']])
+		) {
+			list($alt, $id) = $all_by_title[$data['title']];
+			// If someone initially imports a song with a just Title, then edits the CSV to set Alt_Title and reimports, we want the existing record updated.
+			// However if Jethro has a song with Title and Alt_Title already set, and the CSV row matches the title not the Alt_Title, we want a new record created.
+			if ($alt) {
+				if ($alt == $data['alt_title']) {
+					// Matched both title and alt title.
+					return new Service_Component($id);
+				} else {
+					// Matched the title, but the CSV has a different alt title to ours. Treat it as a different song.
+					return null;
+				}
+			} else {
+				// Title matched, and we don't have an alt title to compare, so it's a match
+				return new Service_Component($id);
+			}
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
Fixes #1282

<img width="964" height="392" alt="image" src="https://github.com/user-attachments/assets/a3f3b43d-2a62-49b9-8621-219d602e9cea" />

Title is not, in general, reliable at distinguishing songs, e.g. there are multiple "Hosanna" songs with different CCLIs. So the lookup-by-CCLI is done first, then (if CCLI didn't match) lookup-by-title.

I also want to support having two songs with identical Title, but different Alt_Title. Hence, there's code that only identifies a duplicate if Title and Alt_Title match (if Jethro's record has an Alt_Title), but if Jethro knows of no Alt_Title, then just a Title match is sufficient.

I started by cloning the "does CCLI match" code, but then it started to get really ugly, so broke the new code out into a method, and then, for consistency, did the same for the CCLI matching code.

As a final improvement, the success message now distinguishes the number of songs _created_ vs. those _updated_. For repeated imports, one would want 0 songs created:

<img width="579" height="408" alt="image" src="https://github.com/user-attachments/assets/4eb50fbc-e3d9-44c0-9cca-e4fcfdde3c66" />
