### PR TITLE
Get song search working again, after CCLI search broke it.

### DIFF
--- a/db_objects/service_component.class.php
+++ b/db_objects/service_component.class.php
@@ -194,7 +194,12 @@ class Service_Component extends db_object
 		}
 		if ($keyword) {
 			$qk = $GLOBALS['db']->quote("%{$keyword}%");
-			$res['where'] .= ' '.$logic.' (service_component.title LIKE '.$qk.' OR alt_title LIKE '.$qk.' OR cast(service_component.ccli_number AS char) = '.$GLOBALS['db']->quote($keyword).' OR content_html LIKE '.$qk.')';
+			$res['where'] .= ' '.$logic.' (service_component.title LIKE '.$qk.' OR alt_title LIKE '.$qk.' OR content_html LIKE '.$qk;
+			if (filter_var($keyword, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]])  !== false) {
+				// Add CCLI search if $keyword is a positive integer
+				$res['where'] .= ' OR cast(service_component.ccli_number AS char) = '.$GLOBALS['db']->quote($keyword);
+			}
+			$res['where'] .= ')';
 		}
 
 		return $res;


### PR DESCRIPTION
Fixes #1292.

MySQL is the same clown show as PHP when it comes to type coercion. My code added `ccli_number = '$searchterm'` to the SQL. When comparing an int to a string, MySQL typecasts the string to an int, so 'jungle' becomes 0, so all songs with 0 CCLI match.

The fix is to cast `ccli_number` to characters (`CHAR`) before testing.