### PR TITLE
Fix bug where pressing enter on service Topic offers to delete the service

### DIFF
--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -1729,6 +1729,15 @@ table.service-details td table td input {
 	height: 12px !important;
 	line-height: 12px !important;
 }
+
+/* When editing a service schedule, The 'delete this service' and 'delete all services' buttons must render as just an icon, without button decoration */
+#body table.service-program tr td button {
+    background-color: transparent;
+    border: 0px;
+    margin: 0px;
+    padding: 0px;
+}
+
 #body table.service-program tr.insert-space td button {
 	height: 10px !important;
 	width: 16px !important;

--- a/views/view_8_services__1_list_all.class.php
+++ b/views/view_8_services__1_list_all.class.php
@@ -536,8 +536,11 @@ class View_Services__List_All extends View
 
 				<tr <?php echo $class_clause; ?>>
 					<td class="service-date"><strong><?php echo date('j M y', strtotime($date)); ?></strong><br />
-					<input type="image" name="delete_all_date" value="<?php echo $date; ?>" src="<?php echo BASE_URL; ?>/resources/img/cross_red.png" class="confirm-shift" title="Delete all services on this date" /></td>
-				<?php
+					<button type="button" name="delete_all_date" value="<?php echo $date; ?>" class="confirm-shift" title="Delete all services on this date">
+						<img  src="<?php echo BASE_URL; ?>/resources/img/cross_red.png" />
+					</button>
+					</td>
+					<?php
 				foreach ($this->_congregations as $i => $congid) {
 					?>
 					<td class="left-tools">
@@ -553,8 +556,12 @@ class View_Services__List_All extends View
 						}
 						if (isset($services[$congid])) {
 							?>
-							<input type="image" name="delete_single" value="<?php echo $services[$congid]['id']; ?>" src="<?php echo BASE_URL; ?>/resources/img/cross_red.png" class="delete-single confirm-shift" title="Delete this service" />
-							<?php
+
+							<button type="button" name="delete_single" value="<?php echo $services[$congid]['id']; ?>"  class="delete-single confirm-shift" title="Delete this service">
+								<img src="<?php echo BASE_URL; ?>/resources/img/cross_red.png">
+							</button>
+
+<?php
 						}
 						?>
 					</td>


### PR DESCRIPTION
Fixes #1298

The 'Delete this service' and 'Delete all services' icons must be in a `<button>` not `<input>`, otherwise they become the default 'submit' action when enter is pressed.

The only problem with `<button>` is that we don't want button-like styling. I've fixed that with CSS.