### PR TITLE
Set appropriate cursors for the runsheet and component library when editing

### DIFF
--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -1208,7 +1208,7 @@ JethroServicePlanner.init = function() {
     $("#service-comps tbody tr").draggable({
 		containment: "#service-planner",
 		helper: "clone",
-		cursor: "move",
+		cursor: "grabbing",
 		start: function(event, ui) {
 			$('#service-plan').addClass('comp-dragging');
 			ui.helper.remove();
@@ -1232,7 +1232,8 @@ JethroServicePlanner.init = function() {
 		JethroServicePlanner.addFromComponent($(this));
 	})
 
-	$("#service-comps td, #service-plan td").css('cursor', 'default').disableSelection();
+	$("#service-comps tbody").css('cursor', 'grab').disableSelection();
+	$(" #service-plan tbody").css('cursor', 'move').disableSelection();
 
 	// SERVICE PLAN TABLE:
 	JethroServicePlanner.setDroppable($("#service-plan tbody tr"));


### PR DESCRIPTION
Currently there is no indication that runsheet items are movable, when in edit mode:

<img width="544" height="185" alt="image" src="https://github.com/user-attachments/assets/b58d399b-b7f9-43f8-9176-9329459ae568" />

when dragging, the runsheet uses the 'move' cursor (which is fine): 

<img width="521" height="171" alt="image" src="https://github.com/user-attachments/assets/3a39546e-9888-4748-bf72-b0aa9c5912e5" />

and dragging a component library item uses the standard cursor:

<img width="518" height="341" alt="image" src="https://github.com/user-attachments/assets/b05327f3-adf2-4e65-af2b-cd80fab1090b" />

### Proposed changes

This PR changes the cursor while hovering over the runsheet to the 'move' icon, indicating items can be moved but not dragged off:

<img width="524" height="163" alt="image" src="https://github.com/user-attachments/assets/e9f432cb-0eba-4428-a767-6c5aec3488fe" />

The same 'move' icon is retained when actually moving a runsheet item.

In the component library, hovering over an item shows the 'drag' icon, indicating things can be dragged to the runsheet:

<img width="530" height="336" alt="image" src="https://github.com/user-attachments/assets/8468ffb5-c0f2-4044-9245-db97b220915b" />

Actually dragging uses the 'grabbing' cursor:

<img width="548" height="328" alt="image" src="https://github.com/user-attachments/assets/c6a3b9d5-9a4e-4b0a-8a67-014d2fda0e0d" />
