### PR TITLE
Only display song details in rosters if the viewer has correct service permissions.

### DIFF
--- a/db_objects/service.class.php
+++ b/db_objects/service.class.php
@@ -387,8 +387,7 @@ class service extends db_object
 					$res = Array();
 					foreach ($this->getItems(FALSE, $compCatID) as $item) {
 						$line = nbsp(ents($item['title']));
-						if (!$printableMode && (strlen($item['ccli_number'] ?? '') + strlen($item['comments'] ?? '') > 0)) {
-							
+						if (!$printableMode && (strlen($item['ccli_number'] ?? '') + strlen($item['comments'] ?? '') > 0) && $this->checkPerm(PERM_VIEWSERVICE)) {
 							// yuck, but oh well...
 							ob_start();
 							$dummy_comp = new Service_Component();
@@ -400,7 +399,11 @@ class service extends db_object
 							$compid = $item['componentid'];
 							$line .= ' <i class="clickable icon-info-sign" data-toggle="visible" data-target="#compdetail'.$compid.'-'.$this->id.'"></i>';
 							$line .= '<table class="help-block custom-field-tooltip" id="compdetail'.$compid.'-'.$this->id.'"><tr><td class="narrow">CCLI #:</td><td>'.$ccli_code.'</td>';
-							$line .= '<td class="narrow"><a title="Edit this component" href="'.BASE_URL.'?view=_edit_service_component&service_componentid='.$compid.'"><i class="icon-wrench"></i></a></td></tr>';
+							$line .= '<td class="narrow">';
+							if ($this->checkPerm(PERM_SERVICECOMPS)) {
+								$line .= '<a title="Edit this component" href="'.BASE_URL.'?view=_edit_service_component&service_componentid='.$compid.'"><i class="icon-wrench"></i></a>';
+							}
+							$line .= '</td></tr>';
 							$line .= '<tr><td>Comments:</td><td colspan="2">'.linkUrlsInTrustedHtml(nl2br($item['comments'] ?? '')).'</td></tr></table>';
 						}
 						$res[] = $line;


### PR DESCRIPTION
Fixes #1302

Only the CCLI-rendering code actually triggers the permission check, so we can just omit that if the requester lacks the permission.

With this change, here is how a Songs column renders with full, partial and no component permissions:

| Permissions | Songs in roster |
|-------------------|----------|
| <img width="616" height="208" alt="image" src="https://github.com/user-attachments/assets/6a521ed4-839b-4d5b-ae58-4cd7099d4964" /> | Song title, CCLI and link to component library.  <br><img width="305" height="153" alt="image" src="https://github.com/user-attachments/assets/d6733493-2ae8-4629-9a5a-bc815e405876" /> |
| <img width="614" height="199" alt="image" src="https://github.com/user-attachments/assets/57a60d34-a0b1-4588-8c56-a810f1e66773" /> | Song title, CCLI, no link to component library. <br> <img width="175" height="203" alt="image" src="https://github.com/user-attachments/assets/7689e483-0b6f-4232-8f15-274b11392440" /> |
| <img width="621" height="212" alt="image" src="https://github.com/user-attachments/assets/6009fa0a-c3cd-4276-9c52-47050004332c" /> | Song title, no CCLI or link.  <br> <img width="174" height="110" alt="image" src="https://github.com/user-attachments/assets/e33753ac-8226-4c91-ad02-ae51dc1478b3" /> | 

 


