### PR TITLE
HTML-escape error message, which can contain user-controlled text.

### DIFF
--- a/include/system_controller.class.php
+++ b/include/system_controller.class.php
@@ -322,7 +322,7 @@ class System_Controller
 			if ($showTechDetails || !$send_email) {
 				?>
 				<h4><?php echo $title; ?></h4>
-				<p><?php echo $errstr; ?></p>
+				<p><?php echo ents($errstr); ?></p>
 				<?php
 			} else {
 				echo _('An error occurred. Please contact your system administrator for help.');


### PR DESCRIPTION
This is a theoretical problem, but:

If Jethro can be tricked into passing invalid SQL to the database (which shouldn't happen), Jethro's error handler does not HTML-escape the user-controlled text.

For instance, if a duplicate system configuration field is entered:

<img width="517" height="418" alt="image" src="https://github.com/user-attachments/assets/2ab586fc-479c-4f20-900f-2a03a43e2ee7" />

it can contain HTML which is rendered to the browser:

<img width="638" height="252" alt="image" src="https://github.com/user-attachments/assets/daf802b3-045a-478f-a3b8-da2eaa4063bc" />

We should escape HTML entities in any error message we display.
