### PR TITLE
Increase required PHP version to PHP 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ System requirements are:
 * Some kind of web server (apache/ngnix etc)
 * MySQL 8.0 or above
     * with [ONLY_FULL_GROUP_BY](https://dev.mysql.com/doc/refman/8.4/en/sql-mode.html#sqlmode_only_full_group_by) disabled
-* PHP 7.0 or above
+* PHP 8.3 or above
     * with [gettext extension](https://www.php.net/manual/en/book.gettext.php) enabled
     * with [zip extension](https://www.php.net/manual/en/book.zip.php) enabled
     * with [xmlwriter extension](https://www.php.net/manual/en/book.xmlwriter.php) enabled, to create DOCX files


### PR DESCRIPTION
Jethro has supported PHP 5.6+ for most of it's existence, and PHP 7.0 for the 2.36.1 release.

I think we should, as a policy, only support [supported PHP versions](https://www.php.net/supported-versions.php). Currently that's PHP 8.3.  By 'only support', I mean our code can make use of language features in this minimal version.

Old PHP is a painful language to develop in, due to lack of types, which means lack of IDE autocomplete and type-checking.  Just from PHP 7.1 to 7.3 they added enough type features to significantly improve type safety and the IDE experience:

```
function foo(object $o)   // object typehints
function foo(?int $x) {}   // Nullable types
public int $id;    // Typed properties in classes
$a ??= 1   // Null coalescing assignment
array_key_first()   // replaces reset()
```

Hosting providers like CPanel all support modern PHPs. We don't have a giant user base who can't upgrade. If we're to have a policy, "last upstream-supported PHP" seems a good target.