### PR TITLE
Search for either Title or CCLI number, if filled in

### DIFF
--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -145,9 +145,13 @@ $(document).ready(function() {
 	});
 
 	$('a.ccli-lookup').click(function() {
-		var title = $('[name=title]').val();
-		if (title == '') return false;
-		var url = this.href.replace('__TITLE__', title);
+		var searchterm = $('[name=ccli_number]').val();
+		if (!searchterm || searchterm==0) searchterm = $('[name=title]').val();
+		if (!searchterm) {
+			alert('Fill in either Title or CCLI Number');
+			return false;
+		}
+		var url = this.href.replace('__TITLE__', searchterm);
 		var ccliWindow = window.open(url, 'ccli', 'height='+(screen.height-100)+',width='+(screen.width/2)+',left='+(screen.width/2)+',top=0location=no,menubar=no,titlebar=no,toolbar=no,resizable=yes,statusbar=no,scrollbars=yes');
 		if (!ccliWindow) {
 			alert('Jethro tried but could not open a popup window - you probably have a popup blocker enabled.  Please disable your popup blocker for this site, reload the page and try again.');


### PR DESCRIPTION
Fixes #1322.

Previously, the code would look for a filled-in Title field, and search on that. The 'Search CCLI' link would do nothing if Title was blank.

Now, if 'CCLI Number' is filled in (and isn't '0'), it is used in the search, preferentially to 'Title'.  This works because, happily, the SongSelect website will redirect to the song if an exact-matching CCLI number is searched for.

Also, I added an `alert()` to say what's going on if neither 'Title' nor 'CCLI Number' is filled in.