### PR TITLE
Print help even for config settings that are hardcoded in conf.php

### DIFF
--- a/views/view_10_admin__6_system_configuration.class.php
+++ b/views/view_10_admin__6_system_configuration.class.php
@@ -95,9 +95,11 @@ class View_Admin__System_Configuration extends View {
 							if (Config_Manager::allowSettingInFile($symbol) && constant($symbol)) {
 								// Don't show the value here - sensitive
 								print_message('This setting has been set in the system config file', 'warning');
+								if ($details['note']) echo '<p class="smallprint">'.ents($details['note']).'</p>';
 							} else {
 								$this->printValue($symbol, $details);
 								print_message('This setting has been set in the system config file. To make it editable here, remove it from the config file.', 'warning');
+								if ($details['note']) echo '<p class="smallprint">'.ents($details['note']).'</p>';
 							}
 						} else {
 							$this->printWidget($symbol, $details);


### PR DESCRIPTION
In Admin -> System Configuration, each setting has help text. However the help text doesn't display if the setting has been hardcoded in conf.php:

<img width="912" height="740" alt="image" src="https://github.com/user-attachments/assets/3e8ad8ec-356c-476f-9fdd-66ef9c90347a" />


It would be nice to still display the help, so that one can tell if a setting is worth changing in conf.php:

<img width="899" height="862" alt="image" src="https://github.com/user-attachments/assets/a38a531b-d161-4308-a38e-3006ab4e8f5f" />
