### PR TITLE
Bugfix: validate all of the directory name, not just the first part.

### DIFF
--- a/include/documents_manager.class.php
+++ b/include/documents_manager.class.php
@@ -47,7 +47,7 @@ class Documents_Manager {
 	// Else triggers an error and returns empty string
 	public static function validateDirName($name) {
 		$name = str_replace(' ', '_', $name);
-		if (!preg_match('/[-_A-Za-z0-9&]+/', $name)) {
+		if (!preg_match('/^[-_A-Za-z0-9&]+$/', $name)) {
 			trigger_error("Invalid folder name");
 			return '';
 		}


### PR DESCRIPTION
Fixes #1326

The bug is in `validateDirName()`, which does a regex check, but doesn't require the entire string to be matched. So given directory name `Templates/../../BadDir`, the `Templates` part matches the regex, and the function succeeds.

The fix is to add `^...$` anchors to ensure the whole string is regexed.