### PR TITLE
'Services using this song' box should always be on the right. #1290

### DIFF
--- a/views/view_8_services__3_component_library.class.php
+++ b/views/view_8_services__3_component_library.class.php
@@ -124,10 +124,9 @@ class View_Services__Component_Library extends View
 			<div class="span6 well well-small preview-pane" id="preview">
 				<p class="center"><i><br /><br />Select a component to view its details here</i></p>
 			</div>
-			<div class="span6 well well-small preview-pane anchor-bottom" id="usage">
+			<div class="span6 well well-small preview-pane anchor-bottom pull-right" id="usage">
 				<p class="center"><i><br /><br />Select a component to view its usage here</i></p>
 			</div>
-
 			<script>
 
                 function updateURL(componentId) {


### PR DESCRIPTION
Fix bug in #1290 code.

When the song list is shorter than the loaded song details, the 'Services using this song' panel shifted to the left:

<img width="1202" height="1087" alt="1290-pre" src="https://github.com/user-attachments/assets/c6d2b9c8-635b-4d81-93f6-b36c53ca3b0a" />

Fixed by adding a `pull-right` class:

<img width="1249" height="1312" alt="image" src="https://github.com/user-attachments/assets/f78e8b43-dd82-4b07-aca2-b21a6962eeea" />
