### PR TITLE
If $dir is unset, default to the current directory rather than /

### DIFF
--- a/members/views/view_4_documents.class.php
+++ b/members/views/view_4_documents.class.php
@@ -34,6 +34,7 @@ class View_Documents extends View
 
 	private function _printDir($dir)
 	{
+		if (!$dir) $dir=".";
 		$files = glob($dir.'/*');
 		foreach ($files as $f) {
 			if (is_dir($f)) {


### PR DESCRIPTION
Fixes #1334.

If `$dir` is falsey (blank or `false`), default to the current directory (`DOCUMENTS_ROOT_PATH`), not the OS root.

Discovered while working on #1224 / https://github.com/tbar0970/jethro-pmm/pull/1329, but independent of it.