### PR TITLE
CSV person import: don't break when setting a previously unset variable

### DIFF
--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -1156,7 +1156,7 @@ class Person extends DB_Object
 			if (isset($customFields[$k]) && strlen($v)) {
 				if (empty($this->id)
 						|| $overwriteExistingValues
-						|| ($this->_custom_values[$customFields[$k]->id] == '')
+						|| (array_get($this->_custom_values, $customFields[$k]->id, '') == '')
 				) {
 					$this->setCustomValue($customFields[$k]->id, $customFields[$k]->parseValue($v));
 				}


### PR DESCRIPTION
Fixes #1381

In line 1159, `$customFields[$k]->id` is set to an integer, but this existing person has no custom field value, so the code expands to `(null == '')`.  PHP 8 triggers a WARNING, whereas earlier versions triggered a NOTICE.

This patch fixes the warning. A bigger, unaddressed problem is: why does Jethro with `define('SHOW_ERROR_DETAILS', FALSE);` break at all when a mere warning is encountered.
