### PR TITLE
Demonstration 'fake' data available online

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The steps to install are:
 3. Edit Jethro's configuration file conf.php and fill in the essential details (system name, URL, database details).  Further explanation can be found inside the file.
 4. Open the Jethro system URL in your web browser.  The Jethro installer will start automatically and will prompt you for details to create the initial user account.  When the installer completes, it will prompt you to log into the installed system.
 
+You might like to download and load some [sample data](https://easyjethro.com.au/demo/jethro_demodata.gz) (this can
+be seen running at https://easyjethro.com.au/demo/). The jethro_demodata file is SQL which can be loaded into MySQL. See
+[here](https://github.com/tbar0970/jethro-pmm/pull/1398) for further instructions.
+
 # Documentation
 
 ## User Documentation


### PR DESCRIPTION
It would sometimes be useful to have realistic 'fake' church data in Jethro, for testing its capabilities, replicating bugs and taking screenshots/videos of new features.

There is some pretty good fake data running at https://easyjethro.com.au/demo/. It has structure from a real church, anonymized, and then populated with made-up people (including photos).

<img width="1756" height="791" alt="image" src="https://github.com/user-attachments/assets/b0d7c95a-1975-4301-b31a-6be26bc30ebf" />

I have put a SQL dump of the demo data at https://easyjethro.com.au/demo/jethro_demodata.gz, and tweaked the demo deploy process to keep it up-to-date. The hardcoded username in the SQL is 'demo', and password 'demo' (the online version's password is different). It can be loaded into a local database with:

```bash
curl -LOJ 'https://easyjethro.com.au/demo/jethro_demodata.gz'
gunzip jethro_demodata.gz
mv jethro_demodata jethro_demodata.sql
# Set variables to your Jethro database name, host and connecting username
JETHRO_DATABASE=jethro
JETHRO_DATABASE_HOST=localhost
JETHRO_DATABASE_USER=jethro
# Localize SQL for your installation
perl -i -pe 's/(DEFINER=`)[^`]+(`)@`([^`]+)`/\1'"$JETHRO_DATABASE_USER"'`@`'"$JETHRO_DATABASE_HOST"'`/gm;
              s/^(-- Host: .*    Database: )[^ \n]*$/\1'"$JETHRO_DATABASE"'/g;
              s/^(-- Current Database: )[^ \n]*$/\1\`'"$JETHRO_DATABASE"'\`/g;
              s/^(USE )[^ \n]*;$/\1'\`"$JETHRO_DATABASE"\`';/g;
              s/^((?:CREATE|ALTER) DATABASE [^\`]*\`)[^\`]+(\`)/\1'"$JETHRO_DATABASE"'\2/g;
              s/^(-- Dumping (events|routines) for database '"'"')[^ \n]*'"'"'$/\1'"$JETHRO_DATABASE'"'/g;' jethro_demodata.sql
mysql $JETHRO_DATABASE < jethro_demodata.sql    # adjust as appropriate
```

This PR tweaks the README to point to these instructions.