### PR TITLE
Fix bug in re-ranking: MySQL checks integrity constraints even on intermediate states

### DIFF
--- a/db_objects/roster_view.class.php
+++ b/db_objects/roster_view.class.php
@@ -1063,22 +1063,26 @@ class roster_view extends db_object
 		// target slots; pass 2 sets the final correct values.
 		$rank_offset = 100000;
 		$role_ids_sql = implode(',', $clean_role_ids);
+		$date_range_sql = 'assignment_date BETWEEN '.$GLOBALS['db']->quote($start_date).' AND '.$GLOBALS['db']->quote($end_date);
 		$SQL = 'UPDATE roster_role_assignment rra
 				INNER JOIN ( SELECT *,
 								(row_number() OVER (PARTITION BY assignment_date, roster_role_id
 													ORDER BY `rank` ASC) - 1) AS correctrank
 							   FROM roster_role_assignment
+							   WHERE '.$date_range_sql.'
 							) a
 							ON rra.assignment_date = a.assignment_date
 								AND rra.roster_role_id = a.roster_role_id
 								AND rra.personid = a.personid
 				SET rra.`rank` = a.correctrank + '.$rank_offset.'
 				WHERE rra.`rank` <> a.correctrank
+				AND rra.'.$date_range_sql.'
 				AND rra.roster_role_id IN ('.$role_ids_sql.')';
 		$GLOBALS['db']->query($SQL);
 		$SQL = 'UPDATE roster_role_assignment
 				SET `rank` = `rank` - '.$rank_offset.'
 				WHERE `rank` >= '.$rank_offset.'
+				AND '.$date_range_sql.'
 				AND roster_role_id IN ('.$role_ids_sql.')';
 		$GLOBALS['db']->query($SQL);
 


### PR DESCRIPTION
Fixes #1399

Background info: say we have a table with `rank` uniqueness enforced:

```sql
CREATE TABLE t (
      id   INT AUTO_INCREMENT PRIMARY KEY,
      rank INT NOT NULL,
      UNIQUE KEY unique_rank (rank)
);
INSERT INTO t(rank) VALUES (0), (1), (3), (4);
SELECT * FROM t;
```
```sql
+----+------+
| id | rank |
+----+------+
|  1 |    0 |
|  2 |    1 |
|  3 |    3 |
|  4 |    4 |
+----+------+
```
What happens if we try to change more than one rank at once?
```sql
  -- Attempt to compact ranks 3→2 and 4→3 in one statement:                                                                 
  UPDATE t SET rank = rank - 1 WHERE rank IN (3, 4);
```
Internally, the database could either:
 - set 3→2, then set 4→3
 - set 4→3, then set 3→2

If it first sets 4→3, then _temporarily_ we have two rows with `rank`=3, which violates the constraint, and so the query breaks.
(in practice, for this toy example, it doesn't break, but it illustrates the problem)

This problem is described at
https://bugs.mysql.com/bug.php?id=92027

The nicest fix, were it available, would be to run the UPDATE in a transaction with `SET CONSTRAINTS DEFERRED` set. Postgres supports this, but MySQL doesn't.

So we have to rely on hacks. The hack I chose was to temporarily add 100000 to modified `rank`s, to ensure uniqueness during the change, and then modify them all back.

Another solution considered: why not just ignore the form-submitted `rank` altogether, and just keep a counter and set `rank` to it? We can't do that because, as https://github.com/tbar0970/jethro-pmm/issues/782 notes, the current editor may not be able to see all assignees. An apparent rank 'gap' might just be because we can't see the person. If we 're-rank' we might collapse a gap that is actually used.

There are 2 commits in this PR: 
 - the first does the add-100000 trick to fix the bug.
 - The second fixes a lesser bug: the re-ranking was being applied to all `roster_role_assignment`s, which could be thousands. We only want to edit ranks of assignments in 1 role, for a specific date range.