### PR TITLE
Fix roster save deleting visible assignees when cell contains hidden persons (#782)

### DIFF
--- a/db_objects/roster_view.class.php
+++ b/db_objects/roster_view.class.php
@@ -1033,6 +1033,7 @@ class roster_view extends db_object
 				if (in_array($roleid, $roles)) { // don't delete any allocations for read-only roles!!
 					foreach ($role_allocs as $rank => $person_details) {
 						if ($person_details['assigneehidden']) continue;
+						if (!isset($_POST['assignees'][$roleid][$date])) continue; // cell was read-only, don't delete
 						$del_clauses[] = '(roster_role_id = '.(int)$roleid.' AND assignment_date = '.$GLOBALS['db']->quote($date).' AND `rank` = '.(int)$rank.')';
 					}
 				}


### PR DESCRIPTION
Fixes #782

[jethro_congregationrestriction_bug_fixed.webm](https://github.com/user-attachments/assets/b4201d07-3f75-44bd-97e1-b3e38c8030b0)
