### PR TITLE
Removed debug statements

### DIFF
--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -586,7 +586,6 @@ class Person extends DB_Object
 		$top = reset($res);
 		$second_hit = next($res);
 		if ($top && (!$second_hit || ($second_hit['match_rating'] < $top['match_rating']))) {
-			bam("Got one stand-out");
 			// There is one stand-out result
 			$DIFFERENT = -1;
 			$MATCH = 1;
@@ -594,7 +593,6 @@ class Person extends DB_Object
 			foreach ($keys as $k) {
 				$cmp[$k] = self::_compareMatch(array_get($match_data, $k), $top[$k]);
 			}
-			bam($cmp);
 			if ($cmp['last_name'] == $MATCH) {
 				if ($cmp['first_name'] == $MATCH) {
 					if (($cmp['mobile_tel'] != $DIFFERENT) && ($cmp['email'] != $DIFFERENT)) {
@@ -623,7 +621,6 @@ class Person extends DB_Object
 				}
 			}
 		}
-		bam("bottomed out");
 		return Array(NULL => NULL);
 	}
 


### PR DESCRIPTION
Within
https://github.com/tbar0970/jethro-pmm/blob/0720dd22a948ae27690a3ceff3967cd5dbcb28be/db_objects/person.class.php#L552
there are three calls to `bam()`
https://github.com/tbar0970/jethro-pmm/blob/0720dd22a948ae27690a3ceff3967cd5dbcb28be/db_objects/person.class.php#L589
https://github.com/tbar0970/jethro-pmm/blob/0720dd22a948ae27690a3ceff3967cd5dbcb28be/db_objects/person.class.php#L597
https://github.com/tbar0970/jethro-pmm/blob/0720dd22a948ae27690a3ceff3967cd5dbcb28be/db_objects/person.class.php#L626

Inspired by https://github.com/tbar0970/jethro-pmm/commit/c58c9873fbf8b7b971a667b5a2ba31ecfc141703, I suggest removing them. I expect they have gone unnoticed because `getMatchingPerson()` isn't called from anywhere.