### PR TITLE
Bugfix: when editing services, correctly handle inserting a blank service row before the first existing service.

### DIFF
--- a/views/view_8_services__1_list_all.class.php
+++ b/views/view_8_services__1_list_all.class.php
@@ -490,17 +490,15 @@ class View_Services__List_All extends View
 			<tbody>
 			<?php
 			// Print rows for existing services
-			if (empty($this->_grouped_services)) {
-				$last_date = date('Y-m-d', strtotime($this->_start_date.' -8 days'));
-			} else {
-				$last_date = key(array_reverse($this->_grouped_services));
-			}
+			$first_date = $this->_grouped_services ? key($this->_grouped_services) : NULL;
+			$last_date = $first_date ?: date('Y-m-d', strtotime($this->_start_date.' -8 days'));
 			$last_cong = count($this->_congregations) -1;
 			$this_sunday = date('Y-m-d', strtotime('Sunday'));
-			if ($this->_grouped_services) {
-				$last_date = key($this->_grouped_services);
-			}
 			$new_service_i = 0;
+			// Handle insert date that falls before all existing services
+			if ($this->_insert_date && $first_date && $this->_insert_date < $first_date) {
+				$this->_printNewServiceRow($new_service_i++, $this->_insert_date);
+			}
 			foreach ($this->_grouped_services as $date => $services) {
 				// first, print a blank one if necessary
 				if (($this->_insert_date) && ($last_date < $this->_insert_date) && ($this->_insert_date < $date)) {


### PR DESCRIPTION
When editing services, Jethro displays a form with rows of input text fields. Clicking the insert arrows opens a modal box, asking the user for a date to insert. Submitting the modal re-renders the form, this time with a new row, courtesy of `$this->_printNewServiceRow`:

https://github.com/tbar0970/jethro-pmm/blob/8dc561d39b8822ead8cffb4948191d2df44faf6c/views/view_8_services__1_list_all.class.php#L493-L517

There is some confusing code above the loop, setting and then resetting `$last_date`, which is in fact the _first_ date. 

Then inside the loop on L504, the `if` clause on L506 always fails if the `_insert_date` is earlier than `$last_date` (which is actually the first date).

This PR fixes the `$last_date` mess, explicitly tracks `$first_date`, and adds special handling to insert a row before any displayed service.

Fixes #1404

[jethro_insert_service_before_first_fixed.webm](https://github.com/user-attachments/assets/7c54a359-9a45-4c3e-9b0d-d26e3c0ba64d)
