### PR TITLE
Make service dates editable

### DIFF
--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -1300,6 +1300,65 @@ JethroServiceProgram.init = function() {
 				$display.fadeOut(150, function() { $widget.fadeIn(150).find('input:first').focus(); });
 			}
 		});
+
+		var $draggedInsertRow = null;
+		$('#service-program-editor tbody').sortable({
+			items: 'tr.existing-service-row',
+			handle: '.drag-handle',
+			axis: 'y',
+			revert: 100,
+			cursor: 'grabbing',
+			helper: function(e, item) {
+				// Build a floating table that shows both the insert-space row and the service row
+				var $insertRow = item.prev('.insert-space');
+				var $table = $('<table style="border-collapse:collapse;background:#fff;opacity:0.9"/>');
+				if ($insertRow.length) {
+					$table.append($insertRow.clone());
+				}
+				var $clone = item.clone();
+				// Fix column widths so the helper doesn't collapse
+				$clone.find('td').each(function(i) {
+					$(this).width(item.find('td').eq(i).width());
+				});
+				$table.append($clone);
+				return $table;
+			},
+			start: function(e, ui) {
+				$draggedInsertRow = ui.item.prev('.insert-space');
+				// Hide the insert-space row so there is no gap above the sortable placeholder
+				$draggedInsertRow.hide();
+			},
+			change: function(e, ui) {
+				// If the placeholder has landed directly below an .insert-space row, bump it
+				// above that row — dropping between an insert-space and its service row would
+				// strand the insert-space when we reattach the dragged row's own insert-space.
+				var $prev = ui.placeholder.prev();
+				if ($prev.hasClass('insert-space')) {
+					$prev.before(ui.placeholder);
+				}
+			},
+			stop: function(e, ui) {
+				// Always reattach and show the insert-space row, whether or not position changed
+				if ($draggedInsertRow && $draggedInsertRow.length) {
+					ui.item.before($draggedInsertRow);
+					$draggedInsertRow.show();
+				}
+				$draggedInsertRow = null;
+			},
+			update: function(e, ui) {
+				// Auto-open the date widget to prompt for the new date (fires after stop, only when moved)
+				var $td = ui.item.find('td.service-date');
+				var $display = $td.find('.service-date-display');
+				var $widget  = $td.find('.service-date-widget');
+				// Blank the day so the user must confirm or enter a new date
+				$widget.find('.day-box').val('');
+				if (!$widget.is(':visible')) {
+					$display.fadeOut(150, function() {
+						$widget.fadeIn(150).find('input:first').focus();
+					});
+				}
+			}
+		});
 };
 	/*
 	function cancelShiftConfirmPopup()

--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -1278,7 +1278,28 @@ JethroServiceProgram.init = function() {
 		$('#populate-services').click(function() {
 			var placeholder = prompt('Enter a topic to apply to all empty services:');
 			if (placeholder) $('[name^="topic_title"][value=]').val(placeholder);
-		})
+		});
+
+		// Toggle the date cell between read-only display and editable widget.
+		// Uses delegated binding so it works for rows added after page load.
+		$('#service-program-editor').on('click', '.service-date-edit-toggle', function() {
+			var $td = $(this).closest('td.service-date');
+			var $display = $td.find('.service-date-display');
+			var $widget  = $td.find('.service-date-widget');
+			if ($widget.is(':visible')) {
+				// Close: sync the display text from the widget values, then crossfade back.
+				// Read the selected month label directly from the <option> text so we don't
+				// need to maintain a separate month-name array.
+				var d = parseInt($widget.find('.day-box').val(), 10);
+				var m = $widget.find('.month-box option:selected').text();
+				var y = $widget.find('.year-box').val().slice(-2);
+				if (d && m && y) { $display.find('strong').text(d + ' ' + m + ' ' + y); }
+				$widget.fadeOut(150, function() { $display.fadeIn(150); });
+			} else {
+				// Open: crossfade to the date widget and focus its first input
+				$display.fadeOut(150, function() { $widget.fadeIn(150).find('input:first').focus(); });
+			}
+		});
 };
 	/*
 	function cancelShiftConfirmPopup()

--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -1793,6 +1793,25 @@ table.service-details td table td input {
 	margin-bottom: 0px !important;
 }
 
+/* Pencil toggle button that switches a service date cell between read-only and editable */
+#body table.service-program .service-date-edit-toggle {
+	color: #aaa;
+	padding: 0 2px;
+	font-size: 1em;
+	vertical-align: middle;
+}
+#body table.service-program .service-date-edit-toggle:hover { color: #333; }
+
+/* Six-dot grip used as a drag handle to reorder service rows */
+#body table.service-program .drag-handle {
+	cursor: grab;
+	color: #ccc;
+	padding: 0 4px 0 0;
+	font-size: 1.1em;
+	vertical-align: middle;
+}
+#body table.service-program .drag-handle:hover { color: #555; }
+
 
 /*********** NOTES **************/
 .notes-history-entry small {

--- a/views/view_8_services__1_list_all.class.php
+++ b/views/view_8_services__1_list_all.class.php
@@ -670,12 +670,18 @@ class View_Services__List_All extends View
 
 	function _printServiceEditCell($congid, $date, $data)
 	{
+		$f_topic  = "topic_title[$congid][$date]";
+		$f_format = "format_title[$congid][$date]";
+		$f_notes  = "notes[$congid][$date]";
+		$f_refs   = "bible_refs[$congid][$date][]";
+		$f_read   = "bible_to_read[$congid][$date][]";
+		$f_preach = "bible_to_preach[$congid][$date][]";
 		?>
 		<table class="service-details">
 			<tr>
 				<th>Topic</th>
 				<td class="topic">
-					<input type="text" name="topic_title[<?php echo $congid; ?>][<?php echo $date; ?>]" value="<?php echo ents(array_get($data, 'topic_title')); ?>" />
+					<input type="text" name="<?php echo $f_topic; ?>" value="<?php echo ents(array_get($data, 'topic_title')); ?>" />
 				</td>
 			</tr>
 			<tr>
@@ -691,7 +697,7 @@ class View_Services__List_All extends View
 						?>
 						<tr>
 							<td>
-								<input type="text" name="bible_refs[<?php echo $congid; ?>][<?php echo $date; ?>][]" class="bible-ref" value="<?php echo ents($this->_formatBible(array_get($reading, 'bible_ref', ''), FALSE)); ?>" />
+								<input type="text" name="<?php echo $f_refs; ?>" class="bible-ref" value="<?php echo ents($this->_formatBible(array_get($reading, 'bible_ref', ''), FALSE)); ?>" />
 							</td>
 							<td class="bible-options">
 
@@ -704,13 +710,13 @@ class View_Services__List_All extends View
 									the hidden field when the checkbox is clicked */
 									?>
 									<input type="checkbox"  class="toggle-next-hidden" />
-									<input type="hidden" name="bible_to_read[<?php echo $congid; ?>][<?php echo $date; ?>][]" value="<?php echo (int)array_get($reading, 'to_read'); ?>" />
+									<input type="hidden" name="<?php echo $f_read; ?>" value="<?php echo (int)array_get($reading, 'to_read'); ?>" />
 								</label>
 
 								<label title="to be preached on" class="preserve-value">
 									P
 									<input type="checkbox" class="toggle-next-hidden bible-to-preach" />
-									<input type="hidden" name="bible_to_preach[<?php echo $congid; ?>][<?php echo $date; ?>][]" value="<?php echo (int)array_get($reading, 'to_preach'); ?>" />
+									<input type="hidden" name="<?php echo $f_preach; ?>" value="<?php echo (int)array_get($reading, 'to_preach'); ?>" />
 								</label>
 
 								<img src="<?php echo BASE_URL; ?>/resources/img/arrow_up_thin_black.png" class="icon move-row-up" title="Move up" />
@@ -727,13 +733,13 @@ class View_Services__List_All extends View
 			<tr>
 				<th>Format</th>
 				<td class="format">
-					<input type="text" name="format_title[<?php echo $congid; ?>][<?php echo $date; ?>]" value="<?php echo array_get($data, 'format_title'); ?>" />
+					<input type="text" name="<?php echo $f_format; ?>" value="<?php echo array_get($data, 'format_title'); ?>" />
 					<i class="icon-chevron-down clickable toggle-next-tr <?php if (!empty($data['notes'])) echo 'got-notes'; ?>" title="Show notes" ></i>
 				</td>
 			</tr>
 			<tr class="hide">
 				<th>Notes</th>
-				<td><textarea class="full-width-input" name="notes[<?php echo $congid; ?>][<?php echo $date; ?>]"><?php echo ents(array_get($data, 'notes')); ?></textarea></td>
+				<td><textarea class="full-width-input" name="<?php echo $f_notes; ?>"><?php echo ents(array_get($data, 'notes')); ?></textarea></td>
 			</tr>
 		</table>
 		<?php

--- a/views/view_8_services__1_list_all.class.php
+++ b/views/view_8_services__1_list_all.class.php
@@ -108,14 +108,53 @@ class View_Services__List_All extends View
 
 	private function _handleProgramSave()
 	{
-		// Update and/or create services on existing dates
+		// Design: date changes are handled in two phases so that swaps and any other
+		// permutation of moves resolve without conflict, and without needing to know
+		// about other rows' moves in advance.
+		//
+		// Phase 1 (save loop): every service whose date is changing is moved to a
+		//   unique far-future temp date (2999-01-xx) and written to the DB immediately.
+		//   Writing to temp dates avoids uniqueness constraint violations: if two services
+		//   are swapping dates, writing either one directly to its target would clash with
+		//   the other service still sitting there. Temp dates sidestep this by vacating
+		//   all original slots before any service occupies a new one.
+		//
+		// Phase 2 (resolution loop): each service is moved from its temp date to its
+		//   intended final date. A clash at this point means a genuinely non-moving
+		//   service occupies the target, which is a real conflict; the service is
+		//   returned to its original date and an error is shown.
+		//
+		// Example — swapping 2026-04-05 ↔ 2026-04-12:
+		//   Phase 1: Apr 5 service  → 2999-01-01  (Apr 5  slot now free)
+		//            Apr 12 service → 2999-01-02  (Apr 12 slot now free)
+		//   Phase 2: 2999-01-01    → 2026-04-12  (no clash: Apr 12 freed in phase 1)
+		//            2999-01-02    → 2026-04-05  (no clash: Apr 5  freed in phase 1)
+
 		$dummy = new Service();
+		// $temp_moves[temp_date][congid] = ['original' => original_date, 'target' => target_date]
+		// 'original' is retained so the service can be restored if phase 2 finds a conflict.
+		$temp_moves = Array();
+		$temp_counter = 0;
+
+		// Phase 1: save form fields and park date-changing services at temp dates.
 		foreach ($this->_grouped_services as $date => $date_services) {
+			// row_date[$date] is the editable date widget submitted for this row.
+			// Example: row_date[2026-04-05] = '2026-04-12'
+			$new_date = process_widget('row_date['.$date.']', Array('type' => 'date')) ?: $date;
+
 			foreach ($this->_congregations as $congid) {
 				if (isset($date_services[$congid])) {
 					// update the existing service
-					$dummy->populate($date_services[$congid]['id'], $date_services[$congid]);
+					$id = $date_services[$congid]['id'];
+					$dummy->populate($id, $date_services[$congid]);
 					if ($dummy->acquireLock()) {
+						if ($new_date !== $date) {
+							// Park at a unique temp date; record original and target for phase 2.
+							// Example: Apr 5 service → 2999-01-01
+							$temp = sprintf('2999-%02d-%02d', 1, ++$temp_counter);
+							$dummy->setValue('date', $temp);
+							$temp_moves[$temp][$congid] = Array('original' => $date, 'target' => $new_date);
+						}
 						$this->_processServiceCell($congid, $date, $dummy);
 						$dummy->save();
 						$dummy->releaseLock();
@@ -131,6 +170,32 @@ class View_Services__List_All extends View
 
 					if (!$service->create()) {
 						add_message('New '.$service->toString().' could not be created', 'error');
+					}
+				}
+			}
+		}
+
+		// Phase 2: move each service from its temp date to its final destination.
+		// All original slots have been freed in phase 1, so swaps resolve automatically.
+		// Example: 2999-01-01 → 2026-04-12  (free: Apr 12 moved to 2999-01-02 in phase 1)
+		//          2999-01-02 → 2026-04-05  (free: Apr 5  moved to 2999-01-01 in phase 1)
+		foreach ($temp_moves as $temp => $cong_map) {
+			foreach ($cong_map as $congid => $move) {
+				$services = $GLOBALS['system']->getDBObjectData('service', Array('date' => $temp, 'congregationid' => $congid), 'AND');
+				foreach ($services as $id => $details) {
+					$svc = $GLOBALS['system']->getDBObject('service', $id);
+					if ($svc && $svc->acquireLock()) {
+						// A clash here means a non-moving service occupies the target — a genuine conflict.
+						// Example: a third service permanently on 2026-04-12 that isn't being moved.
+						$clashes = $GLOBALS['system']->getDBObjectData('service', Array('date' => $move['target'], 'congregationid' => $congid), 'AND');
+						if ($clashes) {
+							add_message('Cannot move '.format_date($move['original']).' service to '.format_date($move['target']).' — a service already exists then for that congregation', 'error');
+							$svc->setValue('date', $move['original']); // restore to original date
+						} else {
+							$svc->setValue('date', $move['target']);
+						}
+						$svc->save();
+						$svc->releaseLock();
 					}
 				}
 			}
@@ -466,7 +531,7 @@ class View_Services__List_All extends View
 			<?php echo _("Use the fields below to enter a topic, format and/or Bible readings for each service. <br />For each Bible reading, use the checkboxes to indicate if it is to be read, to be preached on, or both."); ?>
 		</p>
 		<form method="post" class="warn-unsaved" data-lock-length="<?php echo db_object::getLockLength(); ?>">
-		<input type="hidden" name="program_submitted" value="1" />
+<input type="hidden" name="program_submitted" value="1" />
 		<!-- the following hidden fields preserve the value of an image input whose click
 		     is intercepted by a confirm-shift popup -->
 		<input type="hidden" name="delete_single" value="" id="delete_single" />
@@ -533,19 +598,33 @@ class View_Services__List_All extends View
 				</tr>
 
 				<tr <?php echo $class_clause; ?>>
-					<td class="service-date"><strong><?php echo date('j M y', strtotime($date)); ?></strong><br />
-					<button type="button" name="delete_all_date" value="<?php echo $date; ?>" class="confirm-shift" title="Delete all services on this date">
-						<img  src="<?php echo BASE_URL; ?>/resources/img/cross_red.png" />
-					</button>
+					<td class="service-date">
+						<!-- Static display; hidden when the date widget is open -->
+						<span class="service-date-display">
+							<strong><?php echo date('j M y', strtotime($date)); ?></strong>
+						</span>
+						<!-- Editable date widget; hidden by default, toggled open by the pencil button.
+							 Keyed by original date so the save handler can match it to the right row. -->
+						<span class="service-date-widget" style="display:none">
+							<?php print_widget('row_date['.$date.']', Array('type' => 'date', 'month_format' => 'M'), $date); ?>
+						</span>
+						<!-- Pencil icon (✎); clicking toggles between display and edit mode (see jethro.js) -->
+						<button type="button" class="service-date-edit-toggle" title="Edit date">&#9998;</button>
+						<br />
+						<button type="button" name="delete_all_date" value="<?php echo $date; ?>" class="confirm-shift" title="Delete all services on this date">
+							<img src="<?php echo BASE_URL; ?>/resources/img/cross_red.png" />
+						</button>
 					</td>
 					<?php
 				foreach ($this->_congregations as $i => $congid) {
+					$service_data = array_get($services, $congid, Array());
+					$service_id = array_get($service_data, 'id', NULL);
 					?>
 					<td class="left-tools">
 						<?php if ($i != 0) echo '<img src="'.BASE_URL.'/resources/img/arrow_left_heavy_blue.png" class="clickable copy-left" title="Click to copy this service\'s details to the previous congregation" />'; ?>
 					</td>
 					<td class="service">
-						<?php $this->_printServiceEditCell($congid, $date, array_get($services, $congid, Array())); ?>
+						<?php $this->_printServiceEditCell($congid, $date, $service_data); ?>
 					</td>
 					<td class="right-tools">
 						<?php

--- a/views/view_8_services__1_list_all.class.php
+++ b/views/view_8_services__1_list_all.class.php
@@ -531,7 +531,7 @@ class View_Services__List_All extends View
 			<?php echo _("Use the fields below to enter a topic, format and/or Bible readings for each service. <br />For each Bible reading, use the checkboxes to indicate if it is to be read, to be preached on, or both."); ?>
 		</p>
 		<form method="post" class="warn-unsaved" data-lock-length="<?php echo db_object::getLockLength(); ?>">
-<input type="hidden" name="program_submitted" value="1" />
+		<input type="hidden" name="program_submitted" value="1" />
 		<!-- the following hidden fields preserve the value of an image input whose click
 		     is intercepted by a confirm-shift popup -->
 		<input type="hidden" name="delete_single" value="" id="delete_single" />
@@ -580,7 +580,7 @@ class View_Services__List_All extends View
 				}
 
 				// Now print the service we actually have
-				$class_clause = ($date == $this_sunday) ? 'class="hovered"' : '';
+				$row_classes = 'existing-service-row' . ($date == $this_sunday ? ' hovered' : '');
 				?>
 				<tr class="insert-space">
 					<td>
@@ -597,9 +597,10 @@ class View_Services__List_All extends View
 				?>
 				</tr>
 
-				<tr <?php echo $class_clause; ?>>
+				<tr class="<?php echo $row_classes; ?>">
 					<td class="service-date">
 						<!-- Static display; hidden when the date widget is open -->
+						<span class="drag-handle" title="Drag to reorder">&#8286;</span>
 						<span class="service-date-display">
 							<strong><?php echo date('j M y', strtotime($date)); ?></strong>
 						</span>


### PR DESCRIPTION
Fixes #1406 

What do we think about this implementation of editable service dates:

[jethro_editable_service_dates.webm](https://github.com/user-attachments/assets/4d054806-1e50-4f14-b38b-1ea31bbd985d)

## Design choices

### Editability hidden behind icon

We could just make the service date always-editable, like any other field:

<img width="575" height="778" alt="image" src="https://github.com/user-attachments/assets/f640f93b-4b20-4e79-9647-2d78393432ea" />

That would be simplest, but I don't like it because:
 - the service date 'blends in' with all the other editable fields, when really it should be more distinct. The date is what **identifies the whole row**, not just another field.
 - it's harder to visually scan a visual date - <img width="188" height="32" alt="image" src="https://github.com/user-attachments/assets/73c5f26f-6b17-43c5-bd55-f94bbdb050ec" /> - than static text - <img width="73" height="20" alt="image" src="https://github.com/user-attachments/assets/bff3266a-6ffa-4560-8c38-792cafc08176" />
 - service dates rarely change, so the downsides are hard to justify.

So instead I've kept dates as static text, except now with a pencil ✎ icon indicating it's editable:

<img width="504" height="613" alt="image" src="https://github.com/user-attachments/assets/bfe9588a-4490-4769-bf9a-b6481a050e48" />

Clicking the pencil toggles between editable and static modes, as in the video.

### Drag/drop support

I've added the ability to drag and drop service rows to reorder them. This lets users get the services visually in correct order (e.g. as a logical sermon series), and then later adjust each date.

The drag & drop operation doesn't automatically adjust dates. When a service row is dropped, its date is made editable and the day field is blanked out, forcing manual entry.

## Backend code

Reordering sequential things in a database is tricky! As I learned from https://github.com/tbar0970/jethro-pmm/pull/1400, databases enforce uniqueness at all times, so if we need to swap dates A and B, we can never have two As or two Bs, even temporarily.

The algorithm is similar to that of https://github.com/tbar0970/jethro-pmm/pull/1400, and explained in a giant code comment. It will handle not only A-B swaps, but longer shuffles like A-B-C -> C-A-B.