### PR TITLE
roster_reminder.php: Add a START_DATE_OFFSET setting to notify people rostered >1 week in advance

### DIFF
--- a/scripts/roster_reminder.php
+++ b/scripts/roster_reminder.php
@@ -104,8 +104,9 @@ require_once JETHRO_ROOT.'/db_objects/roster_view.class.php';
 //get the roster information using the roster view id
 //
 $view = $GLOBALS['system']->getDBObject('roster_view', $roster_id);
-$start_date = date("Y-m-d");
-$end_date = date('Y-m-d', strtotime("+6 day"));
+$start_date_offset = (int)getvar('START_DATE_OFFSET', 0);
+$start_date = date('Y-m-d', strtotime("+$start_date_offset day"));
+$end_date = date('Y-m-d', strtotime("+" . ($start_date_offset + 6) . " day"));
 
 
 //

--- a/scripts/roster_reminder_sample.ini
+++ b/scripts/roster_reminder_sample.ini
@@ -56,4 +56,8 @@ VERBOSE=1
 ; [Email only; optional]
 ;if your server does not like the built-in email class (swiftmailer) try php mail() instead, toggle by changing 0 to 1
 PHP_MAIL=0
-;
+
+; Normally people rostered in the upcoming week (today + 6 days inclusive) are notified. Setting START_DATE_OFFSET=7 lets one
+; notify those rostered the week after this.
+; START_DATE_OFFSET=0
+


### PR DESCRIPTION
START_DATE_OFFSET lets roster_reminder.php can notify people rostered not this week, but the week after (START_DATE_OFFSET=7) or further in the future. This allows notification of people, like service leaders, who might need more than 1 week's notice.