### PR TITLE
Allow for '{roster_date}', '{roster_date_short}' and '{roster_day_of_week}' token substitution in notification text

### DIFF
--- a/scripts/roster_reminder.php
+++ b/scripts/roster_reminder.php
@@ -142,6 +142,20 @@ if (count($roster_array) > 2) {
 	if ($rds) $roster_date = ' ('.implode(', ', $rds).')';
 }
 
+// Template substitution for PRE_MESSAGE / POST_MESSAGE.  Three tokens are available:
+//   {roster_date}       - e.g. "Sunday, 29 April" or "Sunday, 29 April, Friday, 3 April"
+//   {roster_date_short} - e.g. "29 Apr" (no year or day name; keeps SMS messages short)
+//   {roster_day_of_week}       - e.g. "Sunday" or "Sunday, Friday"
+// See roster_reminder_sample.ini for examples.
+$roster_date_full  = implode(' or ', array_map(fn($d) => date('l, j F', strtotime($d)), $rds));
+$roster_date_short = implode('/', array_map(fn($d) => date('j M',    strtotime($d)), $rds));
+$day_of_week       = implode(' or ', array_map(fn($d) => date('l',      strtotime($d)), $rds));
+$tokens       = ['{roster_date}', '{roster_date_short}', '{roster_day_of_week}'];
+$replacements = [$roster_date_full, $roster_date_short, $day_of_week];
+$pre_message  = str_replace($tokens, $replacements, $pre_message);
+$post_message = str_replace($tokens, $replacements, $post_message);
+if ($sendemail) $email_subject = str_replace($tokens, $replacements, $email_subject);
+
 $assignees=$view->getAssignees($start_date, $end_date);
 
 if ($sendsms) { // make the sms message!

--- a/scripts/roster_reminder_sample.ini
+++ b/scripts/roster_reminder_sample.ini
@@ -20,7 +20,11 @@ ROSTER_COORDINATOR_ID=1
 
 ; [SMS + Email; required]
 ; First (intro) part of the SMS and/or email, before the rostered names.
-PRE_MESSAGE='This is a roster reminder for Sunday...<br>'
+; Three date placeholders are available:
+;   {roster_date}       - full date, e.g. "Sunday, 29 April" (good for email)
+;   {roster_date_short} - short date, e.g. "29 Apr" (good for SMS, saves characters)
+;   {roster_day_of_week}       - day name only, e.g. "Sunday"
+PRE_MESSAGE='This is a roster reminder for {roster_day_of_week}<br>'
 
 ; [SMS + Email; optional, default 1]
 ;Whether to include the roster content within the email or SMS. For SMS you probably want to set this to 0 and include a shortened URL in the PRE_MESSAGE instead.
@@ -28,6 +32,7 @@ INCLUDE_ROSTER_CONTENT=1
 
 ; [SMS + Email; required]
 ; Message after the roster list/table. E.g. who to contact if the recipient can't do the roster this week.
+; Placeholders ('{roster_date}' etc) are substituted - see above.
 POST_MESSAGE='The full roster can be viewed at xxx/jethro/public/?view=display_roster.<br> If you have any questions or difficulties or if you have arranged a swap, please contact the roster coordinator.<br><br> Thank you for serving on Sunday!<br>'
 
 ; [Email only; optional, default 0]
@@ -39,7 +44,8 @@ EMAIL_FROM='no-reply@church.something'
 ; [Email only; required]
 EMAIL_FROM_NAME='no-reply'
 ; [Email only; required]
-EMAIL_SUBJECT='roster reminder - Sunday'
+; Email subject. Placeholders ('{roster_date}' etc) are substituted - see above.
+EMAIL_SUBJECT='roster reminder - {roster_day_of_week}'
 
 ; [SMS only; required]
 ; The mobile number that SMS reminders will appear to come from


### PR DESCRIPTION
e.g.:

`{roster_date}` → 'Sunday, 29 March'
`{roster_date_short}` → '29 Mar'
`{roster_day_of_week}` → 'Sunday'

If more than one day matches, e.g. weeks with both Good Friday and Easter
Sunday, the script notifies people rostered on both dates and the variables
expand to e.g.:

`{roster_date}` → "Friday, 3 April or Sunday, 5 April"
`{roster_date_short}` → "3 Apr/5 Apr"
`{roster_day_of_week}` → "Friday or Sunday"

`{roster_date_short}` is intended for use in SMSes where brevity is important.
`{roster_day_of_week}` is for the initial "Hello, you are rostered on this
{roster_day_of_week}" PRE_MESSAGE.

`{roster_date}` and `{roster_date_short}` are useful especially for reminders of
events beyond the current week (START_DATE_OFFSET >= 7) - see https://github.com/tbar0970/jethro-pmm/pull/1411