### PR TITLE
Add gap between group choosers

### DIFF
--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -2018,6 +2018,11 @@ li div.delete-list-item, li div.delete-chosen-person {
 span.group-chooser-container {
 	display: inline-block;
 }
+.group-chooser-multi {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
 .group-chooser-multi.active select, .group-chooser.active {
 	outline: 2px solid rgb(0,94,204);
 }


### PR DESCRIPTION
Before

<img width="544" height="58" alt="Screenshot 2026-04-05 at 5 38 37 am" src="https://github.com/user-attachments/assets/e0eb9a98-cebd-4f67-938d-c7b749aaf98d" />

After - this looks more visually appealing to me.

<img width="540" height="61" alt="Screenshot 2026-04-05 at 5 38 51 am" src="https://github.com/user-attachments/assets/02696c45-e4e4-44fd-951b-80799a5f03d0" />