### PR TITLE
roster_reminder.php: don't break if there are no results

### DIFF
--- a/scripts/roster_reminder.php
+++ b/scripts/roster_reminder.php
@@ -131,8 +131,8 @@ foreach ($roster_lines as $line) {
 	$roster_array[] = str_getcsv($line, ",", '"', "");
 }
 $roster_date = '';
+$rds = Array();
 if (count($roster_array) > 2) {
-	$rds = Array();
 	$roster_date_index = array_search('Date', $roster_array[1]);
 	if ($roster_date_index !== FALSE) {
 		for ($i=2; $i < count($roster_array); $i++) {


### PR DESCRIPTION
A bugfix to https://github.com/tbar0970/jethro-pmm/pull/1412

The new code broke when the upcoming week's roster did not contain anyone.