### PR TITLE
#800 enhanced group picker fixes

### DIFF
--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -714,10 +714,10 @@ JethroGroupChooser.onPageLoad = function() {
 			$('.group-chooser-multi, select.group-chooser').removeClass('active');
 			$(this).addClass('active');
 
-			// the selectbox might have a margin-bottom. We don't want a gap before the treeContainer.
-			// so we add a negative margin to the treeContainer, if necessary, to compensate.
 			const selectBoxStyle = window.getComputedStyle(this);
 			treeContainer.css('margin-top', ((parseInt(selectBoxStyle.marginBottom) * -1)+2)+"px");
+			var availableHeight = window.innerHeight - this.getBoundingClientRect().bottom - 10;
+			treeContainer.css('max-height', availableHeight + 'px');
 			treeContainer.show(400, function() {
 				$(this).find('input[type=text]:visible').focus();
 			});

--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -845,7 +845,6 @@ table.custom-field-tooltip {
 }
 select, input, textarea,div.editor {
 	width: auto;
-	max-width: 97%;
 }
 .full-width-input {
 	width: 99.5%;

--- a/templates/view_person.template.php
+++ b/templates/view_person.template.php
@@ -42,13 +42,13 @@ if ($GLOBALS['user_system']->havePerm(PERM_EDITGROUP)) {
 			<div class="modal-header">
 				<h4><?php echo _('Add ')?> <?php $person->printFieldValue('name'); ?><?php echo _(' to a group');?></h4>
 			</div>
-			<div class="modal-body" style="height: 50vh">
+			<div class="modal-body" style="overflow: visible">
 				<?php
 				$GLOBALS['system']->includeDBClass('person_group');
-				echo _('Add as a ');
-				Person_Group::printMembershipStatusChooser('membership_status');
-				echo _(' of ');
+				echo _('Add to ');
 				$can_add_group = Person_Group::printChooser('groupid', 0);
+				echo _(' as a ');
+				Person_Group::printMembershipStatusChooser('membership_status');
 				?>
 			</div>
 			<div class="modal-footer">


### PR DESCRIPTION
The recent group picker enhancement (#800) introduced a bit of jankiness. For reference, here is the old vanilla group picker:

<img width="810" height="764" alt="Image" src="https://github.com/user-attachments/assets/0074c5cc-3d65-43ae-aeee-272178c43e06" />

and here is a video of the new group picker:

[js_800_treeview.webm](https://github.com/user-attachments/assets/67ae6196-1b23-41d2-aedc-8740540de208)

Some problems:
 - the select-list is clipped to the boundary of the modal (unlike previously, when it expanded outside). Only a handful of groups can be seen, and there are double scrollbars (and clicking the outer one closes the select-list).
 - the select-list is pushed off to the right, resulting in a horizontal scrollbar.
 - The '(Choose)' text is slightly clipped

This PR addresses the problems:

[js_800_treeview_fixed.webm](https://github.com/user-attachments/assets/3795d647-dae0-4df8-ac47-df68294276b0)

 - The select list now extends beyond the borders of the modal
 - The select list expands to fill the available vertical space (if needed). Normally the browser determines an open select-list's height, but with dynamic content in treeview.js confuses it. 
 - The '(Choose)' clip is fixed, by removing a `max-width: 97%`. I've no idea what it achieved, so possibly I've broken layout elsewhere, but I can't see it.

While tinkering, I've also reordered the sequence to put the group select-list first, then the membership role:

<img width="571" height="375" alt="image" src="https://github.com/user-attachments/assets/f35d47c9-723c-490d-bfa6-8c802b807fbc" />

because:
 - it makes more sense to put the important field first
 - the group list is now nicely centred instead of squashed to the right
 - the order now matches that in action plans: <img width="629" height="56" alt="image" src="https://github.com/user-attachments/assets/98b0bea8-63f0-4590-bd59-3cba63be820d" />

