### PR TITLE
mailchimp_sync.php + email_report.php fail hard on misconfigured report

### DIFF
--- a/scripts/email_report.php
+++ b/scripts/email_report.php
@@ -54,6 +54,13 @@ if (!(int)$ini['REPORT_ID']) {
 // Use the report to generate the subject and content of the email using the output buffer, then clear the buffer
 //
 $report = $GLOBALS['system']->getDBObject('person_query', (int)$ini['REPORT_ID']);
+$validationErrors = $report->getValidationErrors();
+if (!empty($validationErrors)) {
+	foreach (Person_Query::formatValidationErrors($validationErrors) as $message) {
+		echo "Validation error in report #".$ini['REPORT_ID'].": $message\n";
+	}
+	exit(1);
+}
 $reportname = $report->getValue('name');
 if (empty($reportname)) $reportname = 'Jethro-Report-'.date('Y-m-d_H:i');
 ob_start();

--- a/scripts/mailchimp_sync.php
+++ b/scripts/mailchimp_sync.php
@@ -135,6 +135,13 @@ function run_mc_sync($mc, $report_id, $list_id)
                 throw new \RuntimeException("[Syncing report $report_id to list $list_id] Could not find report #$report_id - please check your config in ".__FILE__);
         }
 
+        $validationErrors = $report->getValidationErrors();
+        if (!empty($validationErrors)) {
+                foreach (Person_Query::formatValidationErrors($validationErrors) as $message) {
+                        echo "[Syncing report $report_id to list $list_id] Validation error: $message\n";
+                }
+                exit(1);
+        }
 
         // BUSINESS TIME
 


### PR DESCRIPTION
Scripts that depend on a report output (mailchimp_sync.php, email_report.php) now fail hard if that report is invalid, rather than risk doing something with incorrect data.

To test:
1) add a group 'fakegroup'
2) edit the mailchimp filter
3) Set filter param: "who are not in any of these groups: fakegroup"
4) save report
5) delete 'fakegroup'
4) run mailchimp_sync.php. Expected output:
    ```
    # ej_runas.php admin ./mailchimp_sync.php
    [Syncing report 4 to list 58dca206f5] Validation error: A group (ID 5)
    this report filtered on has been deleted — report may return more
    results than intended
    ```
5) ensure non-zero exit code.

Builds upon #1414
Fixes #1423

