### PR TITLE
Don't double-confirm the Cancel button on the Edit Roster Assignments

### DIFF
--- a/db_objects/roster_view.class.php
+++ b/db_objects/roster_view.class.php
@@ -882,7 +882,7 @@ class roster_view extends db_object
 
 			?>
 			<input type="submit" class="btn" value="Save" accesskey="s" />
-			<a class="btn confirm-title" href="<?php echo build_url(Array('viewing' => 1)); ?>" title="Discard your changes">Cancel</a>
+			<a class="btn" href="<?php echo build_url(Array('viewing' => 1)); ?>" title="Discard your changes">Cancel</a>
 			</form>
 			<?php
 		}


### PR DESCRIPTION
The new 'Edit Roster Assignments' cancel button (#1063) is nice, but has the annoying behaviour of requiring confirmation even if no changes were made. Worse, if a change was made that you want to abandon, there are now _two_ confirmations:

[jethro_cancel_doubleconfirm.webm](https://github.com/user-attachments/assets/d4f8b970-e88c-4036-a8f1-5a5dd8ed2acd)

This is because browsers already want confirmation if you're about to lose form data. We're just doing it twice, badly.

The fix is to remove the `confirm-title` class which triggers the extra confirmation:

[jethro_cancel_doubleconfirm_fix.webm](https://github.com/user-attachments/assets/b6b4b4ce-89d0-41ba-bf8c-54e6f877eb9f)

