### PR TITLE
Add exact person ID matching to getMatchingPerson() for reliable bulk CSV imports

### DIFF
--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -546,11 +546,26 @@ class Person extends DB_Object
 
 	/**
 	 * Find a person who matches the details given.
-	 * @param array $match_data - keys can be first_name, last_name, mobile_tel, email
+	 * @param array $match_data - keys can be first_name, last_name, mobile_tel, email, OR id/person_id
 	 * @return Array(personid => (bool)$certain)
 	 */
 	public static function getMatchingPerson($match_data)
 	{
+		// === EXACT ID MATCH (added to support bulk updates after migrations with duplicates) ===
+		// If the import supplies the internal Jethro person ID (column "id" or "person_id"),
+		// perform an immediate exact lookup. This is certain and bypasses all fuzzy logic.
+		// The rest of the function (fuzzy matching on name/email/mobile) is completely unchanged.
+		// Full support requires changes to the CSV import handler + reports (planned follow-ups).
+		if (!empty($match_data['id']) || !empty($match_data['person_id'])) {
+			$id = (int)($match_data['id'] ?? $match_data['person_id']);
+			if ($id > 0) {
+				$db = JethroDB::get();
+				$exists = $db->queryOne('SELECT id FROM person WHERE id = '.$db->quote($id));
+				if ($exists) {
+					return Array($id => TRUE);   // certain match on ID
+				}
+			}
+		}
 		$keys = Array('first_name', 'last_name', 'email', 'mobile_tel');
 		foreach ($keys as $k) {
 			if (isset($match_data[$k])) $match_data[$k] = trim($match_data[$k]);


### PR DESCRIPTION
After migrations like Fluro → Jethro, a church may end up with multiple archived duplicate person records. The current CSV import fails with “too many people with the same details” because getMatchingPerson() only does fuzzy matching on name/email/mobile.

This PR adds a tiny, isolated early-exit:
- If 'id' or 'person_id' is supplied in $match_data, it does an immediate exact lookup by the internal person ID (certain match).
- All existing fuzzy logic, scoring, and behaviour for normal imports remains 100% unchanged.

See the added comment in db_objects/person.class.php for details.

Next steps (planned follow-up PRs):
- Expose person.id in reports/CSV exports
- Update the import UI to allow mapping an ID column and pass it through