### PR TITLE
#1429 - use absolute URLs in emails

### DIFF
--- a/include/general.php
+++ b/include/general.php
@@ -796,9 +796,9 @@ function get_url_pathprefix()
 }
 
 /**
- * Infer Jethro's base URL from the request.
+ * Infer Jethro's absolute base URL from the request.
  */
-function base_url()
+function baseurl_absolute()
 {
     // Detect scheme
     $https = (

--- a/include/general.php
+++ b/include/general.php
@@ -764,7 +764,7 @@ function build_url($params)
  *  - 'https://mychurch.org/jethro/public/'   returns '/jethro'
  * @return string
  */
-function get_relative_baseurl()
+function baseurl_relative()
 {
     // SCRIPT_NAME is the path part of the URL, e.g. /index.php or /jethro/index.php, or /jethro/members/index.php
     $parts = explode('/', $_SERVER['SCRIPT_NAME']);
@@ -790,7 +790,7 @@ function get_relative_baseurl()
  */
 function get_url_pathprefix()
 {
-    $relbase = get_relative_baseurl(); // e.g. '' or '/jethro'
+    $relbase = baseurl_relative(); // e.g. '' or '/jethro'
     $subdir = dirname(substr($_SERVER['SCRIPT_NAME'], strlen($relbase))); // e.g. '/', '/members' or '/public'
     return rtrim($relbase.$subdir, '/').'/'; // e.g. '/members/', '/public/', '/jethro/', '/jethro/members/', '/jethro/members/public/'
 }
@@ -812,7 +812,7 @@ function baseurl_absolute()
     $host = $_SERVER['HTTP_X_FORWARDED_HOST'] ?? $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'];
 
     // Detect base path (the directory your app runs from)
-    $scriptDir = get_relative_baseurl();
+    $scriptDir = baseurl_relative();
 
     // Build base URL (no trailing slash if at root)
     return $scheme . '://' . $host . ($scriptDir !== '' ? $scriptDir : '');

--- a/include/init.php
+++ b/include/init.php
@@ -47,14 +47,14 @@ if (defined('SESSION_TIMEOUT_MINS')) {
 }
 
 // Infer BASE_URL from the request, if it hasn't been set manually.
-if (!defined('BASE_URL')) define('BASE_URL', get_relative_baseurl());
+if (!defined('BASE_URL')) define('BASE_URL', baseurl_relative());
 
 if (session_id() == '') {
   	// If max length is set, set the cookie timeout - this will allow sessions to outlast browser invocations
   	$expiryTime = defined('SESSION_MAXLENGTH_MINS') ? SESSION_MAXLENGTH_MINS * 60 : NULL;
   	session_set_cookie_params([
   		'lifetime'=> $expiryTime,
- 		'path'     => get_relative_baseurl() . '/',
+ 		'path'     => baseurl_relative() . '/',
 		'httponly' => true,
   		'samesite' => 'Lax'
   		]);

--- a/include/system_controller.class.php
+++ b/include/system_controller.class.php
@@ -354,7 +354,7 @@ class System_Controller
 			$content .= "REQUEST: \n".print_r($safe_request,1)."\n\n";
 			$content .= "BACKTRACE:\n";
 			$content .= print_r($bt, 1);
-			@mail(constant('ERRORS_EMAIL_ADDRESS'), 'Jethro Error from '.base_url(), $content);
+			@mail(constant('ERRORS_EMAIL_ADDRESS'), 'Jethro Error from '.baseurl_absolute(), $content);
 		}
 		if ($send_email) error_log("$errstr - Line $errline of $errfile");
 	}

--- a/include/user_system.class.php
+++ b/include/user_system.class.php
@@ -514,7 +514,7 @@ class User_System extends Abstract_User_System
 		$emails = $GLOBALS['db']->queryCol($SQL);
 		if (empty($emails)) return;
 
-		$text = "Hi, \n\nThis is an automated message to System Administrators, sent from the Jethro system at ".BASE_URL.".\n\n";
+		$text = "Hi, \n\nThis is an automated message to System Administrators, sent from the Jethro system at ".baseurl_absolute().".\n\n";
 		$text .= $message;
 
 		$message = Emailer::newMessage()

--- a/members/include/member_user_system.class.php
+++ b/members/include/member_user_system.class.php
@@ -87,7 +87,7 @@ class Member_User_System extends Abstract_User_System
 				WHERE id = '.(int)$person['id'];
 		$res = $GLOBALS['db']->exec($SQL);
 
-		$url = BASE_URL.'/members/?email='.rawurlencode($person['email']).'&verify='.rawurlencode($hash);
+		$url = baseurl_absolute().'/members/?email='.rawurlencode($person['email']).'&verify='.rawurlencode($hash);
 
 		$body = "Hi %s,
 
@@ -139,8 +139,8 @@ If you didn't request an account, you can just ignore this email";
 				  ->setSubject("Member Account request from multi-family email")
 				  ->setFrom(array(MEMBER_REGO_EMAIL_FROM_ADDRESS => SYSTEM_NAME.' Jethro System'))
 				  ->setTo(MEMBER_REGO_FAILURE_EMAIL)
-				  ->setBody("Hi, \n\nThis is an automated message from the Jethro system at ".BASE_URL.".\n\n"
-						  ."Somebody has used the form at ".BASE_URL."/members to request member-access to this Jethro system. \n\n"
+				  ->setBody("Hi, \n\nThis is an automated message from the Jethro system at ".baseurl_absolute().".\n\n"
+						  ."Somebody has used the form at ".baseurl_absolute()."/members to request member-access to this Jethro system. \n\n"
 						  ."The email address they specified was ".$_REQUEST['email']." but this address belongs to SEVERAL persons from DIFFERENT families.  It therefore can't be used for member access.\n\n"
 						  ."Please look up this email address in Jethro and contact the relevant persons to help them solve this problem.\n\n");
 
@@ -159,8 +159,8 @@ If you didn't request an account, you can just ignore this email";
 				  ->setSubject("Member Account request from unknown email")
 				  ->setFrom(array(MEMBER_REGO_EMAIL_FROM_ADDRESS => SYSTEM_NAME.' Jethro System'))
 				  ->setTo(MEMBER_REGO_FAILURE_EMAIL)
-				  ->setBody("Hi, \n\nThis is an automated message from the Jethro system at ".BASE_URL.".\n\n"
-						  ."Somebody has used the form at ".BASE_URL."/members to request member-access to this Jethro system. \n\n"
+				  ->setBody("Hi, \n\nThis is an automated message from the Jethro system at ".baseurl_absolute().".\n\n"
+						  ."Somebody has used the form at ".baseurl_absolute()."/members to request member-access to this Jethro system. \n\n"
 						  ."The email address they specified was ".$_REQUEST['email']." but there is no current person record in the Jethro system with that address. (There could be an archived record).\n\n"
 						  ."If you believe this person is a church member, please add their email address to their person record and then ask them to try registering again.\n\n");
 


### PR DESCRIPTION
In emails, use absolute base URL instead of probably-relative BASE_URL constant.

This uses the previously unused base_url() function, which is renamed to baseurl_absolute() for clarity.

Fixes #1429

