### PR TITLE
Remove 'Show init SQL' button in System configuration page

### DIFF
--- a/views/view_10_admin__6_system_configuration.class.php
+++ b/views/view_10_admin__6_system_configuration.class.php
@@ -60,17 +60,6 @@ class View_Admin__System_Configuration extends View {
 
 	public function printView()
 	{
-		if (JETHRO_VERSION == 'DEV') {
-			if (!empty($_REQUEST['dump_sql'])) {
-				$installer = new Installer();
-				$installer->initDB(TRUE);
-				return;
-			} else {
-				?>
-				<a class="btn" href="<?php echo build_url(Array('dump_sql' => 1)) ?>">Show init SQL</a>
-				<?php
-			}
-		}
 		$this->_doConfigChecks();
 		?>
 		<form method="post">


### PR DESCRIPTION
When `JETHRO_VERSION` is undefined or set to `DEV` (i.e. not normally), the System configuration page acquires this 'Show init SQL' button:

<img width="300" src="https://github.com/user-attachments/assets/fdfd739a-910c-4891-971c-beef0bba1f5c" />

I'm wondering what it's for? Is it some artifact of a past debugging session?

If it's useful in any way to any person, great.