### PR TITLE
Improve CSV person import with exact Person ID matching support

### DIFF
--- a/views/view_10_admin__7_import.class.php
+++ b/views/view_10_admin__7_import.class.php
@@ -126,7 +126,7 @@ class View_Admin__Import extends View
 				<td>
 					<label class="checkbox">
 						<input type="checkbox" name="match_existing" value="1" <?php if (array_get($_REQUEST, 'match_existing', 1)) echo 'checked="checked"';?> data-toggle="enable" data-target="#match-options *"/>
-						Update existing persons if their first and last name match
+						Update existing persons (by Person ID if provided, otherwise by names)
 					</label>
 					<div class="indent-left" id="match-options">
 						<label class="checkbox">
@@ -1022,6 +1022,20 @@ class View_Admin__Import extends View
 	 */
 	private function _findExistingPerson($row)
 	{
+		// === NEW: Exact ID match ===
+		// If the CSV supplies the internal Jethro person ID (column "id" or "person_id"),
+		// perform an immediate certain lookup. This bypasses name/email/mobile logic
+		// and solves import failures caused by multiple archived duplicates.
+		// All existing matching behaviour remains unchanged when no ID is provided.
+		if (!empty($row['id']) || !empty($row['person_id'])) {
+			$id = (int)($row['id'] ?? $row['person_id']);
+			if ($id > 0) {
+				$person = $GLOBALS['system']->getDBObject('person', $id);
+				if ($person && $person->id) {
+					return $person;
+				}
+			}
+		}
 		if (empty($_REQUEST['match_existing'])) return NULL;
 		$params = Array(
 					'first_name' => $row['first_name'],


### PR DESCRIPTION
### What this PR does

After the Fluro → Jethro migration, a church may ended up with multiple archived duplicate person records. This causes the CSV importer to fail with “too many people with the same details” errors.

This PR makes bulk imports much more reliable by adding support for **exact Person ID matching**.

#### Changes
- Updated the checkbox label from  
  *"Update existing persons if their first and last name match"*  
  to  
  **"Update existing persons (by Person ID if provided, otherwise by name)"**

- Added a exact match in `_findExistingPerson()`:
  - If the import CSV contains an `id` or `person_id` column with a valid Jethro Person ID, it immediately matches and updates that exact record.
  - When no ID column is present, behaviour falls back to the original first + last name matching (unchanged).

#### Why this matters
- Solves the post-migration duplicate blocking issue without breaking any existing workflows.
- Makes bulk updates safe and predictable when the internal Person ID is available (e.g. from a previous export or report).
- The ID check is an early-exit and does not affect performance or logic when not used.

#### Notes
- `Person::getMatchingPerson()` was **not** modified in this PR (as it is not used by the CSV importer).
- The maintainer previously confirmed the core logic lives in `_findExistingPerson()`.

This is a small, safe, and backward-compatible improvement requested by churches struggling with legacy data.

Looking forward to feedback!