### PR TITLE
Fix bug where the last assignee could not be deleted, if the role had no volunteer group

### DIFF
--- a/db_objects/roster_role.class.php
+++ b/db_objects/roster_role.class.php
@@ -290,7 +290,7 @@ class Roster_Role extends db_object
 	function printChooser($date, $currentval=Array(''), $absentees=Array())
 	{
 		if ($groupid = $this->getValue('volunteer_group')) {
-			$volunteers = $this->_getVolunteers();
+            $volunteers = $this->_getVolunteers();
 			if ($this->getValue('assign_multiple')) {
 				if (empty($currentval)) $currentval = Array('');
 				?>
@@ -334,6 +334,9 @@ class Roster_Role extends db_object
 			$GLOBALS['system']->includeDBClass('person');
 			if ($this->getValue('assign_multiple')) {
 				Person::printMultipleFinder('assignees['.$this->id.']['.$date.']', $currentval, $date);
+				// Sentinel: always submit something so processAllocations can distinguish
+				// "user deleted all assignees" from "cell was read-only (not submitted at all)".
+				echo '<input type="hidden" name="assignees_submitted['.$this->id.']['.$date.']" value="1" />';
 			} else {
 				$currentID = (int)reset($currentval);
 				Person::printSingleFinder('assignees['.$this->id.']['.$date.']', $currentID, $date);

--- a/db_objects/roster_view.class.php
+++ b/db_objects/roster_view.class.php
@@ -1033,7 +1033,7 @@ class roster_view extends db_object
 				if (in_array($roleid, $roles)) { // don't delete any allocations for read-only roles!!
 					foreach ($role_allocs as $rank => $person_details) {
 						if ($person_details['assigneehidden']) continue;
-						if (!isset($_POST['assignees'][$roleid][$date])) continue; // cell was read-only, don't delete
+						if (!isset($_POST['assignees'][$roleid][$date]) && empty($_POST['assignees_submitted'][$roleid][$date])) continue; // cell was read-only, don't delete
 						$del_clauses[] = '(roster_role_id = '.(int)$roleid.' AND assignment_date = '.$GLOBALS['db']->quote($date).' AND `rank` = '.(int)$rank.')';
 					}
 				}


### PR DESCRIPTION
Fixes #1434

The bug was introduced in v2.38.0 by the fix for #782.

A Claude-generated full explanation of how form processing works:

processAllocations determines what to delete by starting from all existing DB assignments and removing any that appear unchanged in the POST data. What remains in $to_delete gets deleted. The problem: when a roster cell contains a person the editing user lacks permission to see (e.g. due to congregation restrictions), printView renders that cell as plain
text rather than an editable widget — printChooser is never   called, so no assignees[roleid][date] data is submitted
for it. processAllocations saw no POST data for the cell, assumed the user had      cleared it, and deleted all
assignments including visible ones. Data loss.                                                                  

The #782 fix added a single guard in the deletion loop:                   

if (!isset($_POST['assignees'][$roleid][$date])) continue; // cell was read-only, don't delete                                              

The reasoning: if nothing was submitted for a cell, it must have been read-only, so don't touch it. This correctly preserved assignments in hidden-person cells.

This was a bad idea, because the guard conflates two situations that both produce no POST data for a cell:                                                               
1. Read-only cell (hidden persons) — printChooser not called, nothing submitted. Should not delete.                                         
2. Editable NonVG multi-person cell, all assignees removed — printChooser was called and rendered each existing assignee as a <li> with a hidden input (assignees[roleid][date][]). When the user clicks the JS delete button, those <li> elements are removed from the DOM. With nothing left in the list, no assignees[roleid][date] data reaches the server. Should delete.

The server cannot distinguish between these two cases, so the guard silently skips the deletion in both — reintroducing a data-loss bug in the opposite direction.

The new fix makes the two cases distinguishable by adding a sentinel hidden input in printChooser, emitted specifically for the Non-volunteer-group multi-person path:
```php
echo '<input type="hidden" name="assignees_submitted['.$this->id.']['.$date.']" value="1" />';
```
This input is outside the `<ul>` list, so it is unaffected when person <li> items are removed by JS. It is only ever emitted by printChooser, which is only called for editable cells (i.e. when !$haveHidden).    

The guard in processAllocations is updated to check for it:
```php
if (!isset($_POST['assignees'][$roleid][$date]) && empty($_POST['assignees_submitted'][$roleid][$date])) continue;
```
This now correctly handles all three cases:

  | Cell state | `assignees` in POST | `assignees_submitted` in POST | Result |                                                               
  |---|---|---|---|                                                                                                                           
  | Read-only (hidden persons) | absent | absent | skip — #782 preserved |                                                                    
  | Editable, all persons deleted | absent | **present** | delete — #1434 fixed |                                                           
  | Editable, persons remaining | present | present | normal processing |        