### PR TITLE
Remove the fade-in effect from group selector drop-downs

### DIFF
--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -708,7 +708,7 @@ JethroGroupChooser.onPageLoad = function() {
 		var treeContainer = JethroGroupChooser.getTreeContainer(this);
 		if ($(this).hasClass('active')) {
 			$(this).removeClass('active');
-			treeContainer.hide(400);
+			treeContainer.hide(0);
 		} else {
 			$('.custom-treeview-wrapper').hide(400); // close any open ones
 			$('.group-chooser-multi, select.group-chooser').removeClass('active');
@@ -718,7 +718,7 @@ JethroGroupChooser.onPageLoad = function() {
 			treeContainer.css('margin-top', ((parseInt(selectBoxStyle.marginBottom) * -1)+2)+"px");
 			var availableHeight = window.innerHeight - this.getBoundingClientRect().bottom - 10;
 			treeContainer.css('max-height', availableHeight + 'px');
-			treeContainer.show(400, function() {
+			treeContainer.show(0, function() {
 				$(this).find('input[type=text]:visible').focus();
 			});
 			$(document).on('mousedown', function(event) {


### PR DESCRIPTION
I've been using the new group picker intensively while testing other stuff. Ifind it's 400ms fade-in and fade-out to be juuust slightly annoyingly slow:

[ej_grouppicker_fadein.webm](https://github.com/user-attachments/assets/457230f3-24d6-4f30-902b-e701209d00e1)

No other Jethro drop-downs have fade-ins, and this one feels out of place.  

Could we remove it, or drastically reduce it?