### PR TITLE
Introduce Person::getFamily() helper method

### DIFF
--- a/calls/call_envelopes.class.php
+++ b/calls/call_envelopes.class.php
@@ -54,7 +54,7 @@ class Call_Envelopes extends Call
 				}
 			} else {
 				$person = $GLOBALS['system']->getDBObject('person', (int)$_REQUEST['personid']);
-				$family = $GLOBALS['system']->getDBObject('family', $person->getValue('familyid'));
+				$family = $person->getFamily();
 				$env->addAddress($person->toString()."\n".$family->getPostalAddress());
 			}
 		}

--- a/calls/call_envelopes.class.php
+++ b/calls/call_envelopes.class.php
@@ -62,7 +62,7 @@ class Call_Envelopes extends Call
 					trigger_error('Person #'.(int)$_REQUEST['personid'].' not found', E_USER_WARNING);
 					return;
 				}
-				$family = $GLOBALS['system']->getDBObject('family', $person->getValue('familyid'));
+				$family = $person->getFamily();
 				$env->addAddress($person->toString()."\n".$family->getPostalAddress());
 			}
 		}

--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -653,6 +653,11 @@ class Person extends DB_Object
 		return 0; // one must be blank, can't be sure.
 	}	
 
+	public function getFamily(): Family
+    {
+		return $GLOBALS['system']->getDBObject('family', $this->getValue('familyid'));
+	}
+
 	public function save($update_family=TRUE)
 	{
 		$GLOBALS['system']->doTransaction('BEGIN');
@@ -663,7 +668,7 @@ class Person extends DB_Object
 			// be updating themselves but saving the family will fail
 
 			if (!empty($this->_old_values['status']) || !empty($this->_old_values['last_name'])) {
-				$family = $GLOBALS['system']->getDBObject('family', $this->getValue('familyid'));
+				$family = $this->getFamily();
 				$members = $family->getMemberData(TRUE);
 				$archivedStatuses = Person_Status::getArchivedIDs();
 
@@ -1244,7 +1249,7 @@ class Person extends DB_Object
 			$n->delete();
 		}
 
-		$family = $GLOBALS['system']->getDBObject('family', $this->getValue('familyid'));
+		$family = $this->getFamily();
 		$members = $family->getMemberData();
 		$found_live_member = false;
 		foreach ($members as $id => $details) {
@@ -1265,7 +1270,7 @@ class Person extends DB_Object
 	public function delete()
 	{
 		$GLOBALS['system']->doTransaction('BEGIN');
-		$family = $GLOBALS['system']->getDBObject('family', $this->getValue('familyid'));
+		$family = $this->getFamily();
 		$members = $family->getMemberData();
 		unset($members[$this->id]);
 		parent::delete();

--- a/views/view_0_delete_person.class.php
+++ b/views/view_0_delete_person.class.php
@@ -33,7 +33,7 @@ class View__Delete_Person extends View
 											Array('personid' => $this->_person->id, 'status' => 'pending'),
 											'AND'
 			  	  );
-		$family = $GLOBALS['system']->getDBObject('family', $this->_person->getValue('familyid'));
+		$family = $this->_person->getFamily();
 		$members = $family->getMemberData();
 		if (count($members) == 1) {
 			$fnotes = $GLOBALS['system']->getDBObjectData(

--- a/views/view_0_delete_person.class.php
+++ b/views/view_0_delete_person.class.php
@@ -37,7 +37,7 @@ class View__Delete_Person extends View
 											Array('personid' => $this->_person->id, 'status' => 'pending'),
 											'AND'
 			  	  );
-		$family = $GLOBALS['system']->getDBObject('family', $this->_person->getValue('familyid'));
+		$family = $this->_person->getFamily();
 		$members = $family->getMemberData();
 		if (count($members) == 1) {
 			$fnotes = $GLOBALS['system']->getDBObjectData(

--- a/views/view_0_move_person_to_family.class.php
+++ b/views/view_0_move_person_to_family.class.php
@@ -15,7 +15,7 @@ class View__Move_Person_To_Family extends View
 		if (!empty($_REQUEST['move_to'])) {
 			if ($_REQUEST['move_to'] == 'new') {
 				$old_familyid = $this->_person->getValue('familyid');
-				$family = $GLOBALS['system']->getDBObject('family', (int)$this->_person->getValue('familyid'));
+				$family = $this->_person->getFamily();
 				$family->id = 0;
 				$family->create();
 				$this->_person->setValue('familyid', $family->id);

--- a/views/view_10_admin__7_import.class.php
+++ b/views/view_10_admin__7_import.class.php
@@ -387,7 +387,7 @@ class View_Admin__Import extends View
 
 				// Try updating the family fields
 				$family_row['status'] = 'current';
-				$familyObj = $GLOBALS['system']->getDBObject('family', $existingPerson->getValue('familyid'));
+				$familyObj = $existingPerson->getFamily();
 				$family_row['family_name'] = $familyObj->getValue('family_name'); // avoid case munging
 				$familyObj->fromCsvRow($family_row, $this->_sess['overwrite_existing']);
 				if (empty($current_existing_family_data) || ($existingPerson->getValue('familyid') != $current_existing_family_data['id'])) {

--- a/views/view_3_persons.class.php
+++ b/views/view_3_persons.class.php
@@ -10,7 +10,7 @@ class View_Persons extends View
 		if (!empty($_REQUEST['personid'])) {
 			$this->_person = $GLOBALS['system']->getDBObject('person', (int)$_REQUEST['personid']);
 			if ($this->_person) {
-				$this->_family = $GLOBALS['system']->getDBObject('family', $this->_person->getValue('familyid'));
+				$this->_family = $this->_person->getFamily();
 			}
 		}
 	}


### PR DESCRIPTION
**This PR builds upon https://github.com/tbar0970/jethro-pmm/pull/1444, which builds on https://github.com/tbar0970/jethro-pmm/pull/1443, which should be dealt with first. Only the last commit is actually part of this PR**

Introduce Person::getFamily() - new method is used in 8 call sites.

This simplifies code and gives us a nice Family object to work with, rather than the array getDBObject() returns.
