### PR TITLE
Fix crash caused by trying to save half-populated notes (#1446)

### DIFF
--- a/include/db_object.class.php
+++ b/include/db_object.class.php
@@ -10,6 +10,7 @@ class db_object
 	protected $_old_values = Array();
 	protected $_held_locks = Array();
 	protected $_acquirable_locks = Array();
+	protected $_populated_partial = FALSE;
 
 	protected $_tmp = Array();
 
@@ -201,6 +202,7 @@ class db_object
 
 		$parent_class =  strtolower(get_parent_class($this));
 		if ($parent_class != 'db_object') {
+            /** @var DB_Object $parent_obj */
 			$parent_obj = new $parent_class();
 			$parent_obj->populate(0, $this->values);
 			if (!$parent_obj->create()) {
@@ -314,9 +316,9 @@ class db_object
 				} else {
 					$this->values[$name] = unserialize($this->values[$name]);
 				}
-					
 			}
 		}
+		$this->_populated_partial = FALSE;
 	}
 
 
@@ -340,6 +342,9 @@ class db_object
 
 	public function save()
 	{
+		if (!empty($this->_populated_partial)) {
+			throw new \RuntimeException(get_class($this).' was populated from partial data (missing serialise fields) and cannot be saved. Use new '.get_class($this).'($id) instead of populate().');
+		}
 		if (!$this->checkPerm($this->_save_permission_level)) {
 			throw new \RuntimeException('Current user has insufficient permission level to save a '.get_class($this).' object');
 		}
@@ -451,8 +456,21 @@ class db_object
 	{
 		$this->values = $this->_old_values = Array();
 		$this->id = 0;
+		$this->_populated_partial = FALSE;
 	}
 
+	/**
+	 * Hydrate this object from an array of field values, typically from a
+	 * batch query result. Only fields present in $values are set;
+	 * serialise-type fields are deserialized automatically if passed as
+	 * strings.
+	 *
+	 * Note: populate()'ed objects are cheap to construct ('history' and
+	 * other serialized fields omitted) and intended for read-only use. Be
+	 * careful save()'ing a populate()'ed object. as serialized fields like
+	 * 'history' are not loaded, and saving would wipe them. Instead call
+	 * new ClassName($id), which calls load() from the constructor.
+	 */
 	public function populate($id, $values)
 	{
 		$this->_old_values = Array();
@@ -467,6 +485,15 @@ class db_object
 		}
 		$this->_held_locks = Array();
 		$this->_acquirable_locks = Array();
+
+		// Flag this object as read-only / partially populated, so save() rejects it.
+		$this->_populated_partial = FALSE;
+		foreach ($this->fields as $fieldname => $details) {
+			if ($details['type'] === 'serialise' && !array_key_exists($fieldname, $values)) {
+				$this->_populated_partial = TRUE;
+				break;
+			}
+		}
 	}
 
 	public function canDelete($trigger_messages=FALSE)

--- a/include/db_object.class.php
+++ b/include/db_object.class.php
@@ -202,7 +202,7 @@ class db_object
 
 		$parent_class =  strtolower(get_parent_class($this));
 		if ($parent_class != 'db_object') {
-            /** @var DB_Object $parent_obj */
+			/* @var DB_Object $parent_obj */
 			$parent_obj = new $parent_class();
 			$parent_obj->populate(0, $this->values);
 			if (!$parent_obj->create()) {

--- a/views/abstract_view_notes_list.class.php
+++ b/views/abstract_view_notes_list.class.php
@@ -38,10 +38,8 @@ abstract class Abstract_View_Notes_List extends View
 		$this->_reassigning = $GLOBALS['user_system']->havePerm(PERM_BULKNOTE) && !empty($_REQUEST['reassigning']);
 		if ($this->_reassigning && !empty($_POST['reassignments_submitted'])) {
 			$this->_notes = $this->_getNotesToShow(array_get($_REQUEST, 'assignee'), array_get($_REQUEST, 'search'));
-			$dummy_note = new Abstract_Note();
 			foreach ($this->_notes as $id => $note) {
-				$dummy_note->reset();
-				$dummy_note->populate($id, $note);
+				$dummy_note = new Abstract_Note($id);
 				$dummy_note->setValue('assignee', $_POST['note_'.$id.'_assignee']);
 				$dummy_note->save();
 				$dummy_note->releaseLock();


### PR DESCRIPTION
Fixes #1446

The root cause of this, and https://github.com/tbar0970/jethro-pmm/issues/836 earlier, is that it is not safe to `populate()` then `save()` an object, as in this code pattern:

```php
// Load a bunch of rows from db into $things
$dummy = new Something();
foreach ($this->things as $id -> $arr) {
  $dummy->reset();
  $dummy->populate($id, $arr);    // loads a subset of fields
  ... // update somehow
  $dummy->save();    // history is lost!
}
```
`populate()` is for quick read-only objects, and does not populate serialised fields like `history`. If you `populate()` an object like an Abstract_Note, then `save()` it, the history gets lost.

We actually had this data loss bug in Jethro (losing note histories) until 2.33, when #836 was found and fixed. #836 is a different instance of `populate()` being misused, but as part of the fix the `"History field is not an array - this should not be. Aborting."` sanity check you see triggered here. Hurrah for sanity checks!

This PR has two commits: one fixes the immediate problem, the other makes `populate()` into less of a footgun by documenting its intended purpose, and adding a flag so that if it ever misused, and `save()` called, it blows up with a clean error.

