### PR TITLE
Page errors should always show, rather than becoming 'Undefined view' after first load.

### DIFF
--- a/include/system_controller.class.php
+++ b/include/system_controller.class.php
@@ -37,7 +37,7 @@ class System_Controller
 		ini_set('include_path', ini_get('include_path').$path_sep.$this->_base_dir);
 
 		if (!isset($_SESSION['views'][$base_dir]) || isset($_REQUEST['regen'])) {
-			$_SESSION['views'][$base_dir] = Array();
+			$scanned_views = Array();
 			$raw_filenames = glob($this->_base_dir.'/views/*.class.php');
 			natsort($raw_filenames);
 			foreach ($raw_filenames as $filename) {
@@ -59,14 +59,15 @@ class System_Controller
 					}
 					if ($showView) {
 						if (preg_match('/^view_([0-9.]*)_(.*)__([0-9]*)_(.*)\.class\.php/', $filename, $matches)) {
-							$_SESSION['views'][$base_dir][$matches[2]]['children'][$matches[4]]['filename'] = $filename;
+							$scanned_views[$matches[2]]['children'][$matches[4]]['filename'] = $filename;
 						} else if (preg_match('/^view_([0-9.]*)_(.*)\.class\.php/', $filename, $matches)) {
 							if ($matches[1] == 0) $matches[2] = '_'.$matches[2];
-							$_SESSION['views'][$base_dir][$matches[2]]['filename'] = $filename;
+							$scanned_views[$matches[2]]['filename'] = $filename;
 						}
 					}
 				}
 			}
+			$_SESSION['views'][$base_dir] = $scanned_views;
 		}
 	}
 


### PR DESCRIPTION
When developing PHP 'view' pages, any syntax error gets 'cached' by Jethro's view system. You only get to see the syntax error once before the page shows 'Undefined view':

[ej_undefined_view.webm](https://github.com/user-attachments/assets/3750443a-31a9-4713-99b2-edb0a863ea25)

This patch fixes System_Controller to only declare the views loaded (set `$_SESSION['views']`) when all PHP pages have loaded. A broken PHP page will be re-tried on page load, as you'd expect.