### PR TITLE
#1449 - fix 'Print Envelope' vertical align.

### DIFF
--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -1079,6 +1079,7 @@ img.person-photo {
 	background: @jethroLight;
 	border-radius: 5px;
 	margin-bottom: 15px;
+	display: flow-root;
 }
 .view-person .details-box {
 	width: 500px;


### PR DESCRIPTION
Set 'display: flow-root' on details-boxes to visually enclose contained floats, like .pull-right links like 'Print Envelope'.

Fixes #1449

<img width="1473" height="768" alt="image" src="https://github.com/user-attachments/assets/3aea18f8-a1ac-4b7c-90cb-7402262eddb8" />
