### PR TITLE
UI cleanup: View Family Members: add missing action divider

### DIFF
--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -1212,6 +1212,8 @@ img.person-photo {
 	row-gap: 10px;
 	box-sizing: border-box;
 	margin-bottom: 10px;
+	padding-bottom: 8px;
+	border-bottom: 1px solid #dddddd;
  }
 .family-member {
 	box-sizing: border-box;

--- a/templates/bulk_actions.template.php
+++ b/templates/bulk_actions.template.php
@@ -5,7 +5,7 @@ $groupid = array_get($_REQUEST, 'groupid', array_get($_REQUEST, 'person_groupid'
 $selected = Array(array_get($_REQUEST, 'bulk_action', '') => 'selected="selected"'); // email, sms or merge
 ?>
 
-<div class="form-horizontal bulk-actions">
+<div class="form-horizontal bulk-actions pull-left">
 	<?php echo _('With selected persons:')?>
 		<select id="bulk-action-chooser" class="no-autofocus">
 			<option><?php echo _('-- Choose Action --')?></option>


### PR DESCRIPTION
On the Family page's "Family Members" section, there is no horizontal line separating the members from the actions:

<img width="1296" height="688" alt="image" src="https://github.com/user-attachments/assets/b9037deb-c3f3-4b95-b190-49d8ade4ee9f" />

This PR changes it to:

<img width="1415" height="773" alt="image" src="https://github.com/user-attachments/assets/96697630-45fa-493c-a350-54c53556dc59" />

This makes it consistent with other places in Jethro:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/efe26958-5f8e-4085-9411-bdbcc1827e39" />

<img width="700" alt="image" src="https://github.com/user-attachments/assets/79d753d8-cd17-4d5d-9352-aad8f2fbd6f9" />