### PR TITLE
Removed unreachable code

### DIFF
--- a/db_objects/service.class.php
+++ b/db_objects/service.class.php
@@ -371,14 +371,7 @@ class service extends db_object
 					$bits[] = ents($this->values['format_title']);
 				}
 				if (!empty($this->values['notes'])) {
-					$x = '<small>';
-					if ($fieldname == 'summary_inline') {
-						$x .= str_replace("\n", ' / ', ents($this->values['notes']));
-					} else {
-						$x .= nl2br(ents($this->values['notes']));
-					}
-					$x .= '</small>';
-					$bits[] = $x;
+					$bits[] = '<small>'.str_replace("\n", ' / ', ents($this->values['notes'])).'</small>';
 				}
 				echo implode($separator, $bits);
 				break;


### PR DESCRIPTION
Within the following `switch`,
https://github.com/tbar0970/jethro-pmm/blob/40705b6a3bcef64b2c21f923a39fc220025c5dc7/db_objects/service.class.php#L306
https://github.com/tbar0970/jethro-pmm/blob/40705b6a3bcef64b2c21f923a39fc220025c5dc7/db_objects/service.class.php#L359
`$fieldname` is checked, which is unnecessary, since the `switch` has already determined what the value is.
https://github.com/tbar0970/jethro-pmm/blob/40705b6a3bcef64b2c21f923a39fc220025c5dc7/db_objects/service.class.php#L374-L381