### PR TITLE
Don't break if upgrades/2026-upgrade-to-2.38.sql is run twice

### DIFF
--- a/upgrades/2026-upgrade-to-2.38.sql
+++ b/upgrades/2026-upgrade-to-2.38.sql
@@ -10,7 +10,7 @@ AND NOT EXISTS (
 
 -- The following is in 2.38-RC2 but not RC1
 -- #1380 - allow for 'team groups' to be configured for a roster role.
-CREATE TABLE `roster_role_team` (
+CREATE TABLE IF NOT EXISTS `roster_role_team` (
 	`roster_role_id` INT NOT NULL,
 	`person_group_id` INT NOT NULL,
 	PRIMARY KEY (roster_role_id, person_group_id),


### PR DESCRIPTION
Upgrade SQL should be idempotent.