### PR TITLE
roster_reminder.php: make DEBUG=1 show real recipients and never send anything

### DIFF
--- a/scripts/roster_reminder.php
+++ b/scripts/roster_reminder.php
@@ -177,9 +177,6 @@ if ($sendsms) { // make the sms message!
 
 			}
 			$smsroster .= "\n";
-			if ((int)$debug==1){
-			 $assignees=Array();
-			}
 		}
 
 		$assignees = array_merge($assignees, $coordinator);
@@ -192,6 +189,10 @@ if ($sendsms) { // make the sms message!
 		if ($debug) {
 			bam($sms_message);
 			bam("Debug mode - no messages sent");
+			$recipientNames = array_map(function($a) {
+				return $a['first_name'] . ' ' . $a['last_name'] . ' (' . $a['mobile_tel'] . ')';
+			}, $assignees);
+			bam("Recipients: " . implode(', ', $recipientNames));
 			exit;
 		}
 		if (strlen($sms_message) > SMS_MAX_LENGTH) {
@@ -303,10 +304,20 @@ if ($sendemail) {
 		$no_emails = array_unique($no_emails);
 		//send the emails
 
-		//if DEBUG then echo the email content
+		//if DEBUG then echo the email content and recipients, then exit without sending
 		if ((int)$debug==1){
 			echo "Sending the following message:\n\n";
 			echo $longstring."\n\n";
+			echo "Recipients:\n";
+			foreach ($assignees as $a) {
+				if (!empty($a['email'])) {
+					echo "  " . $a['first_name'] . ' ' . $a['last_name'] . ' <' . $a['email'] . ">\n";
+				} else {
+					echo "  " . $a['first_name'] . ' ' . $a['last_name'] . " (no email)\n";
+				}
+			}
+			echo "\nDebug mode - no messages sent\n";
+			exit;
 		}
 		//
 		//send using built in email class


### PR DESCRIPTION
roster_reminder.php's old DEBUG=1 behaviour had two problems:

1. In the SMS codepath, `DEBUG=1` with `INCLUDE_ROSTER_CONTENT=1` would empty the `$assignees` array (line 195-197), then re-merge only the coordinator. This meant the debug output could never show who would *really* receive the SMS — it always showed just the coordinator. The emptying was also dead code since the exit() on line 210 prevented any sending anyway.

2. In the email codepath, `DEBUG=1` would print the message body but then *actually send the email* (to the coordinator only). This violated the principle that debug mode should never send real messages.

Fix:
- Remove the `$assignees=Array()` dead code so the real assignee list is preserved for debug output.
- In the SMS debug block, print the real recipient names and mobile numbers before exiting.
- In the email debug block, print the real recipient names and email addresses, then exit instead of sending.