### PR TITLE
Bugfix: When determining if a View is enabled, check getMenuRequiredFeature even if getMenuPermissionLevel passed

### DIFF
--- a/include/system_controller.class.php
+++ b/include/system_controller.class.php
@@ -53,9 +53,10 @@ class System_Controller
 					include_once($this->_base_dir.'/views/'.$filename);
 					$showView = TRUE;
 					if ($view_perm = call_user_func(Array($classname, 'getMenuPermissionLevel'))) {
-						$showView = !empty($GLOBALS['user_system']) && $GLOBALS['user_system']->havePerm($view_perm);
-					} else if ($view_feature = call_user_func(Array($classname, 'getMenuRequiredFeature'))) {
-						$showView = $this->featureEnabled($view_feature);
+						$showView &= !empty($GLOBALS['user_system']) && $GLOBALS['user_system']->havePerm($view_perm);
+					}
+					if ($view_feature = call_user_func(Array($classname, 'getMenuRequiredFeature'))) {
+						$showView &= $this->featureEnabled($view_feature);
 					}
 					if ($showView) {
 						if (preg_match('/^view_([0-9.]*)_(.*)__([0-9]*)_(.*)\.class\.php/', $filename, $matches)) {


### PR DESCRIPTION
I'm experimenting with a "SMS Administration" view, that will require both a 'SMS' feature to be enabled, and the user to have the SYSADMIN permission:

```php
<?php

class View_Admin__SMS extends View
{
	public static function getMenuRequiredFeature(): string
	{
		return 'SMS';
	}
	static function getMenuPermissionLevel(): int
	{
		return PERM_SYSADMIN;
	}

	function processView(): void
	{
	     .....
	}
```
This view should only show if the `SMS` feature is enabled _and_ the current user has sysadmin permission.

There is a bug in the view loader, where if a `getMenuPermissionLevel` function exists, `getMenuRequiredFeature` is never called.

This PR fixes the bug, so both functions are called (if present) and the outcomes ANDed together.