### PR TITLE
Automatic fetching of Bible Reading texts in service handouts, via optional https://api.bible integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ System requirements are:
     * with [zip extension](https://www.php.net/manual/en/book.zip.php) enabled
     * with [xmlwriter extension](https://www.php.net/manual/en/book.xmlwriter.php) enabled, to create DOCX files
     * [GD library](https://www.php.net/manual/en/book.image.php) recommended, to manage the size of uploaded photos
-    * with [curl extension](https://www.php.net/manual/en/book.curl.php) enabled, if you intend to use the Mailchimp integration
+    * with [curl extension](https://www.php.net/manual/en/book.curl.php) enabled, if you intend to use the Mailchimp or https://api.bible integration
     * with [exif extension](https://www.php.net/manual/en/book.exif.php) enabled, if you would like to automatically rotate images
 
 The steps to install are:

--- a/calls/call_service_comp_help_runsheet_format.class.php
+++ b/calls/call_service_comp_help_runsheet_format.class.php
@@ -124,6 +124,11 @@ class call_service_comp_help_runsheet_format extends Call
 							<code>%SERVICE_BIBLE_PREACH_ALL%</code> expands to
 							<code>Psalm 111</code>
 						</p>
+						<p>
+							Add <code>_CONTENT</code> to fetch the full passage text instead of just the reference:
+							<code>%SERVICE_BIBLE_READ_1_CONTENT%</code> — fetches and displays the passage
+							using the preferred Bible translation (set in System Configuration).
+						</p>
 					</td>
 				</tr>
 				</tbody>

--- a/calls/call_service_content.class.php
+++ b/calls/call_service_content.class.php
@@ -14,6 +14,26 @@ class Call_Service_Content extends Call
 		?>
 		<html>
 			<head>
+				<?php if ($GLOBALS['system']->featureEnabled('BIBLE_API')) { ?>
+				<link rel="preconnect" href="https://fonts.googleapis.com">
+				<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+				<link href="https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+				<link type="text/css" rel="stylesheet" href="https://assets.api.bible/css/scripture-styles.css" />
+				<style>
+					body {
+						font-family: "Noto Serif", serif;
+						font-size: 1.125rem;
+						line-height: 1.5;
+						color: #2a2a2a;
+					}
+				</style>
+				<?php } else { ?>
+				<style>
+				    body {
+					font-family: sans-serif;
+				    }
+				</style>
+				<?php } ?>
 				<style media="print">
 					html body * {
 						color: black;
@@ -21,9 +41,6 @@ class Call_Service_Content extends Call
 					}
 				</style>
 				<style>
-					* {
-						font-family: sans-serif;
-					}
 					td, th {
 						padding: 5px 10px;
 						vertical-align: top;

--- a/calls/call_service_content.class.php
+++ b/calls/call_service_content.class.php
@@ -14,6 +14,18 @@ class Call_Service_Content extends Call
 		?>
 		<html>
 			<head>
+				<link rel="preconnect" href="https://fonts.googleapis.com">
+				<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+				<link href="https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+				<link type="text/css" rel="stylesheet" href="https://assets.api.bible/css/scripture-styles.css" />
+				<style>
+					body {
+						font-family: "Noto Serif", serif;
+						font-size: 1.125rem;
+						line-height: 1.5;
+						color: #2a2a2a;
+					}
+				</style>
 				<style media="print">
 					html body * {
 						color: black;
@@ -21,9 +33,6 @@ class Call_Service_Content extends Call
 					}
 				</style>
 				<style>
-					* {
-						font-family: sans-serif;
-					}
 					td, th {
 						padding: 5px 10px;
 						vertical-align: top;

--- a/conf.php.sample
+++ b/conf.php.sample
@@ -177,6 +177,20 @@ define('2FA_ENABLED', true);
 // define('SMTP_PASSWORD', '');
 
 
+///////////////////////////////////////////////////////////////////////////
+// BIBLE REF LOOKUP SETTINGS - optional integration with https://api.bible to 
+// automatically fetch Bible Reading passages in service handouts.
+//
+// API key obtainable after registering on https://api.bible
+// define('BIBLE_API_APIKEY', '........-Cn');
+//
+// Base URL for the API.Bible REST API (used for fetching Bible passage text).
+// Defaults to the standard API.Bible endpoint if not set.
+// define('BIBLE_API_URL', 'https://rest.api.bible/v1');
+
+// Timeout in seconds for API.Bible REST API requests. Defaults to 10 if not set.
+// define('BIBLE_API_TIMEOUT', 10);
+
 
 ///////////////////////////////////////////////////////////////////////////
 // ADVANCED SETTINGS - These are not available within the web interface

--- a/conf.php.sample
+++ b/conf.php.sample
@@ -179,6 +179,20 @@ define('2FA_ENABLED', true);
 // Mailchimp API key for list synchronization
 // define('MAILCHIMP_API_KEY', '');
 
+///////////////////////////////////////////////////////////////////////////
+// BIBLE REF LOOKUP SETTINGS - optional integration with https://api.bible to 
+// automatically fetch Bible Reading passages in service handouts.
+//
+// API key obtainable after registering on https://api.bible
+// define('BIBLE_API_APIKEY', '........-Cn');
+//
+// Base URL for the API.Bible REST API (used for fetching Bible passage text).
+// Defaults to the standard API.Bible endpoint if not set.
+// define('BIBLE_API_URL', 'https://rest.api.bible/v1');
+
+// Timeout in seconds for API.Bible REST API requests. Defaults to 10 if not set.
+// define('BIBLE_API_TIMEOUT', 10);
+
 
 ///////////////////////////////////////////////////////////////////////////
 // ADVANCED SETTINGS - These are not available within the web interface

--- a/db_objects/service.class.php
+++ b/db_objects/service.class.php
@@ -527,9 +527,45 @@ class service extends db_object
 		} else if (substr($keyword, -10) == '_FIRSTNAME') {
 			return $this->getPersonnelByRoleTitle(substr($keyword, 0, -10), TRUE);
 
-		} else if (str_starts_with($keyword, 'SERVICE_')) {
-			$service_field = strtolower(substr($keyword, strlen('SERVICE_')));
-			if (in_array($service_field, Array('topic', 'format'))) {
+		} else if (str_starts_with((string) $keyword, 'SERVICE_')) {
+			$service_field = strtolower(substr((string) $keyword, strlen('SERVICE_')));
+
+			// Handle %SERVICE_BIBLE_READ_N_CONTENT% tokens:
+			// resolve the underlying reference, then fetch the passage text via API
+			// using the preferred translation from the BIBLE_PREFERRED setting.
+			if (preg_match('/^bible_(read|preach)_(\d+|all)_content$/', $service_field, $m)) {
+				if ($GLOBALS['system']->featureEnabled('BIBLE_API')) {
+					$baseServiceField = "bible_{$m[1]}_{$m[2]}";
+					$reference = $this->getValue($baseServiceField);
+					if ($reference && ($reference !== '')) {
+						require_once JETHRO_ROOT . '/include/bibleapi.php';
+						$translation = defined('BIBLE_TRANSLATION_PREFERRED') ? constant('BIBLE_TRANSLATION_PREFERRED') : null;
+						if ($m[2] === 'all') {
+							// Comma-separated list of references — fetch each
+							$references = array_map('trim', explode(',', $reference));
+							$output = '';
+							foreach ($references as $ref) {
+								if ($ref !== '') {
+									$result = $translation ? fetchBiblePassage($ref, $translation) : fetchBiblePassage($ref);
+									if ($result !== null) {
+										[$text, $attribution] = $result;
+										$output .= "<h5>".ents($ref)."</h5>" . $text . $attribution;
+									}
+								}
+							}
+							return $output;
+						}
+						$result = $translation ? fetchBiblePassage($reference, $translation) : fetchBiblePassage($reference);
+						if ($result !== null) {
+							[$text, $attribution] = $result;
+							return $text . $attribution;
+						}
+					}
+				}
+				return '';
+			}
+
+			if (in_array($service_field, ['topic', 'format'])) {
 				$service_field .= '_title';
 			}
 			if ((substr($service_field, 0, 5) == 'bible') || isset($this->fields[$service_field])) {
@@ -813,8 +849,8 @@ class service extends db_object
 			</h4>
 			<?php
 			if ($i['show_in_handout'] == 'full') {
-				echo $i['content_html'];
-				?>
+                echo $this->keywordsInBody($i['content_html']) ? $this->replaceKeywords($i['content_html']) : $i['content_html'];
+                ?>
 				<small>
 					<?php echo nl2br(ents($i['credits'])); ?>
 				</small>
@@ -822,6 +858,14 @@ class service extends db_object
 			}
 		}
 	}
+
+    /** @return Whether a service component HTML body contains a single %.*_CONTENT% token (i.e. bible readings) which is the only case in which we allow substitution.
+     */
+    private function keywordsInBody(string $content): bool
+    {
+        $stripped = trim(strip_tags($content));
+        return preg_match('/^%[A-Z0-9_]+_CONTENT%$/i', $stripped) === 1;
+    }
 
 	public function getServiceContent()
 	{
@@ -835,7 +879,8 @@ class service extends db_object
 				$title = $this->replaceKeywords($title);
 				//$serviceContent[] = ents($title);
 			if ($i['show_in_handout'] == 'full') {
-				$itemContent = $i['content_html'];
+                $itemContent = $this->keywordsInBody($i['content_html']) ? $this->replaceKeywords($i['content_html']) : $i['content_html'];
+
 				$itemCredit = nl2br(ents($i['credits']));
 			}
 			else {

--- a/db_objects/service.class.php
+++ b/db_objects/service.class.php
@@ -522,9 +522,43 @@ class service extends db_object
 		} else if (substr($keyword, -10) == '_FIRSTNAME') {
 			return $this->getPersonnelByRoleTitle(substr($keyword, 0, -10), TRUE);
 
-		} else if (str_starts_with($keyword, 'SERVICE_')) {
-			$service_field = strtolower(substr($keyword, strlen('SERVICE_')));
-			if (in_array($service_field, Array('topic', 'format'))) {
+		} else if (str_starts_with((string) $keyword, 'SERVICE_')) {
+			$service_field = strtolower(substr((string) $keyword, strlen('SERVICE_')));
+
+			// Handle %SERVICE_BIBLE_READ_N_CONTENT% tokens:
+			// resolve the underlying reference, then fetch the passage text via API
+			// using the preferred translation from the BIBLE_PREFERRED setting.
+			if (preg_match('/^bible_(read|preach)_(\d+|all)_content$/', $service_field, $m)) {
+				$baseServiceField = "bible_{$m[1]}_{$m[2]}";
+				$reference = $this->getValue($baseServiceField);
+				if ($reference && ($reference !== '')) {
+					require_once JETHRO_ROOT . '/include/bibleapi.php';
+					$translation = defined('BIBLE_TRANSLATION_PREFERRED') ? constant('BIBLE_TRANSLATION_PREFERRED') : null;
+					if ($m[2] === 'all') {
+						// Comma-separated list of references — fetch each
+						$references = array_map('trim', explode(',', $reference));
+						$output = '';
+						foreach ($references as $ref) {
+							if ($ref !== '') {
+								$result = $translation ? fetchBiblePassage($ref, $translation) : fetchBiblePassage($ref);
+								if ($result !== null) {
+									[$text, $attribution] = $result;
+									$output .= "<h5>".ents($ref)."</h5>" . $text . $attribution;
+								}
+							}
+						}
+						return $output;
+					}
+					$result = $translation ? fetchBiblePassage($reference, $translation) : fetchBiblePassage($reference);
+					if ($result !== null) {
+						[$text, $attribution] = $result;
+						return $text . $attribution;
+					}
+				}
+				return '';
+			}
+
+			if (in_array($service_field, ['topic', 'format'])) {
 				$service_field .= '_title';
 			}
 			if ((substr($service_field, 0, 5) == 'bible') || isset($this->fields[$service_field])) {
@@ -808,8 +842,8 @@ class service extends db_object
 			</h4>
 			<?php
 			if ($i['show_in_handout'] == 'full') {
-				echo $i['content_html'];
-				?>
+                echo $this->keywordsInBody($i['content_html']) ? $this->replaceKeywords($i['content_html']) : $i['content_html'];
+                ?>
 				<small>
 					<?php echo nl2br(ents($i['credits'])); ?>
 				</small>
@@ -817,6 +851,14 @@ class service extends db_object
 			}
 		}
 	}
+
+    /** @return Whether a service component HTML body contains a single %.*_CONTENT% token (i.e. bible readings) which is the only case in which we allow substitution.
+     */
+    private function keywordsInBody(string $content): bool
+    {
+        $stripped = trim(strip_tags($content));
+        return preg_match('/^%[A-Z0-9_]+_CONTENT%$/i', $stripped) === 1;
+    }
 
 	public function getServiceContent()
 	{
@@ -830,7 +872,8 @@ class service extends db_object
 				$title = $this->replaceKeywords($title);
 				//$serviceContent[] = ents($title);
 			if ($i['show_in_handout'] == 'full') {
-				$itemContent = $i['content_html'];
+                $itemContent = $this->keywordsInBody($i['content_html']) ? $this->replaceKeywords($i['content_html']) : $i['content_html'];
+
 				$itemCredit = nl2br(ents($i['credits']));
 			}
 			else {

--- a/include/bibleapi.php
+++ b/include/bibleapi.php
@@ -1,0 +1,349 @@
+<?php
+const APIBIBLE_NIV='78a9f6124f344018-01';
+/**
+ * Bible API library - provides functions to look up Bible passage text
+ * via the API.Bible REST API.
+ *
+ * Requires BIBLE_API_APIKEY constant to be defined in conf.php.
+ */
+
+
+/**
+ * Fetch the HTML content of a Bible passage from a specific translation.
+ *
+ * @param string $reference   Human-readable reference like "John 3:16-17" or "Jer 3:6-18"
+ * @param string $bibleId Bible translation to use. This is an id as defined by https://api.bible's API (run 'php scripts/biblelookup.php --bibles' to see available)
+ * @return ?array{string
+ * , string} [passageHTML, attributionHTML] or null on failure
+ */
+function fetchBiblePassage(string $reference, string $bibleId = APIBIBLE_NIV): ?array
+{
+    if ($bibleId === '') throw new InvalidArgumentException('$bibleId must not be blank');
+	$result = callBibleApi("/bibles/$bibleId/search", [
+		'query' => $reference,
+	]);
+
+	$passage = $result['data']['passages'][0] ?? null;
+	if (!$passage || empty($passage['content'])) {
+		return null;
+	}
+
+	$content = $passage['content'];
+	if (ifdef('BIBLE_API_PARSE', true)) {
+		$parsed = parseBibleHtml($content);
+		if ($parsed === null) {
+			return null;
+		}
+
+		// Compare against a DOM round-trip without filtering.
+		// If they differ, log both versions and use our parsed version.
+		$doc = domParse($content);
+		$canon = $doc !== null ? domSerialize($doc) : null;
+		if ($parsed !== $canon) {
+			error_log("Bible API returned HTML our parser couldn't handle.\nPARSED: " . $parsed . "\nUPSTREAM: " . $canon);
+			$content = $parsed;
+		} else {
+			$content = $parsed;
+		}
+	}
+	$content = '<div class="scripture-styles">' . $content . '</div>';
+
+	$attribution = '';
+	if (!empty($passage['copyright'])) {
+		$short = shortenAttribution($bibleId, $passage['copyright']);
+		$attribution = '<div style="font-size: smaller; text-align: left; margin-top: 1em;">'
+			. ents($short)
+			. '</div>';
+	}
+
+	return [$content, $attribution];
+}
+
+/**
+ * Produce a space-constrained attribution like "NIV © 2011 Biblica, Inc. All rights reserved.", as permitted by https://api.bible/terms-and-conditions#appendix-a---formatting-for-detailed-copyright-information
+ * @param copyright A long-winded copyright string e.g. "The Holy Bible, New International Version® NIV® Copyright © 1973, 1978, 1984, 2011 by Biblica, Inc.® Used by Permission of Biblica, Inc.® All rights reserved worldwide."
+ */
+function shortenAttribution(string $bibleId, string $copyright): string
+{
+	if (stripos($copyright, 'public domain') !== false) {
+		return 'Public domain.';
+	}
+
+	// Extract the Bible abbreviation from the copyright string.
+	// Expected format: "... Version® ABBREV® Copyright © ..."
+	$abbrev = '';
+	if (preg_match('/\b([A-Z]{2,5})®\s*Copyright\b/', $copyright, $m)) {
+		$abbrev = $m[1];
+	}
+	// Fall back to looking up the abbreviation from available translations
+	if ($abbrev === '') {
+		$translations = getBibleTranslations();
+		$abbrev = $translations[$bibleId]['abbreviation'] ?? $bibleId;
+	}
+
+	// Extract the last copyright year
+	$year = '';
+	if (preg_match('/©\s*(?:[\d,\s]+)?(\d{4})/', $copyright, $m)) {
+		$year = $m[1];
+	}
+
+	// Extract organization name after "by" - stop at sentence end, "All rights", or "Used by"
+	$org = '';
+	if (preg_match('/\bby\s+(.+?)(?:\s*[.]\s+[A-Z]|\s+All\s+rights|\s+Used\s+by|\s*$)/s', $copyright, $m)) {
+		$org = trim($m[1]);
+		// Strip trailing punctuation and registered symbols
+		$org = preg_replace('/[®TM,.]+$/', '', $org);
+		$org = trim($org);
+	}
+
+	if ($year && $org) {
+		return "$abbrev © $year $org. All rights reserved.";
+	}
+	if ($year) {
+		return "$abbrev © $year. All rights reserved.";
+	}
+	return "$abbrev. All rights reserved.";
+}
+
+// ===========================================================================
+// API communication
+// ===========================================================================
+
+/**
+ * Call the API.Bible REST API.
+ *
+ * @param string $path   API path (e.g. '/bibles/{id}/passages/{id}')
+ * @param array<string, string> $params Query parameters
+ * @return array<string, mixed> Decoded JSON response
+ */
+function callBibleApi(string $path, array $params = []): array
+{
+	if (!defined('BIBLE_API_APIKEY') || BIBLE_API_APIKEY === '') {
+		return [];
+	}
+
+    defined('BIBLE_API_URL') or define('BIBLE_API_URL', 'https://rest.api.bible/v1');
+	$url = BIBLE_API_URL . $path;
+	if ($params !== []) {
+		$url .= '?' . http_build_query($params);
+	}
+
+	$ch = curl_init();
+	curl_setopt_array($ch, [
+		CURLOPT_URL => $url,
+		CURLOPT_RETURNTRANSFER => true,
+		CURLOPT_HTTPHEADER => [
+			'api-key: ' . BIBLE_API_APIKEY,
+			'Accept: application/json',
+		],
+		CURLOPT_TIMEOUT => ifdef('BIBLE_API_TIMEOUT', 10),
+	]);
+
+	$response = curl_exec($ch);
+	$httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+	if ($response === false || $httpCode >= 400) {
+		$error = curl_error($ch);
+		$effectiveUrl = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+		curl_close($ch);
+		error_log("bibleapi: HTTP $httpCode for $path" . ($error ? " ($error)" : ""));
+		error_log("bibleapi: replicate with: curl -sv " . escapeshellarg($effectiveUrl) . " -H 'api-key: \$BIBLE_API_APIKEY'");
+		return [];
+	}
+
+	curl_close($ch);
+
+	$data = json_decode($response, true);
+	return is_array($data) ? $data : [];
+}
+
+// ===========================================================================
+// HTML parsing
+// ===========================================================================
+
+/**
+ * Parse scripture HTML from the upstream API, emitting only safe elements
+ * and attributes.  Everything else is dropped.
+ *
+ * Allowed: <p>, <span>, any class, and any data-* attribute (inert by definition).
+ *
+ * @return ?string Safe HTML, or null on empty/invalid
+ */
+function parseBibleHtml(string $html): ?string
+{
+	$html = trim($html);
+	if ($html === '') {
+		return null;
+	}
+
+	$doc = domParse($html);
+	if ($doc === null) {
+		return null;
+	}
+
+	// Strip unknown attributes: keep only class and data-*
+	$xpath = new \DOMXPath($doc);
+	foreach ($xpath->query('//*') as $el) {
+		foreach (iterator_to_array($el->attributes) as $attr) {
+			if ($attr->name !== 'class' && !str_starts_with($attr->name, 'data-')) {
+				$el->removeAttribute($attr->name);
+			}
+		}
+	}
+
+	return domSerialize($doc);
+}
+
+/**
+ * Parse an HTML fragment as XML, stripping unknown elements first.
+ * @return ?\DOMDocument
+ */
+function domParse(string $html): ?\DOMDocument
+{
+	$html = trim(strip_tags($html, '<p><span>'));
+	if ($html === '') {
+		return null;
+	}
+
+	// Named HTML entities (e.g. &nbsp; &mdash; &ldquo;) are not valid XML entities.
+	// Decode them to their actual Unicode characters, which are valid XML content.
+	$html = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+	$prev = libxml_use_internal_errors(true);
+	$doc = new \DOMDocument();
+	if (!$doc->loadXML('<root>' . $html . '</root>', \LIBXML_NOERROR | \LIBXML_NOWARNING)) {
+		libxml_use_internal_errors($prev);
+		return null;
+	}
+	libxml_use_internal_errors($prev);
+
+	return $doc;
+}
+
+/**
+ * Serialise the children of a document's root element via saveHTML().
+ * @return ?string
+ */
+function domSerialize(\DOMDocument $doc): ?string
+{
+	$out = '';
+	foreach ($doc->documentElement->childNodes as $child) {
+		$out .= $doc->saveHTML($child);
+	}
+
+	return $out !== '' ? $out : null;
+}
+
+// ===========================================================================
+// Translation lookup
+// ===========================================================================
+
+/**
+ * Resolve a translation abbreviation (e.g. 'WBBE') to a specific Bible ID.
+ *
+ * Some translations exist in multiple editions (e.g. 7142879509583d59-01 through
+ * 7142879509583d59-04). This function groups matching IDs by their base ID and
+ * picks the lexicographically greatest (latest edition).
+ *
+ * @param string $name Translation abbreviation (case-insensitive)
+ * @return ?string Bible ID, or null if not found
+ */
+function resolveBibleId(string $name): ?string
+{
+	$translations = getBibleTranslations();
+
+	// 1. Direct ID match (e.g. '78a9f6124f344018-01' or '78a9f6124f344018')
+	if (isset($translations[$name])) {
+		return $name;
+	}
+	// Partial ID match: if they pass just the base (e.g. '78a9f6124f344018'),
+	// pick the lexicographically greatest edition
+	$baseIds = [];
+	foreach ($translations as $id => $info) {
+		if (str_starts_with($id, $name.'-')) {
+			$baseIds[] = $id;
+		}
+	}
+	if ($baseIds !== []) {
+		rsort($baseIds, \SORT_STRING);
+		return $baseIds[0];
+	}
+
+	// 2. Match by abbreviation or name (case-insensitive)
+	$matching = [];
+	foreach ($translations as $id => $info) {
+		if (strcasecmp($info['abbreviation'], $name) === 0 || strcasecmp($info['name'], $name) === 0) {
+			// Group by base ID (the part before the -NN suffix)
+			$base = preg_replace('/-\d+$/', '', $id);
+			$matching[$base][] = $id;
+		}
+	}
+
+	if ($matching !== []) {
+		// For each base group, pick the lexicographically greatest (latest edition)
+		$candidates = [];
+		foreach ($matching as $ids) {
+			rsort($ids, \SORT_STRING);
+			$candidates[] = $ids[0];
+		}
+		return $candidates[0];
+	}
+
+	return null;
+}
+
+/**
+ * Get available Bible translations from the API, filtered to English.
+ *
+ * @return array<string, array{name: string, abbreviation: string}> Bible ID => {name, abbreviation}
+ */
+function getBibleTranslations(): array
+{
+	static $cache = null;
+	if ($cache !== null) {
+		return $cache;
+	}
+
+	$result = callBibleApi('/bibles', ['language' => 'eng']);
+	$cache = [];
+    // Out of the 36 English bibles, testing shows these 5 don't actually work
+	$brokenBibles = [
+		'685d1470fe4d5c3b-01',
+		'6bab4d6c61b31b80-01',
+		'65bfdebd704a8324-01',
+		'bf8f1c7f3f9045a5-01',
+		'ec290b5045ff54a5-01',
+	];
+	foreach (($result['data'] ?? []) as $bible) {
+		if (in_array($bible['id'], $brokenBibles)) {
+			continue;
+		}
+		$cache[$bible['id']] = [
+			'name'         => $bible['name'] ?? '',
+			'abbreviation' => $bible['abbreviation'] ?? '',
+		];
+	}
+
+	// Put preferred translations first
+	$preferred = [
+		'78a9f6124f344018-01',
+		'a761ca71e0b3ddcf-01',
+		'a556c5305ee15c3f-01',
+		'de4e12af7f28f599-02',
+	];
+	$sorted = [];
+	foreach ($preferred as $id) {
+		if (isset($cache[$id])) {
+			$sorted[$id] = $cache[$id];
+		}
+	}
+	foreach ($cache as $id => $info) {
+		if (!isset($sorted[$id])) {
+			$sorted[$id] = $info;
+		}
+	}
+	$cache = $sorted;
+
+	return $cache;
+}
+

--- a/include/config_manager.class.php
+++ b/include/config_manager.class.php
@@ -33,6 +33,7 @@ class Config_Manager {
 		if (0 === strpos($symbol, 'SMS_')) return TRUE;
 		if (0 === strpos($symbol, '2FA_')) return TRUE;
 		if (0 === strpos($symbol, 'SMTP')) return TRUE;
+		if (0 === strpos($symbol, 'BIBLE_')) return TRUE;
 		return FALSE;
 	}
 
@@ -137,6 +138,8 @@ class Config_Manager {
 	public static function saveSetting($symbol, $value)
 	{
 		$db = $GLOBALS['db'];
+		// UPDATE-only: every valid setting symbol must already exist in the DB
+		// (created by installer.class.php or an upgrade SQL script).
 		$SQL = 'UPDATE setting
 				SET value = '.$db->quote($value).'
 				WHERE symbol = '.$db->quote($symbol);

--- a/include/config_manager.class.php
+++ b/include/config_manager.class.php
@@ -34,6 +34,7 @@ class Config_Manager {
 		if (0 === strpos($symbol, '2FA_')) return TRUE;
 		if (0 === strpos($symbol, 'SMTP')) return TRUE;
 		if (0 === strpos($symbol, 'MAILCHIMP_')) return TRUE;
+		if (0 === strpos($symbol, 'BIBLE_')) return TRUE;
 		return FALSE;
 	}
 
@@ -157,6 +158,8 @@ class Config_Manager {
 	public static function saveSetting($symbol, $value)
 	{
 		$db = $GLOBALS['db'];
+		// UPDATE-only: every valid setting symbol must already exist in the DB
+		// (created by installer.class.php or an upgrade SQL script).
 		$SQL = 'UPDATE setting
 				SET value = '.$db->quote($value).'
 				WHERE symbol = '.$db->quote($symbol);

--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -2565,6 +2565,37 @@ div#send-sms-modal div.results {
 	margin: 1em 1em 1em 5em;
 }
 
+
+/*************** SCRIPTURE VERSES *****************/
+
+.scripture-styles .v {
+	font-size: .7em;
+	font-weight: bold;
+	vertical-align: super;
+	line-height: 0;
+}
+
+
+.scripture-styles .v::after {
+	content: "\00a0";
+}
+
+.scripture-styles .s1 {
+	font-style: italic;
+}
+.scripture-styles .q1 {
+	margin-left: 0;
+}
+.scripture-styles .q2 {
+	margin-left: 1.5em;
+}
+.scripture-styles .q3 {
+	margin-left: 3em;
+}
+.scripture-styles .q4 {
+	margin-left: 4.5em;
+}
+
 /************ PRINT **************/
 @media print {
 	#jethro-overall-width, #jethro-overall-width-inner {

--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -2603,6 +2603,37 @@ div#send-sms-modal div.results {
 	margin: 1em 1em 1em 5em;
 }
 
+
+/*************** SCRIPTURE VERSES *****************/
+
+.scripture-styles .v {
+	font-size: .7em;
+	font-weight: bold;
+	vertical-align: super;
+	line-height: 0;
+}
+
+
+.scripture-styles .v::after {
+	content: "\00a0";
+}
+
+.scripture-styles .s1 {
+	font-style: italic;
+}
+.scripture-styles .q1 {
+	margin-left: 0;
+}
+.scripture-styles .q2 {
+	margin-left: 1.5em;
+}
+.scripture-styles .q3 {
+	margin-left: 3em;
+}
+.scripture-styles .q4 {
+	margin-left: 4.5em;
+}
+
 /************ PRINT **************/
 @media print {
 	#jethro-overall-width, #jethro-overall-width-inner {

--- a/scripts/biblelookup.php
+++ b/scripts/biblelookup.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Test the 'Bible Reading Downloads' feature, by looking up a Bible passage text
+ *  via the API.Bible REST API.
+ *
+ * Usage:
+ *   HTTP_HOST=jethro.mychurch.org php scripts/biblelookup.php "John 3:16-17"
+ *   HTTP_HOST=jethro.mychurch.org php scripts/biblelookup.php --translation=CSB "Genesis 1:1"
+ */
+
+// Bootstrap Jethro
+if (!defined('JETHRO_ROOT')) {
+	define('JETHRO_ROOT', dirname(__DIR__));
+}
+set_include_path(get_include_path().PATH_SEPARATOR.JETHRO_ROOT);
+if (!is_readable(JETHRO_ROOT.'/conf.php')) {
+	throw new RuntimeException('Jethro configuration file not found. You need to copy conf.php.sample to conf.php and edit it before Jethro can run');
+}
+require_once JETHRO_ROOT.'/conf.php';
+define('DB_MODE', 'private');
+require_once JETHRO_ROOT.'/include/init.php';
+require_once JETHRO_ROOT.'/include/user_system.class.php';
+$GLOBALS['user_system'] = new User_System();
+$GLOBALS['user_system']->setCLIScript();
+require_once JETHRO_ROOT.'/include/system_controller.class.php';
+$GLOBALS['system'] = System_Controller::get();
+
+require_once JETHRO_ROOT.'/include/bibleapi.php';
+
+$args = $_SERVER['argv'] ?? [];
+array_shift($args); // Remove script path
+
+if ($args && str_starts_with($args[0], '/')) {
+	// Passthrough mode: first arg is the API path, remaining --key=value become query params
+	$path = array_shift($args);
+	$params = [];
+	foreach ($args as $arg) {
+		if (preg_match('/^--(.+?)=(.+)$/', $arg, $m)) {
+			$params[$m[1]] = $m[2];
+		}
+	}
+	$result = callBibleApi($path, $params);
+	echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n";
+	exit(empty($result) ? 1 : 0);
+}
+
+$referenceParts = [];
+
+$showBibles = false;
+$translation = null;
+for ($i = 0, $n = count($args); $i < $n; $i++) {
+	$arg = $args[$i];
+	if ($arg === '--bibles') {
+		$showBibles = true;
+	} elseif ($arg === '--translation') {
+		$translation = $args[++$i] ?? null;
+	} elseif (str_starts_with($arg, '--translation=')) {
+		$translation = substr($arg, strlen('--translation='));
+	} elseif (!str_starts_with($arg, '--')) {
+		$referenceParts[] = $arg;
+	}
+}
+
+$reference = implode(' ', $referenceParts);
+
+if ($showBibles) {
+	$translations = getBibleTranslations();
+	foreach ($translations as $id => $info) {
+		echo sprintf("%-40s %-10s %s\n", $id, $info['abbreviation'], $info['name']);
+	}
+	exit(empty($translations) ? 1 : 0);
+}
+
+if ($reference === '') {
+	echo "Usage: HTTP_HOST=jethro.mychurch.org php scripts/biblelookup.php [--translation=NIV] <reference>\n";
+	echo "   or: HTTP_HOST=jethro.mychurch.org php scripts/biblelookup.php /path [--param=value ...]\n\n";
+	echo "Examples:\n";
+	echo "  HTTP_HOST=jethro.mychurch.org php scripts/biblelookup.php \"John 3:16-17\"\n";
+	echo "  HTTP_HOST=jethro.mychurch.org php scripts/biblelookup.php --translation=CSB \"Genesis 1:1\"\n";
+	echo "  HTTP_HOST=jethro.mychurch.org php scripts/biblelookup.php /bibles/78a9f6124f344018-01/verses/JHN.3.16\n";
+	exit(1);
+}
+
+$bibleId = isset($translation) ? resolveBibleId($translation) : APIBIBLE_NIV;
+if ($bibleId === null) {
+	echo "Error: Translation '$translation' not found.\n";
+	echo "Run with --bibles to see available translations.\n";
+	exit(1);
+}
+
+$result = fetchBiblePassage($reference, $bibleId);
+
+if ($result === null) {
+	echo "Error: Could not fetch passage.\n";
+	exit(1);
+}
+
+[$text, $attribution] = $result;
+
+echo $text . "\n";
+echo "\n" . strip_tags($attribution) . "\n";

--- a/upgrades/2026-upgrade-to-2.39.sql
+++ b/upgrades/2026-upgrade-to-2.39.sql
@@ -1,0 +1,27 @@
+ALTER TABLE setting MODIFY `type` varchar(512);
+
+UPDATE `setting`
+SET `type` = REPLACE(`type`, '}', ',"BIBLE_API":"Bible Reading Downloads"}')
+WHERE `symbol` = 'ENABLED_FEATURES'
+  AND `type` NOT LIKE '%"BIBLE_API"%';
+
+-- Bible API settings (used by include/bibleapi.php)
+-- COALESCE: if MULTI_EMAIL_SEPARATOR is absent (older installs), fall back to
+-- the current highest rank so the new settings land at the bottom.
+SET @rankBase = COALESCE(
+	(SELECT `rank` FROM setting WHERE symbol = 'MULTI_EMAIL_SEPARATOR'),
+	(SELECT MAX(`rank`) FROM setting)
+);
+UPDATE setting SET `rank` = `rank` + 15 WHERE `rank` > @rankBase;
+
+INSERT IGNORE INTO `setting` (`symbol`, `type`, `heading`, `value`, `note`, `rank`)
+VALUES
+	('BIBLE_API_URL', 'text', 'Bible Reading Lookup', 'https://rest.api.bible/v1', 'Bible Reading Lookups — Base URL for the REST API, e.g. https://rest.api.bible/v1', @rankBase+5),
+	('BIBLE_API_APIKEY', 'text', null, '', 'API key for https://api.bible', @rankBase+10),
+	('BIBLE_TRANSLATION_PREFERRED', 'text', null, '', 'Preferred Bible translation for bible reading lookups in service handouts.', @rankBase+15);
+
+-- Should the instance happen to have these defined, enable content in handouts
+UPDATE service_component SET content_html='<p>%SERVICE_BIBLE_READ_1_CONTENT%</p>', show_in_handout='full' where title='Bible Reading 1';
+UPDATE service_component SET content_html='<p>%SERVICE_BIBLE_READ_2_CONTENT%</p>', show_in_handout='full' where title='Bible Reading 2';
+UPDATE service_component SET content_html='<p>%SERVICE_BIBLE_READ_3_CONTENT%</p>',show_in_handout='full' where title='Bible Reading 3';
+UPDATE service_component SET content_html='<p>%SERVICE_BIBLE_READ_4_CONTENT%</p>', show_in_handout='full' where title='Bible Reading 4';

--- a/upgrades/2026-upgrade-to-2.39.sql
+++ b/upgrades/2026-upgrade-to-2.39.sql
@@ -1,0 +1,23 @@
+ALTER TABLE setting MODIFY `type` varchar(512);
+
+
+-- Bible API settings (used by include/bibleapi.php)
+-- COALESCE: if MULTI_EMAIL_SEPARATOR is absent (older installs), fall back to
+-- the current highest rank so the new settings land at the bottom.
+SET @rankBase = COALESCE(
+	(SELECT `rank` FROM setting WHERE symbol = 'MULTI_EMAIL_SEPARATOR'),
+	(SELECT MAX(`rank`) FROM setting)
+);
+UPDATE setting SET `rank` = `rank` + 15 WHERE `rank` > @rankBase;
+
+INSERT IGNORE INTO `setting` (`symbol`, `type`, `heading`, `value`, `note`, `rank`)
+VALUES
+	('BIBLE_API_URL', 'text', 'Bible Reading Lookup', 'https://rest.api.bible/v1', 'Bible Reading Lookups — Base URL for the REST API, e.g. https://rest.api.bible/v1', @rankBase+5),
+	('BIBLE_API_APIKEY', 'text', null, '', 'API key for https://api.bible', @rankBase+10),
+	('BIBLE_TRANSLATION_PREFERRED', 'text', null, '', 'Preferred Bible translation for bible reading lookups in service handouts.', @rankBase+15);
+
+-- Should the instance happen to have these defined, enable content in handouts
+UPDATE service_component SET content_html='<p>%SERVICE_BIBLE_READ_1_CONTENT%</p>', show_in_handout='full' where title='Bible Reading 1';
+UPDATE service_component SET content_html='<p>%SERVICE_BIBLE_READ_2_CONTENT%</p>', show_in_handout='full' where title='Bible Reading 2';
+UPDATE service_component SET content_html='<p>%SERVICE_BIBLE_READ_3_CONTENT%</p>',show_in_handout='full' where title='Bible Reading 3';
+UPDATE service_component SET content_html='<p>%SERVICE_BIBLE_READ_4_CONTENT%</p>', show_in_handout='full' where title='Bible Reading 4';

--- a/views/view_10_admin__6_system_configuration.class.php
+++ b/views/view_10_admin__6_system_configuration.class.php
@@ -35,6 +35,9 @@ class View_Admin__System_Configuration extends View {
 				case '2FA_REQUIRED_PERMS':
 					$this->process2FARequiredPermsField();
 					break;
+                case 'BIBLE_TRANSLATION_PREFERRED':
+                    $this->processBibleTranslationPreferredOptions();
+                    break;
 				default:
 					if (isset($_REQUEST[$symbol])) {
 						list($params, $value, $multi) = self::getParamsAndValue($symbol, $details);
@@ -238,6 +241,10 @@ class View_Admin__System_Configuration extends View {
 			case '2FA_REQUIRED_PERMS':
 				$this->print2FARequiredPermsField();
 				break;
+
+            case 'BIBLE_TRANSLATION_PREFERRED':
+                $this->printBibleTranslationPreferredOptions();
+                break;
 			default:
 				list($params, $value, $multi) = self::getParamsAndValue($symbol, $details);
 				if ($multi) {
@@ -684,6 +691,29 @@ class View_Admin__System_Configuration extends View {
 		}
 
 	}
+    private function printBibleTranslationPreferredOptions(): void
+    {
+		require_once JETHRO_ROOT.'/include/bibleapi.php';
+		$translations = getBibleTranslations();
+		$current = defined('BIBLE_TRANSLATION_PREFERRED') ? constant('BIBLE_TRANSLATION_PREFERRED') : null;
+		?>
+		<select name="BIBLE_TRANSLATION_PREFERRED">
+			<option value="" <?php if ($current === null || $current === '') echo 'selected="selected"'; ?>>(not set)</option>
+			<?php foreach ($translations as $id => $info): ?>
+				<option value="<?php echo ents($id); ?>" <?php if ($id === $current) echo 'selected="selected"'; ?>>
+					<?php echo ents($info['abbreviation'] . ' — ' . $info['name']); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+		<?php
+    }
+
+    private function processBibleTranslationPreferredOptions(): void
+    {
+		if (isset($_REQUEST['BIBLE_TRANSLATION_PREFERRED'])) {
+			Config_Manager::saveSetting('BIBLE_TRANSLATION_PREFERRED', $_REQUEST['BIBLE_TRANSLATION_PREFERRED']);
+		}
+    }
 
 }
 

--- a/views/view_10_admin__6_system_configuration.class.php
+++ b/views/view_10_admin__6_system_configuration.class.php
@@ -35,6 +35,9 @@ class View_Admin__System_Configuration extends View {
 				case '2FA_REQUIRED_PERMS':
 					$this->process2FARequiredPermsField();
 					break;
+                case 'BIBLE_TRANSLATION_PREFERRED':
+                    $this->processBibleTranslationPreferredOptions();
+                    break;
 				default:
 					if (isset($_REQUEST[$symbol])) {
 						list($params, $value, $multi) = self::getParamsAndValue($symbol, $details);
@@ -312,6 +315,10 @@ class View_Admin__System_Configuration extends View {
 			case '2FA_REQUIRED_PERMS':
 				$this->print2FARequiredPermsField();
 				break;
+
+            case 'BIBLE_TRANSLATION_PREFERRED':
+                $this->printBibleTranslationPreferredOptions();
+                break;
 			default:
 				list($params, $value, $multi) = self::getParamsAndValue($symbol, $details);
 				if ($multi) {
@@ -758,6 +765,29 @@ class View_Admin__System_Configuration extends View {
 		}
 
 	}
+    private function printBibleTranslationPreferredOptions(): void
+    {
+		require_once JETHRO_ROOT.'/include/bibleapi.php';
+		$translations = getBibleTranslations();
+		$current = defined('BIBLE_TRANSLATION_PREFERRED') ? constant('BIBLE_TRANSLATION_PREFERRED') : null;
+		?>
+		<select name="BIBLE_TRANSLATION_PREFERRED">
+			<option value="" <?php if ($current === null || $current === '') echo 'selected="selected"'; ?>>(not set)</option>
+			<?php foreach ($translations as $id => $info): ?>
+				<option value="<?php echo ents($id); ?>" <?php if ($id === $current) echo 'selected="selected"'; ?>>
+					<?php echo ents($info['abbreviation'] . ' — ' . $info['name']); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+		<?php
+    }
+
+    private function processBibleTranslationPreferredOptions(): void
+    {
+		if (isset($_REQUEST['BIBLE_TRANSLATION_PREFERRED'])) {
+			Config_Manager::saveSetting('BIBLE_TRANSLATION_PREFERRED', $_REQUEST['BIBLE_TRANSLATION_PREFERRED']);
+		}
+    }
 
 }
 


### PR DESCRIPTION

As background: in Jethro it is common to define a "bible reading" service component, with tokenized 'Handout Title
Format', e.g.:

```
Bible Readings: %SERVICE_BIBLE_READ_ALL%
Bible Reading 1: %SERVICE_BIBLE_READ_1%
Bible Reading 2: %SERVICE_BIBLE_READ_2%
...
```

In the handout this expands to, e.g. 'Bible Reading 1: John 3:16'.

Now, "bible readings" service components can also have their 'Content' set to a token:

```
%SERVICE_BIBLE_READ_ALL_CONTENT%
%SERVICE_BIBLE_READ_1_CONTENT%
%SERVICE_BIBLE_READ_2_CONTENT%
...
```

These expand to the text of the passage, e.g.:

<img width="1214" height="692" alt="image" src="https://github.com/user-attachments/assets/a4c29074-fce2-43f3-8472-8de2d09a6063" />


For this to work, one must:
1) sign up to https://api.bible, and obtain an API key
2) In Jethro's System configuration page:

 - enable the 'Bible Reading Downloads' feature
     <img width="691" height="362" alt="image" src="https://github.com/user-attachments/assets/7f744bdb-0507-46df-a060-d915091ae177" />

 - in the 'Bible Reading Lookup' section, set the 'Bible Api Apikey' to the API key
     <img width="838" height="338" alt="image" src="https://github.com/user-attachments/assets/e1cfa76f-391e-4985-8bcf-db836a7164a7" />

3) Edit one's "Bible Reading" service components and:
 - Change 'Handout Visibility' from 'Include Title Only' to 'Include Title and Content'
 - set the 'Content' field to the relevant `%*_CONTENT%` token.
      <img width="1693" height="715" alt="image" src="https://github.com/user-attachments/assets/00329bbc-d54b-4471-ba1b-eb4e0a47b8bc" />

4) Edit relevant service runsheets, edit the Bible Reading item, 'Edit item detail' and change 'Show in handout?' to
   'Title and Content'.

For rendering, API.Bible provide a very nice CSS stylesheet, which is used via hyperlink in the 'Printable' view (if the
feature is enabled). We cannot bundle it as copyright is unclear:
<img width="1001" height="932" alt="image" src="https://github.com/user-attachments/assets/8a2e149b-7336-4d36-8db0-dbb7c34a45f1" />
For non-printable, simpler hand-rolled CSS fitting our l&f is used.

If 'Bible Reading Downloads' feature is turned off or the API key is unset, %*_CONTENT% tokens expand to blank.

There is also a 'Bible Translation Preferred' config setting, populated (once API key is set) from those available from API.Bible. Note that API.Bible has NIV, CSB, KJV, NKJV and many other translations, but lacks ESV, NLT, RSV and NASB.

For testing purposes, a scripts/biblelookup.php script is provided, which allows command-line lookup of bible readings
for different translations, and a list of bibles.
