### PR TITLE
Optional support for Unicode SMSes, plus more SMS accurate cost calculation

### DIFF
--- a/conf.php.sample
+++ b/conf.php.sample
@@ -155,6 +155,14 @@ define('2FA_ENABLED', true);
 // Cost of sending a single SMS segment, for cost estimation purposes.
 //define('SMS_SEGMENT_COST', 0.05);
 
+// Whether to allow Unicode characters (e.g. emoji) in SMS messages. Be aware that even a single unicode character doubles the cost for >70 char messages.
+// 1 = allow Unicode freely
+// 0 = disable Unicode entirely — only GSM 03.38 characters are allowed and
+//     non-GSM characters will prevent the form from submitting.
+// 'when_free' = allow Unicode for messages ≤70 chars (single UCS-2 segment).
+//     Longer messages with non-GSM chars will be blocked.
+//define('SMS_UNICODE_PERMITTED', 'when_free');
+
 
 ///////////////////////////////////////////////////////////////////////////
 // SMTP SETTINGS - These can also be configured in the web interface,
@@ -277,7 +285,3 @@ define('2FA_ENABLED', true);
 // For troubleshooting you can use this to show error details in the browser
 // This is usually disabled in production versions but shown in dev.
 // define('SHOW_ERROR_DETAILS', TRUE);
-
-// Text encoding for sending SMS messages.
-// Change it to something other than GSM0338 to stop Jethro filtering out non-GSMS0338 characters.
-// define('SMS_ENCODING', 'GSM0338');

--- a/include/sms_sender.class.php
+++ b/include/sms_sender.class.php
@@ -82,67 +82,6 @@ Class SMS_Sender
 	}
 
 	/**
-	 * Remove invalid characters from message.
-	 * Only understands GSM0338 at the moment - any other charset does not get filtered.
-	 * @see SMS_ENCODING setting/constant.  Defaults to GSM0338.
-	 * @param string $message
-	 * @return string
-	 */
-	private static function cleanseMessage($message)
-	{
-		$encoding = strtoupper(ifdef('SMS_ENCODING', 'GSM0338'));
-		switch ($encoding) {
-			case 'GSM0338':
-				$gsm0338 = array(
-					'@','Δ',' ','0','¡','P','¿','p',
-					'£','_','!','1','A','Q','a','q',
-					'$','Φ','"','2','B','R','b','r',
-					'¥','Γ','#','3','C','S','c','s',
-					'è','Λ','¤','4','D','T','d','t',
-					'é','Ω','%','5','E','U','e','u',
-					'ù','Π','&','6','F','V','f','v',
-					'ì','Ψ','\'','7','G','W','g','w',
-					'ò','Σ','(','8','H','X','h','x',
-					'Ç','Θ',')','9','I','Y','i','y',
-					"\n",'Ξ','*',':','J','Z','j','z',
-					'Ø',"\x1B",'+',';','K','Ä','k','ä',
-					'ø','Æ',',','<','L','Ö','l','ö',
-					"\r",'æ','-','=','M','Ñ','m','ñ',
-					'Å','ß','.','>','N','Ü','n','ü',
-					'å','É','/','?','O','§','o','à'
-				 );
-				if (function_exists('mb_strlen')) {
-					$len = mb_strlen($message, 'UTF-8');
-					$out = '';
-					for ($i=0; $i < $len; $i++) {
-						$char = mb_substr($message,$i,1,'UTF-8');
-						if (in_array($char, $gsm0338)) {
-							$out .= $char;
-						} else {
-							error_log('SMS sender Discarded invalid char "'.$char.'" (ord '.ord($char).')');
-						}
-					}
-					return $out;
-				} else {
-					$len = strlen($message);
-					$out = '';
-					for ($i=0; $i < $len; $i++) {
-						$char = substr($message,$i,1);
-						if (in_array($char, $gsm0338)) {
-							$out .= $char;
-						} else {
-							error_log('SMS sender Discarded invalid char "'.$char.'" (ord '.ord($char).')');
-						}
-					}
-					return $out;
-
-				}
-		}
-		return $message;
-
-	}
-
-	/**
 	 * Returns whether the _USER_MOBILE_ keyword is used, and therefore we
 	 * need a current user or OVERRIDE_USER_MOBILE set.
 	 */
@@ -167,7 +106,6 @@ Class SMS_Sender
 	 */
 	public static function sendMessage($message, $recips, $saveAsNote=FALSE)
 	{
-		$message = self::cleanseMessage($message);
 		$mobile_tels = Array();
 		if (!empty($recips)) {
 			foreach ($recips as $recip) {
@@ -354,7 +292,16 @@ Class SMS_Sender
 	public static function printTextbox()
 	{
 		?>
-		<textarea id="sms_message" name="message" data-segment-length="<?php echo ifdef('SMS_SEGMENT_LENGTH', 160); ?>" data-segment-cost="<?php echo ifdef('SMS_SEGMENT_COST', "0"); ?>" class="span4" rows="5" cols="30" maxlength="<?php echo SMS_MAX_LENGTH; ?>"></textarea>
+		<textarea id="sms_message" name="message" data-segment-length="<?php echo ifdef('SMS_SEGMENT_LENGTH', 160); ?>" data-segment-cost="<?php echo ifdef('SMS_SEGMENT_COST', "0"); ?>" <?php
+			$smsUnicode = ifdef('SMS_UNICODE_PERMITTED', 'when_free');
+			if ($smsUnicode === 0 || $smsUnicode === '0') {
+				echo 'data-sms-unicode-permitted="0" ';
+			} elseif ($smsUnicode === 'when_free' || $smsUnicode === 2 || $smsUnicode === '2') {
+				echo 'data-sms-unicode-permitted="when_free" ';
+			} elseif ($smsUnicode === 1 || $smsUnicode === '1') {
+				echo 'data-sms-unicode-permitted="1" ';
+			}
+		?>class="span4" rows="5" cols="30" maxlength="<?php echo SMS_MAX_LENGTH; ?>"></textarea>
 		<div class="smscharactercount soft"><?php echo SMS_MAX_LENGTH; ?> characters remaining.</div>
 		<?php
 	}

--- a/resources/js/jethro-sms-test.js
+++ b/resources/js/jethro-sms-test.js
@@ -1,0 +1,180 @@
+/**
+ * JethroSMS Boundary Test Script
+ * ================================
+ * Paste this entire file into your browser console (on a page that has
+ * JethroSMS loaded, e.g. the SMS sender page) and run:
+ *
+ *     JethroSMSTest.run();
+ *
+ * Results will be logged to the console as ✅ PASS or ❌ FAIL.
+ */
+
+var JethroSMSTest = {};
+
+JethroSMSTest.assert = function(label, actual, expected) {
+	var pass = actual === expected;
+	console.log(
+		(pass ? '✅' : '❌') + ' ' + label
+		+ ' — got: ' + JSON.stringify(actual)
+		+ (pass ? '' : ', expected: ' + JSON.stringify(expected))
+	);
+};
+
+JethroSMSTest.run = function() {
+	console.log('=== GSM Segment Count Tests ===');
+
+	// 1. Single segment boundaries
+	JethroSMSTest.assert('1 char → 1 segment',
+		JethroSMS.gsmSegmentCount(1), 1);
+	JethroSMSTest.assert('160 chars → 1 segment (max single)',
+		JethroSMS.gsmSegmentCount(160), 1);
+
+	// 2. Multi-segment boundaries
+	JethroSMSTest.assert('161 chars → 2 segments (first multi)',
+		JethroSMS.gsmSegmentCount(161), 2);
+	JethroSMSTest.assert('306 chars → 2 segments (exactly fills 2)',
+		JethroSMS.gsmSegmentCount(306), 2);
+	JethroSMSTest.assert('307 chars → 3 segments (overflows 3rd)',
+		JethroSMS.gsmSegmentCount(307), 3);
+	JethroSMSTest.assert('459 chars → 3 segments (exactly fills 3)',
+		JethroSMS.gsmSegmentCount(459), 3);
+	JethroSMSTest.assert('460 chars → 4 segments (overflows 4th)',
+		JethroSMS.gsmSegmentCount(460), 4);
+
+	console.log('=== Extended Char (GSM) Tests ===');
+
+	// 3. Extended chars count as 2
+	var euro160 = '€'.repeat(80);  // 80 × 2 = 160 effective length
+	JethroSMSTest.assert('80 × € (eff len 160) → 1 segment',
+		JethroSMS.gsmSegmentCount(JethroSMS.gsmLength(euro160)), 1);
+
+	var euro161 = '€'.repeat(81);  // 81 × 2 = 162 effective length
+	JethroSMSTest.assert('81 × € (eff len 162) → 2 segments',
+		JethroSMS.gsmSegmentCount(JethroSMS.gsmLength(euro161)), 2);
+
+	var euro153 = '€'.repeat(153); // 153 × 2 = 306 effective length
+	JethroSMSTest.assert('153 × € (eff len 306) → 2 segments (exactly fills 2)',
+		JethroSMS.gsmSegmentCount(JethroSMS.gsmLength(euro153)), 2);
+
+	var euro154 = '€'.repeat(154); // 154 × 2 = 308 effective length
+	JethroSMSTest.assert('154 × € (eff len 308) → 3 segments',
+		JethroSMS.gsmSegmentCount(JethroSMS.gsmLength(euro154)), 3);
+
+	console.log('=== UCS-2 Segment Count Tests ===');
+
+	// 4. UCS-2 boundaries
+	// Single segment: 70 chars. Concatenated: 67 chars per segment.
+	JethroSMSTest.assert('1 UCS-2 char → 1 segment',
+		JethroSMS.ucs2SegmentCount(1), 1);
+	JethroSMSTest.assert('70 UCS-2 chars → 1 segment (max single)',
+		JethroSMS.ucs2SegmentCount(70), 1);
+	JethroSMSTest.assert('71 UCS-2 chars → 2 segments (first multi)',
+		JethroSMS.ucs2SegmentCount(71), 2);
+	JethroSMSTest.assert('134 UCS-2 chars → 2 segments (exactly fills 2)',
+		JethroSMS.ucs2SegmentCount(134), 2);
+	JethroSMSTest.assert('135 UCS-2 chars → 3 segments (overflows 3rd)',
+		JethroSMS.ucs2SegmentCount(135), 3);
+	JethroSMSTest.assert('201 UCS-2 chars → 3 segments (exactly fills 3)',
+		JethroSMS.ucs2SegmentCount(201), 3);
+	JethroSMSTest.assert('202 UCS-2 chars → 4 segments (overflows 4th)',
+		JethroSMS.ucs2SegmentCount(202), 4);
+
+	console.log('=== GSM Length (effective) Tests ===');
+
+	JethroSMSTest.assert('"a" → eff len 1',
+		JethroSMS.gsmLength('a'), 1);
+	JethroSMSTest.assert('"€" → eff len 2 (extended)',
+		JethroSMS.gsmLength('€'), 2);
+	JethroSMSTest.assert('"a€" → eff len 3',
+		JethroSMS.gsmLength('a€'), 3);
+	JethroSMSTest.assert('"€€" → eff len 4',
+		JethroSMS.gsmLength('€€'), 4);
+
+	console.log('=== Non-GSM Detection Tests ===');
+
+	JethroSMSTest.assert('"Hello" → no non-GSM chars',
+		JethroSMS.getNonGsmChars('Hello').length, 0);
+	JethroSMSTest.assert('"😊" → 2 non-GSM chars (surrogate pair)',
+		JethroSMS.getNonGsmChars('😊').length, 2);
+	JethroSMSTest.assert('"Hello😊" → 2 non-GSM chars (surrogate pair)',
+		JethroSMS.getNonGsmChars('Hello😊').length, 2);
+	JethroSMSTest.assert('"€" → 0 non-GSM (is extended GSM)',
+		JethroSMS.getNonGsmChars('€').length, 0);
+
+	console.log('=== Warning Logic Tests ===');
+	console.log('(These simulate what updateCharCount does internally)');
+
+	// Helper: simulate the warning logic (warns if message > 70 chars with non-GSM chars)
+	function shouldWarn(text) {
+		var nonGsmChars = JethroSMS.getNonGsmChars(text);
+		if (nonGsmChars.length === 0) return false;
+		return text.length > 70;
+	}
+
+	JethroSMSTest.assert('"Hello 😊" → no warning (same segments)',
+		shouldWarn('Hello 😊'), false);
+
+	JethroSMSTest.assert('"😊" only → no warning (empty GSM)',
+		shouldWarn('😊'), false);
+
+	JethroSMSTest.assert('"Hello😊" + 155 a\'s → warning (1 vs 3 segments)',
+		shouldWarn('Hello😊' + 'a'.repeat(155)), true);
+
+	JethroSMSTest.assert('"Hello😊" + 150 a\'s → warning (1 vs 3 segments)',
+		shouldWarn('Hello😊' + 'a'.repeat(150)), true);
+
+	JethroSMSTest.assert('"Hello😊" + 65 a\'s → warning (72 chars = 2 UCS-2 segments vs 1 GSM)',
+		shouldWarn('Hello😊' + 'a'.repeat(65)), true);
+
+	JethroSMSTest.assert('"Hello😊" + 66 a\'s → warning (1 vs 2 segments)',
+		shouldWarn('Hello😊' + 'a'.repeat(66)), true);
+
+	console.log('=== Unicode Mode Tests ===');
+	// Note: getNonGsmChars() does not inspect the unicodeMode flag; these tests
+	// confirm that the underlying char-detection is independent of the flag state.
+
+	// Save original flag state
+	var origUnicodeMode = JethroSMS.unicodeMode;
+
+	// 10. All-GSM text has no non-GSM chars regardless of unicodeMode
+	JethroSMS.unicodeMode = 'disabled';
+	JethroSMSTest.assert('unicodeMode=disabled, all-GSM text → no non-GSM chars',
+		JethroSMS.getNonGsmChars('Hello world').length, 0);
+
+	// 11. Non-GSM text is always detected regardless of unicodeMode
+	JethroSMSTest.assert('unicodeMode=disabled, non-GSM text → has non-GSM chars',
+		JethroSMS.getNonGsmChars('Hello😊').length, 2);
+
+	// 12. unicodeMode = enabled with non-GSM text (normal behavior)
+	JethroSMS.unicodeMode = 'enabled';
+	JethroSMSTest.assert('unicodeMode=enabled, non-GSM text → has non-GSM chars',
+		JethroSMS.getNonGsmChars('Hello😊').length, 2);
+
+	// 13. unicodeMode = when_free, non-GSM chars in a long message (>70 chars) → blocked
+	//     "Hello😊" + 65 a's = 72 chars → blocked
+	JethroSMS.unicodeMode = 'when_free';
+	JethroSMSTest.assert('unicodeMode=when_free, "Hello😊" + 65 a\'s (72 chars) → would save segment',
+		(function() {
+			var text = 'Hello😊' + 'a'.repeat(65);
+			var nonGsmChars = JethroSMS.getNonGsmChars(text);
+			return nonGsmChars.length > 0 && text.length > 70;
+		})(), true);
+
+	// 14. unicodeMode = when_free, non-GSM chars in a short message (≤70 chars) → allowed
+	JethroSMSTest.assert('unicodeMode=when_free, "Hi😊" (4 chars) → would NOT save segment',
+		(function() {
+			var text = 'Hi😊';
+			var nonGsmChars = JethroSMS.getNonGsmChars(text);
+			return nonGsmChars.length > 0 && text.length > 70;
+		})(), false);
+
+	// 15. All-GSM text has no non-GSM chars regardless of unicodeMode
+	JethroSMSTest.assert('unicodeMode=when_free, all-GSM text → no non-GSM chars (flag does not affect getNonGsmChars)',
+		JethroSMS.getNonGsmChars('Hello world').length, 0);
+
+	// Restore original flag
+	JethroSMS.unicodeMode = origUnicodeMode;
+
+	console.log('=== All tests complete ===');
+};
+JethroSMSTest.run();

--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -391,7 +391,7 @@ $(document).ready(function() {
 				.attr('disabled', false)
 				.filter('[type!=radio]:visible:first').focus();
 		selectedInputs.filter('[data-toggle=enable]').attr('disabled', false).change();
-	}).change();;
+	}).change();
 
 	$('form.bulk-person-action').submit(function(event) {
 		var checkboxes = document.getElementsByName('personid[]');
@@ -808,13 +808,56 @@ JethroSearchChooserSingle.reinit = function(inputBox) {
 
 /************* SMS ****************/
 
+// =============================================================================
+// JethroSMS — SMS sending and character-counting module
+// =============================================================================
+// This module handles:
+//   - Real-time character counting with GSM 03.38 / UCS-2 segment calculation.
+//   - Unicode restriction enforcement (disabled / when_free modes)
+//   - Bulk SMS form submission via AJAX
+//   - Modal SMS dialog submission via AJAX
+// =============================================================================
+
 var JethroSMS = {};
 
+/**
+ * Initialise the SMS module.
+ * Called once on page load.  Reads the unicode-enabled flag from the textarea's
+ * data-sms-unicode-permitted attribute, attaches event listeners for character
+ * counting, modal dialog triggers, and both submit handlers.
+ */
 JethroSMS.init = function() {
 
-	// SMS Character counting
+	// -----------------------------------------------------------------------
+	// Read unicode restriction mode from the textarea's data attribute.
+	// The PHP layer sets data-sms-unicode-permitted based on the
+	// SMS_UNICODE_PERMITTED config constant:
+	//   absent / undefined  →  Unicode allowed freely (SMS_UNICODE_PERMITTED=1)
+	//   "1"                 →  Unicode allowed freely (SMS_UNICODE_PERMITTED=1)
+	//   "0"                 →  Unicode fully disabled  (SMS_UNICODE_PERMITTED=0)
+	//   "when_free"         →  Block only if the message is >70 chars (i.e.
+	//                          would need more than one UCS-2 segment)
+	// -----------------------------------------------------------------------
+	var attr = $('#sms_message').attr('data-sms-unicode-permitted');
+	if (attr === '0') {
+		JethroSMS.unicodeMode = 'disabled';
+	} else if (attr === 'when_free') {
+		JethroSMS.unicodeMode = 'when_free';
+	} else {
+		JethroSMS.unicodeMode = 'enabled'; // '1' or absent
+	}
+
+	// -----------------------------------------------------------------------
+	// Attach real-time character counting to the SMS message textarea.
+	// Fires on every keystroke, paste, or property change.
+	// -----------------------------------------------------------------------
 	$('.smscharactercount').parent().find('textarea').on('keyup propertychange paste', JethroSMS.updateCharCount);
 
+	// -----------------------------------------------------------------------
+	// Modal SMS dialog trigger.
+	// When a [data-toggle="sms-modal"] element is clicked, populate the modal
+	// with recipient info and show it.
+	// -----------------------------------------------------------------------
 	$(document).on('click', '[data-toggle="sms-modal"]', function(e) {
 		var $this = $(this)
 				, href = $this.attr('href')
@@ -824,6 +867,7 @@ JethroSMS.init = function() {
 		var $recipients = $this.attr('data-name');
 		var $personid = $this.attr('data-personid');
 
+		// Populate the modal with recipient names and clear previous state
 		$("#send-sms-modal .sms_recipients").html($recipients);
 		$("#sms_message").val(""); // Empty the textarea in case of reuse
 		$("#send-sms-modal .results").html(""); // Empty in case of reuse
@@ -840,11 +884,15 @@ JethroSMS.init = function() {
 		} else {
 			alert('No SMS recipients found');
 		}
+		// Initialise character count display for the empty textarea
 		JethroSMS.updateCharCount.apply($("#sms_message").get(0));
-		
-
 	});
 
+	// -----------------------------------------------------------------------
+	// Bulk SMS submit handler (list view).
+	// Validates that recipients are selected, checks unicode restrictions,
+	// then sends the message via AJAX.
+	// -----------------------------------------------------------------------
 	$('.bulk-sms-submit').click(function(event) {
 		var checkboxes = document.getElementsByName('personid[]');
 		if ($("input[name='personid[]']:checked").length === 0) {
@@ -858,6 +906,7 @@ JethroSMS.init = function() {
 			}
 		}
 
+		// Disable the button and show "Sending..." while the AJAX call runs
 		event.preventDefault();
 		var submitBtn = $("#smshttp .bulk-sms-submit");
 		submitBtn.prop('disabled', true);
@@ -878,9 +927,7 @@ JethroSMS.init = function() {
 			success: function(data) {
 				var smsRequestCount = $("input[name='personid[]']:checked").length;
 				var resultsDiv = $('#bulk-sms-results');
-
 				JethroSMS.onAJAXSuccess(data, resultsDiv);
-
 			},
 			complete: function() {
 				var submitBtn = $("#smshttp .bulk-sms-submit");
@@ -891,6 +938,10 @@ JethroSMS.init = function() {
 		});
 	});
 
+	// -----------------------------------------------------------------------
+	// Modal SMS submit handler.
+	// Validates the message, checks unicode restrictions, then sends via AJAX.
+	// -----------------------------------------------------------------------
 	$('#send-sms-modal .sms-submit').on('click', function(event) {
 		event.preventDefault();
 		var resultsDiv = $("#send-sms-modal .results");
@@ -901,15 +952,17 @@ JethroSMS.init = function() {
 		if (!sms_message) {
 			alert("Please enter a message first.");
 			return false;
-		} else {
-			var smsData, personid;
+		}
+
+		// Disable the button and show "Sending..." while the AJAX call runs
+		var smsData, personid;
 			$(this).prop('disabled', true);
 			$(this).html("Sending...");
 			$("#send-sms-modal .results").hide();
 			var sendButton = $(this);
 			smsData = {
 				personid: modalDiv.attr("data-personid"),
-				saveasnote: ($("#send-sms-modal .saveasnote").attr("checked") === "checked") ? '1' : '0',
+				saveasnote: $("#send-sms-modal .saveasnote").is(":checked") ? '1' : '0',
 				ajax: 1,
 				message: sms_message
 			}
@@ -930,6 +983,7 @@ JethroSMS.init = function() {
 					var modalDiv = $("#send-sms-modal");
 					var showResults = JethroSMS.onAJAXSuccess(data, resultsDiv);
 					if (showResults) {
+						// Partial or all failures — show results in the modal
 						resultsDiv.show();
 						sendButton.html("Send");
 						sendButton.removeClass('sms-success');
@@ -945,7 +999,6 @@ JethroSMS.init = function() {
 				}
 			});
 			return false;
-		}
 	});
 }
 
@@ -962,21 +1015,148 @@ JethroSMS.setFocusedTextbox = function(box) {
 	}
 }
 
+/**
+ * Regex matching any GSM 03.38 character (basic or extended).
+ * Basic set: 128 chars from the GSM 03.38 default alphabet.
+ * Extended set: ^{}\[~]|€ — each counts as 2 chars in effective length.
+ *
+ * The regex is built from the GSM 03.38 code table:
+ *   @£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ
+ *   space !"#$%&'()*+,-./0123456789:;<=>?
+ *   ¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿
+ *   abcdefghijklmnopqrstuvwxyzäöñüà
+ */
+JethroSMS.GSM0338_RE = /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#$%&'()*+,\-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà€{}\[~\]|^\\]$/;
+JethroSMS.GSM0338_EXTENDED_RE = /[€{}\[~\]|^\\]/g;
+
+/**
+ * Check if a single character is valid GSM 03.38 (basic or extended).
+ */
+JethroSMS.isGsm0338 = function(char) {
+	return JethroSMS.GSM0338_RE.test(char);
+};
+
+/**
+ * Check if a message contains any non-GSM 03.38 characters (e.g. emojis).
+ * Returns an array of the problematic characters (unique).
+ */
+JethroSMS.getNonGsmChars = function(text) {
+	var seen = {};
+	for (var i = 0; i < text.length; i++) {
+		var char = text.charAt(i);
+		if (!JethroSMS.GSM0338_RE.test(char)) {
+			seen[char] = true;
+		}
+	}
+	return Object.keys(seen);
+};
+
+/**
+ * Calculate the effective length of a message in GSM 03.38 encoding.
+ * Extended characters count as 2.
+ */
+JethroSMS.gsmLength = function(text) {
+	// Count extended chars, then add total length
+	var extCount = (text.match(JethroSMS.GSM0338_EXTENDED_RE) || []).length;
+	return text.length + extCount;
+};
+
+/**
+ * Calculate the number of GSM 03.38 segments a message will use.
+ * Single segment: 160 chars. Concatenated (multi-segment): 153 chars per segment
+ * (7 bytes lost to the UDH header).
+ */
+JethroSMS.gsmSegmentCount = function(effectiveLength) {
+	if (effectiveLength <= 160) return 1;
+	return Math.ceil((effectiveLength - 153) / 153) + 1;
+};
+
+/**
+ * Calculate the number of UCS-2 segments a message will use.
+ * Single segment: 70 chars. Concatenated (multi-segment): 67 chars per segment
+ * (6 bytes lost to the UDH header).
+ */
+JethroSMS.ucs2SegmentCount = function(charLength) {
+	if (charLength <= 70) return 1;
+	return Math.ceil((charLength - 67) / 67) + 1;
+};
+
 JethroSMS.updateCharCount = function() {
 	JethroSMS.setFocusedTextbox(this);
 	var maxlength = $(this).attr('maxlength');
 	var rawtext = this.value;
-	// Count the "extended" characters that use 2 bytes in GSM 03.38 https://en.wikipedia.org/wiki/GSM_03.38
-	var wideCharacterCount = rawtext.replace(/[^€~{}^|\[\]\\]/g,'').length;
-	var currentLength = rawtext.length + wideCharacterCount;
-	var charsRemain = maxlength - currentLength;
-	var segmentLength = $(this).attr('data-segment-length');
-	var segmentCount = 1;
-	if (segmentLength && currentLength) {
-		segmentCount = Math.ceil(currentLength / segmentLength);
-		var segmentCost = $(this).attr('data-segment-cost');
-		var recipientCount = 0;
+	var segmentLength = parseInt($(this).attr('data-segment-length'), 10) || 160;
+	var ucs2SegmentLength = parseInt($(this).attr('data-ucs2-segment-length'), 10) || 70;
+	var segmentCost = parseFloat($(this).attr('data-segment-cost')) || 0;
 
+	// Detect non-GSM characters
+	var nonGsmChars = JethroSMS.getNonGsmChars(rawtext);
+	var hasNonGsm = nonGsmChars.length > 0;
+
+	// Calculate GSM 03.38 effective length (extended chars count as 2)
+	var gsmEffectiveLength = JethroSMS.gsmLength(rawtext);
+
+	// Calculate segment counts
+	var gsmSegmentCount = hasNonGsm ? 0 : JethroSMS.gsmSegmentCount(gsmEffectiveLength);
+	var ucs2SegmentCount = hasNonGsm ? JethroSMS.ucs2SegmentCount(rawtext.length) : 0;
+
+	// Determine which encoding will be used
+	var useUcs2 = hasNonGsm;
+	var effectiveSegmentCount = useUcs2 ? ucs2SegmentCount : gsmSegmentCount;
+	var effectiveLength = useUcs2 ? rawtext.length : gsmEffectiveLength;
+
+	// Build the message
+	var msg = '';
+
+	// Determine if the message is blocked by unicode restrictions
+	var isBlocked = false;
+	if (hasNonGsm && JethroSMS.unicodeMode === 'disabled') {
+		isBlocked = true;
+	} else if (hasNonGsm && JethroSMS.unicodeMode === 'when_free' && rawtext.length > 70) {
+		isBlocked = true;
+	}
+
+	// Enable/disable send buttons based on blocked state
+	$('#smshttp .bulk-sms-submit, #send-sms-modal .sms-submit').prop('disabled', isBlocked);
+
+	// Unicode disabled mode — block non-GSM characters entirely
+	if (hasNonGsm && JethroSMS.unicodeMode === 'disabled') {
+		var displayChars = nonGsmChars.join('');
+		msg = 'Unicode characters are not allowed: ' + displayChars;
+		$(this).parent().find('.smscharactercount').html(msg);
+		return;
+	}
+
+	// When-free mode — block if the message is too long for a single UCS-2 segment
+	if (hasNonGsm && JethroSMS.unicodeMode === 'when_free' && rawtext.length > 70) {
+		var displayChars = nonGsmChars.slice(0, 3).join('');
+		if (nonGsmChars.length > 3) displayChars += '…';
+		msg = '⚠ Remove special characters (' + displayChars + ') to reduce SMS cost. ';
+		$(this).parent().find('.smscharactercount').html(msg);
+		return;
+	}
+
+	// Warning for non-GSM characters — only if removing them would save a segment
+	if (hasNonGsm) {
+		// Calculate what the GSM segment count would be without non-GSM chars
+		var gsmOnly = '';
+		for (var i = 0; i < rawtext.length; i++) {
+			var c = rawtext.charAt(i);
+			if (JethroSMS.isGsm0338(c)) gsmOnly += c;
+		}
+		var gsmOnlyLength = JethroSMS.gsmLength(gsmOnly);
+		var gsmOnlySegmentCount = JethroSMS.gsmSegmentCount(gsmOnlyLength);
+
+		if (gsmOnly.length > 0 && gsmOnlySegmentCount < ucs2SegmentCount) {
+			var displayChars = nonGsmChars.slice(0, 3).join('');
+			if (nonGsmChars.length > 3) displayChars += '…';
+			msg += '⚠ Use of special characters (' + displayChars + ') — doubles the cost. ';
+		}
+	}
+
+	// Segment info
+	if (effectiveSegmentCount > 0) {
+		var recipientCount = 0;
 		var modal = $(this).parents('#send-sms-modal');
 		if (modal.length) {
 			recipientCount = modal.attr('data-personid').split(',').length;
@@ -984,23 +1164,37 @@ JethroSMS.updateCharCount = function() {
 			recipientCount = $("input[name='personid[]']:checked").length;
 			if (!recipientCount) recipientCount = $("input[name='personid[]']").length;
 		}
-		if ((segmentCost > 0) && (recipientCount > 0)) {
-			var cost = segmentCount * recipientCount * segmentCost;
-			var plural = (segmentCount > 1) ? 's' : '';
-			msg = currentLength+' characters ('+segmentCount+' segment'+plural+') to '+recipientCount+' recipients = $'+cost.toFixed(2)+' approx.';
-		} else if (segmentCount <= 1) {
-			msg = (segmentLength - currentLength) + ' characters remaining in this message segment';
-		} else {
-			msg = currentLength+' characters = '+segmentCount+' message segments';
-		}
-		if (currentLength >= maxlength) {
-			msg = 'Max length reached. '+msg;
-		}
-	} else {
-		var msg = charsRemain + ' characters remaining';
-	}
-	$(this).parent().find('.smscharactercount').html(msg);
 
+		if (hasNonGsm) {
+			// Show UCS-2 segment info
+			if ((segmentCost > 0) && (recipientCount > 0)) {
+				var cost = ucs2SegmentCount * recipientCount * segmentCost;
+				var plural = (ucs2SegmentCount > 1) ? 's' : '';
+				msg += rawtext.length + ' chars (' + ucs2SegmentCount + ' UCS-2 segment' + plural + ') to ' + recipientCount + ' recipients = $' + cost.toFixed(2) + '.';
+			} else if (ucs2SegmentCount <= 1) {
+				msg += (ucs2SegmentLength - rawtext.length) + ' characters remaining in this UCS-2 segment';
+			} else {
+				msg += rawtext.length + ' characters = ' + ucs2SegmentCount + ' UCS-2 segments';
+			}
+		} else {
+			// Show GSM 03.38 segment info
+			if ((segmentCost > 0) && (recipientCount > 0)) {
+				var cost = gsmSegmentCount * recipientCount * segmentCost;
+				var plural = (gsmSegmentCount > 1) ? 's' : '';
+				msg = gsmEffectiveLength + ' characters (' + gsmSegmentCount + ' segment' + plural + ') to ' + recipientCount + ' recipients = $' + cost.toFixed(2) + '.';
+			} else if (gsmSegmentCount <= 1) {
+				msg = (segmentLength - gsmEffectiveLength) + ' characters remaining in this message segment';
+			} else {
+				msg = gsmEffectiveLength + ' characters = ' + gsmSegmentCount + ' message segments';
+			}
+		}
+
+		if (effectiveLength >= maxlength) {
+			msg = 'Max length reached. ' + msg;
+		}
+	}
+
+	$(this).parent().find('.smscharactercount').html(msg);
 }
 
 /**
@@ -1037,7 +1231,7 @@ JethroSMS.onAJAXSuccess = function (data, resultsDiv) {
 			message = 'Message successfully sent to '+sentCount+' recipients';
 		}
 		JethroSMS.appendAlert(resultsDiv, 'alert-success', message, sentCount == 1 ? null : data.sent.recipients);
-		JethroSMS.markRecipientStatuses('Sent', data.sent.recipients, 'sms-success', 'SMS sent', true);
+		JethroSMS.markRecipientStatuses(data.sent.recipients, 'sms-success', 'SMS sent', true);
 
 		if (!data.sent.confirmed) {
 			JethroSMS.appendAlert(resultsDiv, '', 'Unable to confirm whether SMS sending was successful. Please check your system SMS configuration.');
@@ -1052,7 +1246,7 @@ JethroSMS.onAJAXSuccess = function (data, resultsDiv) {
 			message = blankCount+' recipients were not sent the message because they have no mobile number';
 		}
 		JethroSMS.appendAlert(resultsDiv, '', message, blankCount == 1 ? null : data.failed_blank.recipients);
-		JethroSMS.markRecipientStatuses('Failed (No Mobile)', data.failed_blank.recipients, 'sms-failure', null, false);
+		JethroSMS.markRecipientStatuses(data.failed_blank.recipients, 'sms-failure', null, false);
 	}
 
 	if (archivedCount > 0) {
@@ -1063,7 +1257,7 @@ JethroSMS.onAJAXSuccess = function (data, resultsDiv) {
 			message = archivedCount+' archived persons were not sent the message';
 		}
 		JethroSMS.appendAlert(resultsDiv, '', message, archivedCount == 1 ? null : data.failed_archived.recipients);
-		JethroSMS.markRecipientStatuses('Failed (Archived)', data.failed_archived.recipients, 'sms-failure', 'SMS not sent - person is archived', false);
+		JethroSMS.markRecipientStatuses(data.failed_archived.recipients, 'sms-failure', 'SMS not sent - person is archived', false);
 	}
 
 	if (failedCount > 0) {
@@ -1074,7 +1268,7 @@ JethroSMS.onAJAXSuccess = function (data, resultsDiv) {
 			message = 'SMS sending failed for '+failedCount+' recipients';
 		}
 		JethroSMS.appendAlert(resultsDiv, 'alert-error', message, failedCount == 1 ? null : data.failed.recipients);
-		JethroSMS.markRecipientStatuses('Failed', data.failed.recipients, 'sms-failure', 'SMS failed', false);
+		JethroSMS.markRecipientStatuses(data.failed.recipients, 'sms-failure', 'SMS failed', false);
 	}
 
 	return ((failedCount > 0) || (archivedCount > 0) || ( blankCount > 0) || ( sentCount == 0) || (data.error !== undefined));
@@ -1084,15 +1278,15 @@ JethroSMS.appendAlert = function(parent, className, content, recipients)
 {
 	if (recipients) {
 		content += '<p>';
-		var count = 0, personid = 0;
+		var count = 0;
+		var personID;
 		for (personID in recipients) {
 			if (recipients.hasOwnProperty(personID)) {
 				if (count > 0) {
 					content += ", ";
-				} else {
-					count = count + 1;
 				}
-				content += recipients[personID]['first_name'] + " " + recipients[personID]['last_name'];
+				count = count + 1;
+				content += $('<span>').text(recipients[personID]['first_name'] + " " + recipients[personID]['last_name']).html();
 			}
 		}
 		content += '</p>';
@@ -1101,10 +1295,8 @@ JethroSMS.appendAlert = function(parent, className, content, recipients)
 
 }
 
-JethroSMS.markRecipientStatuses = function(notice, recipients, rowClass, buttonMessage, untick)
+JethroSMS.markRecipientStatuses = function(recipients, rowClass, buttonMessage, untick)
 {
-	var fail_list = '<p class="namelist">';
-	// Silly long version to support IE < 9
 	var personID;
 	for (personID in recipients) {
 		if (recipients.hasOwnProperty(personID)) {
@@ -1246,7 +1438,7 @@ var JethroServicePlannerCopier = (function($) {
 			if (checked.indexOf(compid) !== -1) {
 				$r.removeClass("muted");
 			} else {
-				$r.addClass("muted");;
+				$r.addClass("muted");
 			}
 		});
 	}

--- a/upgrades/2026-upgrade-to-2.39.sql
+++ b/upgrades/2026-upgrade-to-2.39.sql
@@ -1,0 +1,5 @@
+SET @smsrank = (SELECT `rank` FROM setting WHERE symbol = 'SMS_SEND_LOGFILE');
+
+INSERT IGNORE INTO `setting` (`symbol`, `type`, `value`, `note`, `rank`)
+VALUES
+('SMS_UNICODE_PERMITTED', 'select{"when_free":"When it costs nothing extra","true":"Permitted (may cost extra)","false":"Not permitted"}', 'when_free', 'Whether to permit emojis and other unicode in SMSes', @smsrank+1);


### PR DESCRIPTION
Churches with Asian congregants may want to send CJK characters in SMSes. SMS provides all support Unicode, but until now Jethro didn't. Jethro silently stripped all non-GSM characters (CJK, emojis, etc.) on the server.

A second problem is that the character count displayed to the user didn't account for GSM 03.38 extended characters (€, ^, {, }, etc.) that count as 2 characters.

This PR moves SMS charset filtering to the frontend (PHP -> JS), where we can now interactively flag unicode chars (if not allowed), disabling the Send button when appropriate, and report on costs accurately.

Behaviour is driven by a new SMS_UNICODE_PERMITTED config constant:
 - false / 0: Unicode (non-GSM03.38) chars are complained about and prevent form submit
 - true / 1: Unicode is allowed
 - 'when_free' / 2 / unset (default): Unicode is allowed for <70 char messages
<img width="613" height="141" alt="image" src="https://github.com/user-attachments/assets/b7f45ab8-c491-48a4-b9b2-ea6e34d49815" />

To explain 'when_free': a SMS can fit:
 - 160 characters in GSM 03.38 encoding (7-bit)
 - 70 characters in Unicode UCS-2 encoding (16-bit).

Longer SMSes are broken into 'segments', which are all of the same encoding.

Clearly, GSM is better for cost. A single Unicode emoji forces the encoding to switch from GSM to Unicode. In a short <70 char message this doesn't matter - it's fitting in a segment regardless of encoding, but in >70 char messages, needing Unicode halves bandwidth or, if you prefer, doubles cost. Most churches care more about cost than emojis, hence the 'when_free' default. Churches who want CJK characters can set SMS_UNICODE_PERMITTED=1.

The segment (cost) counting is now accurate, not just in the face of encoding changes, but also at segment boundaries. 

This video shows the default `when_free` mode. You'll see the cost calculation update when entered unicode forces a charset change. The 'Send' button is dynamically enabled/disabled:

[jethro_ucs2.webm](https://github.com/user-attachments/assets/9e209091-8a41-4f99-bcae-91a7abb5af74)

An optional test script, resources/js/jethro-sms-test.js, tests:

- GSM segment count boundaries (1, 160, 161, 306, 307, 459, 460 chars)
	- Extended char (€) effective length calculations
	- UCS-2 segment count boundaries (1, 70, 71, 134, 135, 201, 202 chars)
- Non-GSM character detection (emoji surrogate pairs)
	- Warning logic for unicode-disabled, when-free, and default modes

To run the tests, jethro-sms-test.js may be copy and pasted into a browser terminal, or (temporarily) sourced on page load be setting (in conf.php):

```php
define('EXTRA_HEAD_HTML', '<script type="text/javascript" src="/resources/js/jethro-sms-test.js"></script>');
```

Expected output in the browser:

```
=== GSM Segment Count Tests ===
jethro-sms-test.js:16 ✅ 1 char → 1 segment — got: 1
jethro-sms-test.js:16 ✅ 160 chars → 1 segment (max single) — got: 1
jethro-sms-test.js:16 ✅ 161 chars → 2 segments (first multi) — got: 2
jethro-sms-test.js:16 ✅ 306 chars → 2 segments (exactly fills 2) — got: 2
jethro-sms-test.js:16 ✅ 307 chars → 3 segments (overflows 3rd) — got: 3
jethro-sms-test.js:16 ✅ 459 chars → 3 segments (exactly fills 3) — got: 3
jethro-sms-test.js:16 ✅ 460 chars → 4 segments (overflows 4th) — got: 4
jethro-sms-test.js:44 === Extended Char (GSM) Tests ===
jethro-sms-test.js:16 ✅ 80 × € (eff len 160) → 1 segment — got: 1
jethro-sms-test.js:16 ✅ 81 × € (eff len 162) → 2 segments — got: 2
jethro-sms-test.js:16 ✅ 153 × € (eff len 306) → 2 segments (exactly fills 2) — got: 2
jethro-sms-test.js:16 ✅ 154 × € (eff len 308) → 3 segments — got: 3
jethro-sms-test.js:63 === UCS-2 Segment Count Tests ===
jethro-sms-test.js:16 ✅ 1 UCS-2 char → 1 segment — got: 1
jethro-sms-test.js:16 ✅ 70 UCS-2 chars → 1 segment (max single) — got: 1
jethro-sms-test.js:16 ✅ 71 UCS-2 chars → 2 segments (first multi) — got: 2
jethro-sms-test.js:16 ✅ 134 UCS-2 chars → 2 segments (exactly fills 2) — got: 2
jethro-sms-test.js:16 ✅ 135 UCS-2 chars → 3 segments (overflows 3rd) — got: 3
jethro-sms-test.js:16 ✅ 201 UCS-2 chars → 3 segments (exactly fills 3) — got: 3
jethro-sms-test.js:16 ✅ 202 UCS-2 chars → 4 segments (overflows 4th) — got: 4
jethro-sms-test.js:82 === GSM Length (effective) Tests ===
jethro-sms-test.js:16 ✅ "a" → eff len 1 — got: 1
jethro-sms-test.js:16 ✅ "€" → eff len 2 (extended) — got: 2
jethro-sms-test.js:16 ✅ "a€" → eff len 3 — got: 3
jethro-sms-test.js:16 ✅ "€€" → eff len 4 — got: 4
jethro-sms-test.js:93 === Non-GSM Detection Tests ===
jethro-sms-test.js:16 ✅ "Hello" → no non-GSM chars — got: 0
jethro-sms-test.js:16 ✅ "😊" → 2 non-GSM chars (surrogate pair) — got: 2
jethro-sms-test.js:16 ✅ "Hello😊" → 2 non-GSM chars (surrogate pair) — got: 2
jethro-sms-test.js:16 ✅ "€" → 0 non-GSM (is extended GSM) — got: 0
jethro-sms-test.js:104 === Warning Logic Tests ===
jethro-sms-test.js:105 (These simulate what updateCharCount does internally)
jethro-sms-test.js:16 ✅ "Hello 😊" → no warning (same segments) — got: false
jethro-sms-test.js:16 ✅ "😊" only → no warning (empty GSM) — got: false
jethro-sms-test.js:16 ✅ "Hello😊" + 155 a's → warning (1 vs 3 segments) — got: true
jethro-sms-test.js:16 ✅ "Hello😊" + 150 a's → warning (1 vs 3 segments) — got: true
jethro-sms-test.js:16 ✅ "Hello😊" + 65 a's → warning (72 chars = 2 UCS-2 segments vs 1 GSM) — got: true
jethro-sms-test.js:16 ✅ "Hello😊" + 66 a's → warning (1 vs 2 segments) — got: true
jethro-sms-test.js:132 === Unicode Mode Tests ===
jethro-sms-test.js:16 ✅ unicodeMode=disabled, all-GSM text → no non-GSM chars — got: 0
jethro-sms-test.js:16 ✅ unicodeMode=disabled, non-GSM text → has non-GSM chars — got: 2
jethro-sms-test.js:16 ✅ unicodeMode=enabled, non-GSM text → has non-GSM chars — got: 2
jethro-sms-test.js:16 ✅ unicodeMode=when_free, "Hello😊" + 65 a's (72 chars) → would save segment — got: true
jethro-sms-test.js:16 ✅ unicodeMode=when_free, "Hi😊" (4 chars) → would NOT save segment — got: false
jethro-sms-test.js:16 ✅ unicodeMode=when_free, all-GSM text → no non-GSM chars (flag does not affect getNonGsmChars) — got: 0
jethro-sms-test.js:178 === All tests complete ===
```