### PR TITLE
Restore previously viewed tab when refreshing Person view

### DIFF
--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -428,7 +428,10 @@ $(document).ready(function() {
 	/***************** LAYOUT FIXES *******************/
 
 	layOutMatchBoxes();
-	$('a[data-toggle="tab"]').on('shown', layOutMatchBoxes);
+	$('a[data-toggle="tab"]').on('shown', function(e) {
+		layOutMatchBoxes();
+		persistActiveTab(e);
+	});
 	$(window).resize(layOutMatchBoxes);
 
 	// Make sure the width doesn't bounce around when we change tabs
@@ -1840,6 +1843,15 @@ function layOutMatchBoxes()
 		sameTop = (lastTop == $(this).position().top);
 	});
 	if (sameTop) $('.match-height').height(maxHeight);
+}
+
+/**
+ * Write the clicked tab's hash to the URL so the active tab survives page reload.
+ */
+function persistActiveTab(e) {
+	if (e.target.hash && history.replaceState) {
+		history.replaceState(null, '', e.target.hash);
+	}
 }
 
 /************************** LOCKING ********************************/


### PR DESCRIPTION
The Person view has tabs: "Basic Details", "Notes", "Groups", etc. If one is viewing "Notes" and refreshes the browser window, Jethro will now take you back to the "Notes" tab, rather than reverting to "Basic Details". The URL now reflects the selected tab. This also allows URLs to specific tabs to be bookmarked and shared.

### Before
[jethro_tabs_not_remembered.webm](https://github.com/user-attachments/assets/7b62c32f-7fb9-4dc6-987d-c455c7e3d926)
### After
[jethro_tabs_remembered.webm](https://github.com/user-attachments/assets/00d182a0-14c3-4b0a-8971-b1842f9c98fa)

