### PR TITLE
Use a pencil icon to represent a note object

### DIFF
--- a/templates/single_note.template.php
+++ b/templates/single_note.template.php
@@ -38,7 +38,7 @@ include_once 'urllinker.php';
 		<?php
 	}
 	?>
-	<i class="icon-<?php echo $type == 'family' ? 'home' : 'user'; ?>"></i>
+	<i class="icon-pencil"></i>
 	<blockquote>
 		<p class="subject"><?php echo ents($entry['subject']); ?></p>
 	<?php


### PR DESCRIPTION
In the Notes tab, Jethro displays a person (or family) icon alongside each note:

<img width="1165" height="830" alt="image" src="https://github.com/user-attachments/assets/91c62836-a4a6-4c1b-a5b1-faf010af08a3" />

I think a pencil icon would make more sense:

<img width="1160" height="829" alt="image" src="https://github.com/user-attachments/assets/cd9394e6-7e14-4f0a-b691-dbb70afe5aef" />

since that is what is used to indicate a note elsewhere:

<img width="321" height="152" alt="image" src="https://github.com/user-attachments/assets/495eaadc-9193-4388-a7cf-ec63e6a71ce2" />

<img width="1004" height="308" alt="image" src="https://github.com/user-attachments/assets/60a5dc86-172e-4122-a5e6-f14d89aac317" />
