### PR TITLE
Let MAILCHIMP_API_KEY be hardcoded in conf.php

### DIFF
--- a/conf.php.sample
+++ b/conf.php.sample
@@ -176,6 +176,8 @@ define('2FA_ENABLED', true);
 // Password to use when authenticating with the SMTP server. Can be left blank for no auth.
 // define('SMTP_PASSWORD', '');
 
+// Mailchimp API key for list synchronization
+// define('MAILCHIMP_API_KEY', '');
 
 
 ///////////////////////////////////////////////////////////////////////////

--- a/include/config_manager.class.php
+++ b/include/config_manager.class.php
@@ -33,6 +33,7 @@ class Config_Manager {
 		if (0 === strpos($symbol, 'SMS_')) return TRUE;
 		if (0 === strpos($symbol, '2FA_')) return TRUE;
 		if (0 === strpos($symbol, 'SMTP')) return TRUE;
+		if (0 === strpos($symbol, 'MAILCHIMP_')) return TRUE;
 		return FALSE;
 	}
 


### PR DESCRIPTION
`MAILCHIMP_API_KEY` is a sensitive variable (like SMTP and SMS/2FA) that an administrator might want hardcoded. This change lets it be set in conf.php, preventing it from being seen or overridden in the System configuration.