### PR TITLE
System configuration page: add section help/status panels

### DIFF
--- a/calls/call_admin_statuspanel.class.php
+++ b/calls/call_admin_statuspanel.class.php
@@ -1,0 +1,277 @@
+<?php
+
+require_once __DIR__ . '/../include/general.php';
+
+/**
+ * Abstract base for admin status panel calls.
+ *
+ * An admin 'status panel' is a HTML snippet reporting the status of some configurable Jethro subsystem, such as SMS, SMTP or Mailchimp. The status panels rendered by subclasses are displayed on the System Configuration page just below the heading ('SMS Gateway', etc), invoked via AJAX.
+ *
+ * The status panel consists of:
+ *
+ *  - a 'Status:' summary line
+ *  - Enabled/Disabled
+ *  - Configured
+ *  - Status message
+ *  - Operations
+ *
+ * Where:
+ *
+ * "Status: …" is a plain-English summary ({@see self::summaryText()}), e.g.
+ * "Status: enabled but not configured".
+ *
+ *   1. Enabled/Disabled (if {@see linkedFeature()} returns a feature flag name) —
+ *      is the feature toggled on? Links to the ENABLED_FEATURES setting: "(link)" when
+ *      enabled, "(see: Enabled Features)" when disabled, naming the fix for the reader.
+ *
+ *   2. Configured — are the required credentials/constants in place? This is a
+ *      cheap check ({@see self::isConfigured()}) that does not touch external services.
+ *
+ *   3. (If configured) Status message with optional collapsible details — is the feature actually
+ *      working right now? This is a live operational check ({@see getStatus()})
+ *      that may contact external providers, fetch balances, test API calls, etc.
+ *      The 'success' field is about operational health, not config existence.
+ *
+ *   4. Operations are configuration-related actions that might be taken for this subsystem, e.g. 'Register Sender ID' for SMS.
+ *
+ * Full writeup: docs/docs/developer/reference/status-panels.mdx
+ */
+abstract class Call_Admin_Statuspanel extends Call
+{
+    /**
+     * Feature flag name for the Enabled/Disabled line.
+     *
+     * @return string|null null means "not applicable" (no Enabled line shown);
+     *                     override to return a feature flag name e.g. 'SMS'.
+     */
+    public function linkedFeature(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Whether the required credentials/constants are in place.
+     *
+     * This is a cheap check — do not contact external services here.
+     *
+     * @return \Result<bool, array{message: string, details?: string}> Success, or failure
+     *     carrying a one-line 'message' saying what is missing, plus an optional 'details'
+     *     block of HTML (shown behind a "(details)" toggle) telling the admin how to fix it.
+     */
+    abstract protected function isConfigured(): \Result;
+
+    /** Help text (HTML) displayed above the status. */
+    abstract protected function getHelpText(): string;
+
+    /**
+     * Live operational check — is the feature actually working right now?
+     *
+     * The 'success' field is about operational health, not config existence. E.g. a SMS provider might be configured correctly (isConfigured succeeds), but its API might be offline (getStatus returns false).
+     * Subclasses should use a message like "Connected" / "Not available" rather
+     * than "Configured" / "Not configured" to avoid redundancy with the Configured line.
+     * 'message' is an overall summary. 'details' is key:value pairs displayed in a table.
+     *
+     * Every string here is PLAIN TEXT and is escaped by the renderer — do not
+     * call ents() on it and do not pass markup. Detail values routinely carry
+     * third-party bytes (SMTP banners, API error text, scripture), so escaping
+     * is centralised rather than left to each panel to remember. This differs
+     * from {@see isConfigured()}, whose 'details' is a block of HTML prose.
+     *
+     * @return array{success: bool, message: string, details?: array<string, string>}
+     */
+    abstract protected function getStatus(): array;
+
+    /**
+     * Operations the admin can initiate from this status panel.
+     *
+     * Each entry maps an operation name to a human-readable button label.
+     * When non-empty, the status panel renders a row of buttons; clicking a
+     * button fires a Datastar @get to the operation handler which returns the
+     * form HTML; submitting the form triggers a Datastar @post to the same
+     * handler which returns the result HTML — both morphed into the container
+     * by ID.
+     *
+     * The operation handler URL is derived from the status panel class name:
+     *
+     *   Call_Admin_Statuspanel_Sms →
+     *   ?call=admin_statuspanel_operation_sms
+     *
+     * @return array<string, string>  operation name => label
+     */
+    protected function getOperations(): array
+    {
+        return [];
+    }
+
+    public function run(): void
+    {
+        if (!$GLOBALS['user_system']->havePerm(PERM_SYSADMIN)) {
+            return;
+        }
+
+        $suffix = strtolower(substr(static::class, strlen('Call_Admin_Statuspanel_')));
+
+        // Resolve every check before rendering: the summary is printed above the
+        // lines it summarises, so it needs their outcomes up front.
+        $feature = $this->linkedFeature();
+        $enabled = $feature === null ? null : $GLOBALS['system']->featureEnabled($feature);
+
+        $configuredResult = $this->isConfigured();
+        $configured = $configuredResult->isSuccess();
+
+        // getStatus() may contact external services — only worth asking once configured.
+        $status = $configured ? $this->getStatus() : null;
+        $working = $status === null ? null : $status['success'];
+        ?>
+        <div id="status-panel-<?php echo ents($suffix); ?>" class="status-panel">
+        <p class="status-panel-help"><?php echo $this->getHelpText(); ?></p>
+        <p class="status-panel-summary">Status:
+            <?php echo ents($this->summaryText($enabled, $configured, $working)); ?>:</p>
+        <div class="status-panel-lines">
+        <?php
+        if ($enabled !== null) {
+            $this->printStatusLine(
+                $enabled,
+                ($enabled ? 'Enabled' : 'Disabled')
+                    . ' <a href="' . baseurl_relative() . '/?view=admin__system_configuration#ENABLED_FEATURES"><i>'
+                    . ($enabled ? '(link)' : '(see: Enabled Features)') . '</i></a>'
+            );
+        }
+
+        if ($status === null) {
+            $error = $configuredResult->getError();
+            $this->printStatusLine(
+                false,
+                'Not configured &mdash; ' . ents($error['message']),
+                $error['details'] ?? '',
+                'config-panel-details-' . $suffix
+            );
+        } else {
+            $this->printStatusLine(true, 'Configured');
+            $this->printStatusLine(
+                $status['success'],
+                ents($status['message']),
+                $this->detailsTable($status['details'] ?? []),
+                'status-panel-details-' . $suffix,
+                'form-horizontal'
+            );
+        }
+        ?>
+        </div>
+        <?php
+
+        // Operation buttons
+        $operations = $configured ? $this->getOperations() : [];
+        if ($operations !== []) {
+            $opCall = 'admin_statuspanel_operation_' . $suffix;
+            $opId = 'status-panel-ops-' . $suffix;
+            ?>
+            <div class="status-panel-operations" id="<?php echo ents($opId); ?>">
+                <?php foreach ($operations as $method => $label): ?>
+                    <a href="javascript:void()"
+                        class="status-panel-op-btn"
+                        data-on:click="@get('?call=<?php echo ents($opCall); ?>&operation=<?php echo ents($method); ?>')">
+                        <i class="icon-plus-sign"></i><?php echo ents($label); ?>
+                    </a>
+                <?php endforeach; ?>
+                <div class="status-panel-op-container" id="<?php echo ents($opId); ?>-container"></div>
+            </div>
+            <?php
+        }
+        ?>
+        </div>
+        <?php
+    }
+
+    /**
+     * One check line: tick/cross icon, text, and an optional collapsible block.
+     *
+     * The collapsible block is emitted after the closing </p>, never inside it:
+     * a <div> nested in a paragraph is invalid HTML, and browsers close the
+     * paragraph early when they meet one — so it ended up a sibling regardless.
+     *
+     * @param bool   $ok           TRUE → green tick, FALSE → red cross.
+     * @param string $text         Line text, already escaped/marked-up by the caller.
+     * @param string $detailsHtml  Collapsible content; '' for no details link.
+     * @param string $detailsId    Element id tying the toggle to the block.
+     * @param string $detailsClass Extra classes for the collapsible block.
+     */
+    private function printStatusLine(
+        bool $ok,
+        string $text,
+        string $detailsHtml = '',
+        string $detailsId = '',
+        string $detailsClass = ''
+    ): void {
+        ?>
+        <p class="status-icon-<?php echo $ok ? 'yes' : 'no'; ?>"><?php echo $text; ?>
+        <?php if ($detailsHtml !== ''): ?>
+            <a href="#" data-toggle="collapse" data-target="#<?php echo ents($detailsId); ?>" onclick="return false"><i>(details)</i></a>
+        <?php endif; ?>
+        </p>
+        <?php if ($detailsHtml !== ''): ?>
+        <div id="<?php echo ents($detailsId); ?>" class="collapse status-panel-details <?php echo ents($detailsClass); ?>">
+            <?php echo $detailsHtml; ?>
+        </div>
+        <?php endif;
+    }
+
+    /**
+     * Render {@see getStatus()}'s detail pairs as a definition-style table.
+     *
+     * Both label and value are plain text and are escaped here — see the
+     * getStatus() contract. Callers must not pre-escape.
+     *
+     * @param array<string, string> $details
+     * @return string HTML, or '' when there is nothing to show.
+     */
+    protected function detailsTable(array $details): string
+    {
+        if ($details === []) {
+            return '';
+        }
+        $html = '';
+        foreach ($details as $label => $value) {
+            $html .= '<div class="control-group">'
+                . '<label class="control-label">' . ents($label) . '</label>'
+                . '<div class="controls">' . ents($value) . '</div>'
+                . '</div>';
+        }
+        return $html;
+    }
+
+    /**
+     * Plain-English one-liner combining the enabled / configured / working lines.
+     *
+     * Returns the bare phrase — {@see run()} wraps it as "Status: <phrase>:", the
+     * trailing colon introducing the indented check lines below. E.g. "enabled and
+     * working", "enabled but not configured", "configured and working, but not enabled".
+     *
+     * @param bool|null $enabled    Whether the linked feature flag is on;
+     *                              null when the feature has no flag ({@see linkedFeature()}).
+     * @param bool      $configured Whether the required settings are in place.
+     * @param bool|null $working    Live operational health ({@see getStatus()});
+     *                              null when not checked, which is always the case
+     *                              when $configured is false.
+     */
+    protected function summaryText(?bool $enabled, bool $configured, ?bool $working): string
+    {
+        // 'unconfigured' | 'working' | 'broken' — operational health is irrelevant when unconfigured.
+        $state = !$configured ? 'unconfigured' : ($working ? 'working' : 'broken');
+
+        return match (true) {
+            // No feature flag: enablement is not a concept for this feature.
+            $enabled === null && $state === 'working' => 'configured and working',
+            $enabled === null && $state === 'broken'  => 'configured but not working',
+            $enabled === null                         => 'not configured',
+
+            $enabled === true && $state === 'working' => 'enabled and working',
+            $enabled === true && $state === 'broken'  => 'enabled, configured but not working',
+            $enabled === true                         => 'enabled but not configured',
+
+            $state === 'working' => 'configured and working, but not enabled',
+            $state === 'broken'  => 'configured but not working, and not enabled',
+            default              => 'not configured and not enabled',
+        };
+    }
+}

--- a/calls/call_admin_statuspanel_bible_api.class.php
+++ b/calls/call_admin_statuspanel_bible_api.class.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Status panel for the Bible API section of the system configuration page.
+ * Fetched via AJAX from ?call=admin_statuspanel_bible_api.
+ *
+ * Verifies the BIBLE_API_APIKEY by fetching available translations from
+ * api.bible, and fetches John 3:16 as a live test.
+ */
+
+require_once __DIR__ . '/call_admin_statuspanel.class.php';
+
+class Call_Admin_Statuspanel_Bible_Api extends Call_Admin_Statuspanel
+{
+    public function linkedFeature(): ?string
+    {
+        return null;
+    }
+
+    protected function isConfigured(): \Result
+    {
+        if (ifdef('BIBLE_API_APIKEY', '') !== '') {
+            return \Result::success(true);
+        }
+        return \Result::failure([
+            'message' => 'BIBLE_API_APIKEY is not set',
+            'details' => 'Register for a free API key at <a href="https://scripture.api.bible" target="_blank">scripture.api.bible</a> '
+                . 'and define <code>BIBLE_API_APIKEY</code> in conf.php.',
+        ]);
+    }
+
+    protected function getHelpText(): string
+    {
+        return 'When configured, Jethro can fetch Bible passage text from api.bible and display it inline in service handouts and run sheets.';
+    }
+
+    protected function getStatus(): array
+    {
+        require_once JETHRO_ROOT . '/include/bibleapi.php';
+
+        $translations = getBibleTranslations();
+        $count = count($translations);
+
+        if ($count === 0) {
+            return [
+                'success' => false,
+                'message' => 'API key is set but no translations could be fetched — check your key and network.',
+                'details' => [],
+            ];
+        }
+
+        // Fetch a well-known passage to verify the API works end-to-end
+        $sampleBibleId = array_key_first($translations);
+        $sampleResult = fetchBiblePassage('John 3:16', $sampleBibleId);
+
+        $details = [
+            'API URL' => BIBLE_API_URL,
+            'Translations available' => (string) $count,
+        ];
+
+        if ($sampleResult !== null) {
+            $sampleText = strip_tags($sampleResult[0]);
+            $sampleText = preg_replace('/\s+/', ' ', trim($sampleText));
+            if (strlen($sampleText) > 120) {
+                $sampleText = substr($sampleText, 0, 117) . '…';
+            }
+            $details['Example (John 3:16)'] = $sampleText;
+        } else {
+            $details['Example (John 3:16)'] = 'Failed to fetch';
+        }
+
+        $preferred = defined('BIBLE_TRANSLATION_PREFERRED') ? BIBLE_TRANSLATION_PREFERRED : null;
+        if ($preferred !== null && $preferred !== '') {
+            $info = $translations[$preferred] ?? null;
+            if ($info !== null) {
+                $details['Preferred translation'] = $info['abbreviation'] . ' — ' . $info['name'];
+            } else {
+                $details['Preferred translation (not found)'] = $preferred;
+            }
+        }
+
+        return [
+            'success' => true,
+            'message' => 'Connected',
+            'details' => $details,
+        ];
+    }
+}

--- a/calls/call_admin_statuspanel_mailchimp.class.php
+++ b/calls/call_admin_statuspanel_mailchimp.class.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Status panel for the Mailchimp section of the system configuration page.
+ * Fetched via AJAX from ?call=admin_statuspanel_mailchimp.
+ */
+
+require_once __DIR__ . '/call_admin_statuspanel.class.php';
+
+class Call_Admin_Statuspanel_Mailchimp extends Call_Admin_Statuspanel
+{
+    protected function isConfigured(): \Result
+    {
+        if (ifdef('MAILCHIMP_API_KEY', '') !== '') {
+            return \Result::success(true);
+        }
+        return \Result::failure([
+            'message' => 'MAILCHIMP_API_KEY is not set',
+            'details' => 'Create an API key in Mailchimp under Account &rarr; Extras &rarr; API keys, '
+                . 'then define <code>MAILCHIMP_API_KEY</code> in conf.php.',
+        ]);
+    }
+
+    protected function getHelpText(): string
+    {
+        return 'Mailchimp integration syncs person query results with Mailchimp audiences, and can send email campaigns.';
+    }
+
+    protected function getStatus(): array
+    {
+        require_once JETHRO_ROOT . '/vendor/drewm/mailchimp-api/src/MailChimp.php';
+
+        $apiKey = ifdef('MAILCHIMP_API_KEY', '');
+
+        try {
+            $mc = new \DrewM\MailChimp\MailChimp($apiKey);
+        } catch (\Exception $e) {
+            return ['success' => false, 'message' => 'Invalid API key: ' . $e->getMessage(), 'details' => []];
+        }
+
+        // Ping — GET / returns account info
+        $account = $mc->get('');
+        if (!$mc->success()) {
+            return ['success' => false, 'message' => 'API key rejected: ' . $mc->getLastError(), 'details' => []];
+        }
+
+        // Fetch audiences
+        $listsResult = $mc->get('lists');
+        if (!$mc->success()) {
+            return [
+                'success' => false,
+                'message' => 'Failed to fetch audiences: ' . $mc->getLastError(),
+                'details' => [],
+            ];
+        }
+
+        $lists = $listsResult['lists'] ?? [];
+        $details = [
+            'Account' => $account['account_name'] ?? 'Unknown',
+            'Audiences' => count($lists) . ' list(s)',
+        ];
+
+        foreach ($lists as $list) {
+            $memberCount = $list['stats']['member_count'] ?? '?';
+            $details[$list['name']] = 'ID ' . $list['id'] . ' — ' . $memberCount . ' members';
+        }
+
+        return [
+            'success' => true,
+            'message' => 'Connected to Mailchimp. ' . count($lists) . ' audience(s) found.',
+            'details' => $details,
+        ];
+    }
+}

--- a/calls/call_admin_statuspanel_operation.class.php
+++ b/calls/call_admin_statuspanel_operation.class.php
@@ -1,0 +1,100 @@
+<?php
+
+require_once __DIR__ . '/../include/general.php';
+
+/**
+ * Abstract base for admin status panel operation handlers.
+ *
+ * These handlers are the AJAX targets for operation buttons rendered by
+ * {@see Call_Admin_Statuspanel}.  Each feature panel (SMS, SMTP, etc.)
+ * has a corresponding operation handler at a predictable URL:
+ *
+ *   Status panel:  ?call=admin_statuspanel_sms
+ *   Operations:    ?call=admin_statuspanel_operation_sms
+ *
+ * Responses are text/html wrapped via {@see echoContainer()} so the Datastar
+ * morph target is consistent.
+ *
+ * Subclasses override {@see run()} to dispatch by operation name (extracted
+ * from GET or POST via {@see operation()}), then call operation-specific
+ * {@code do*()} methods that each handle both GET (form) and POST (process).
+ * They should call {@see parent::run()} first for the permission check and
+ * guard on its return value.
+ *
+ * This class provides the permission check, the operation-name helper, and
+ * the ID helpers that keep the container ID in sync with the static
+ * placeholder rendered by {@see Call_Admin_Statuspanel::run()}.
+ */
+abstract class Call_Admin_Statuspanel_Operation extends Call
+{
+    /**
+     * Check the sysadmin permission.
+     *
+     * If denied, echoes the error container and returns false.
+     * Subclasses override this, call {@see parent::run()}, and guard on the
+     * return value before proceeding with their own dispatch logic.
+     *
+     * @return bool true if permitted, false if denied (error already echoed).
+     */
+    public function run()
+    {
+        if (!$GLOBALS['user_system']->havePerm(PERM_SYSADMIN)) {
+            $this->echoContainer('<p class="text-error">Permission denied.</p>');
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * The requested operation name, extracted from GET or POST params.
+     *
+     * @return string e.g. 'synchronizeHistory', 'registerSenderId', 'manual'.
+     */
+    protected function operation(): string
+    {
+        return $_SERVER['REQUEST_METHOD'] === 'POST'
+            ? ($_POST['operation'] ?? '')
+            : ($_GET['operation'] ?? '');
+    }
+
+    // -----------------------------------------------------------------------
+    // ID helpers — keep GET/POST responses in sync with the static placeholder
+    // rendered by Call_Admin_Statuspanel::run().
+    // -----------------------------------------------------------------------
+
+    /**
+     * Lowercase feature suffix derived from the class name.
+     *
+     * Call_Admin_Statuspanel_Operation_Sms → 'sms'
+     */
+    protected function featureSuffix(): string
+    {
+        return strtolower(substr(static::class, strlen('Call_Admin_Statuspanel_Operation_')));
+    }
+
+    /**
+     * URL call parameter for this operation handler.
+     *
+     * e.g. 'admin_statuspanel_operation_sms'
+     */
+    protected function callName(): string
+    {
+        return 'admin_statuspanel_operation_' . $this->featureSuffix();
+    }
+
+    /**
+     * Echo $innerHtml wrapped in the morphable container div.
+     *
+     * The container ID matches the static placeholder rendered by
+     * {@see Call_Admin_Statuspanel::run()}; Datastar morphs the response
+     * into the existing DOM element by ID.  Pass $visible = false to hide
+     * the container (e.g. a close/cancel response).
+     */
+    protected function echoContainer(string $innerHtml, bool $visible = true): void
+    {
+        $suffix = $this->featureSuffix();
+        $id     = 'status-panel-ops-' . $suffix . '-container';
+        $cls    = 'status-panel-op-container' . ($visible ? ' visible' : '');
+        echo '<div id="' . ents($id) . '" class="' . $cls . '">' . $innerHtml . '</div>';
+    }
+}

--- a/calls/call_admin_statuspanel_sms.class.php
+++ b/calls/call_admin_statuspanel_sms.class.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Status panel for the SMS Gateway section of the system configuration page.
+ * Fetched via AJAX from ?call=admin_statuspanel_sms.
+ */
+
+require_once __DIR__ . '/call_admin_statuspanel.class.php';
+
+class Call_Admin_Statuspanel_Sms extends Call_Admin_Statuspanel
+{
+    protected function isConfigured(): \Result
+    {
+        require_once JETHRO_ROOT . '/include/sms_sender.class.php';
+        return SMS_Sender::canSend() ? \Result::success(true) : \Result::failure(['message' => 'SMS gateway is not configured']);
+    }
+
+    protected function getHelpText(): string
+    {
+        return 'SMS can be sent to individuals, families, groups, and custom person queries. Messages may optionally be saved as person notes.';
+    }
+
+    protected function getStatus(): array
+    {
+        $details = [];
+
+        $url = ifdef('SMS_HTTP_URL', '');
+        $details['Gateway'] = ents($url);
+
+
+        return [
+            'success' => true,
+            'message' => 'Gateway is configured.',
+            'details' => $details,
+        ];
+    }
+}

--- a/calls/call_admin_statuspanel_smtp.class.php
+++ b/calls/call_admin_statuspanel_smtp.class.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Status panel for the SMTP Email section of the system configuration page.
+ * Fetched via AJAX from ?call=admin_statuspanel_smtp.
+ */
+
+require_once __DIR__ . '/call_admin_statuspanel.class.php';
+
+class Call_Admin_Statuspanel_Smtp extends Call_Admin_Statuspanel
+{
+    protected function isConfigured(): \Result
+    {
+        if (ifdef('SMTP_SERVER', '') !== '') {
+            return \Result::success(true);
+        }
+        return \Result::failure([
+            'message' => 'SMTP_SERVER is not set',
+            'details' => 'Define <code>SMTP_SERVER</code> in conf.php (and <code>SMTP_USERNAME</code> / '
+                . '<code>SMTP_PASSWORD</code> if your mail server requires authentication). '
+                . 'Without it, Jethro falls back to PHP&rsquo;s local <code>mail()</code>.',
+        ]);
+    }
+
+    protected function getHelpText(): string
+    {
+        return 'SMTP settings are used to send member registration emails, error alerts to system administrators, and other system notifications.';
+    }
+
+    protected function getStatus(): array
+    {
+        require_once JETHRO_ROOT . '/include/emailer.class.php';
+        $result = Emailer::testConnection();
+
+        $details = [];
+        if ($result['greeting'] !== '') {
+            $details['Greeting'] = $result['greeting'];
+        }
+        if ($result['ehlo'] !== '') {
+            $details['EHLO'] = $result['ehlo'];
+        }
+
+        return [
+            'success' => $result['success'],
+            'message' => $result['success'] ? 'SMTP server is reachable and responding.' : $result['error'],
+            'details' => $details,
+        ];
+    }
+}

--- a/docs/docs/developer/reference/status-panels.mdx
+++ b/docs/docs/developer/reference/status-panels.mdx
@@ -1,0 +1,119 @@
+---
+sidebar_position: 6
+---
+
+# System Configuration Status Panels
+
+Each section of **Admin → System configuration** can show a *status panel*: help text plus a live
+report of whether that integration is enabled, configured, and actually working.
+
+Panels are implemented as `Call`s (`calls/call_admin_statuspanel_*.class.php`) extending
+`Call_Admin_Statuspanel`, and are loaded asynchronously so a dead external service never delays the
+page.
+
+## Discovery
+
+`View_Admin__System_Configuration` takes the first heading-bearing setting in a section (say
+`SMS_MAX_LENGTH`), then looks for a `Call` class matching the longest prefix of the symbol:
+
+```
+BIBLE_API_URL  →  call_admin_statuspanel_bible_api.class.php   (tried first)
+               →  call_admin_statuspanel_bible.class.php
+```
+
+No registry, no hardcoded list — add a settings section, drop in a matching class.
+
+## What a panel must implement
+
+| Method | Purpose |
+|---|---|
+| `getHelpText(): string` | HTML blurb explaining what the integration does |
+| `isConfigured(): \Result` | Cheap check — are the constants/credentials present? Failure always carries `array{message: string, details?: string}` |
+| `getStatus(): array` | Live operational check — `['success' => bool, 'message' => string, 'details' => array<string,string>]`, all plain text |
+| `linkedFeature(): ?string` | Optional feature-flag name for the Enabled/Disabled line; `null` = feature has no flag |
+| `getOperations(): array` | Optional `operation => label` buttons, handled by `call_admin_statuspanel_operation_<suffix>` |
+
+`isConfigured()` must **not** contact external services; `getStatus()` may (and is only called when
+configured).
+
+### Escaping — who does it
+
+Panels never call `ents()`. Every string a panel returns is **plain text** and the renderer escapes
+it; the one exception is `isConfigured()`'s `details`, which is a block of HTML prose (links,
+`<code>` samples) telling the admin how to fix the problem.
+
+| Field | Content | Escaped by |
+|---|---|---|
+| `isConfigured()` failure `message` | plain text, one line | renderer |
+| `isConfigured()` failure `details` | **HTML** prose | nobody — panel owns it |
+| `getStatus()` `message` | plain text | renderer |
+| `getStatus()` `details` keys/values | plain text | renderer (`detailsTable()`) |
+
+This is centralised deliberately. Detail values routinely carry third-party bytes — SMTP server
+banners, provider API error text, scripture fetched from api.bible — and leaving each panel to
+remember `ents()` produced both holes (unescaped banners) and double-escaping (`&amp;amp;`) in the
+same file. `tests/unit/test_statuspanel_summary.php` pins the behaviour.
+
+## Rendered layout
+
+```
+<help text, italic grey>
+Status: enabled and working:
+    ✓ Enabled (link)     (only when linkedFeature() is non-null)
+    ✓ Configured         (or "✗ Not configured — <reason> (details)")
+    ✓ Operational …      (only when configured; from getStatus())
+[ operation buttons ]
+```
+
+The summary leads, and the checks that produced it are indented beneath it
+(`.status-panel-lines { margin-left: 1.5em }`). Because the summary prints first, `run()` resolves
+`linkedFeature()`, `isConfigured()` and `getStatus()` **before** emitting any markup.
+
+Each check is emitted by `printStatusLine()`, which puts any collapsible details block **after**
+the closing `</p>`, never inside it — a `<div>` nested in a paragraph is invalid, and browsers
+close the paragraph early when they meet one, so it ended up a sibling anyway.
+
+The Enabled line always links to the `ENABLED_FEATURES` setting, but names it when that is the
+problem: `(link)` when enabled, `(see: Enabled Features)` when disabled.
+
+## Styling
+
+All of it lives in `resources/less/jethro.less.php`, under a single `status-panel-*` prefix. Two
+things used to be true and no longer are: the rules were split between that file and the system
+configuration view's inline `<style>` (the panels load by AJAX and the SMS constants table is
+reused off-page, so page-local rules were wrong), and the operation widgets used a
+`status_panel-*` underscore spelling for the same component.
+
+The tick and cross are generated content: the element holding the text carries
+`class="status-icon-yes"` or `status-icon-no`, and `:before { content }` supplies the glyph and its
+colour. So the mark is decoration — not selected when the reader copies the line, and not
+duplicating the label beside it. The glyphs are the CSS escapes `\2713` and `\2717`; the stylesheet
+is served as `text/plain` with no charset and compiled client-side by less.js, so a literal UTF-8
+glyph would be taking a chance. Deliberately not the ballot boxes U+2611 ☑ / U+2612 ☒: U+2611 has
+an emoji presentation that some font stacks render as a colour glyph, ignoring the CSS `color`.
+
+## The "Status:" summary line
+
+`Call_Admin_Statuspanel::summaryText()` collapses the icon lines into one plain-English
+sentence, so an admin can tell at a glance whether the integration will actually do anything.
+It is `protected`, so a panel may override the wording.
+
+It returns the bare phrase; `run()` renders it as `Status: <phrase>:`. The trailing colon
+introduces the indented check lines beneath. The table below shows the full rendered line.
+
+| Enabled | Configured | Working | Rendered line |
+|---|---|---|---|
+| yes | yes | yes | `Status: enabled and working:` |
+| yes | yes | no | `Status: enabled, configured but not working:` |
+| yes | no | — | `Status: enabled but not configured:` |
+| no | yes | yes | `Status: configured and working, but not enabled:` |
+| no | yes | no | `Status: configured but not working, and not enabled:` |
+| no | no | — | `Status: not configured and not enabled:` |
+| n/a | yes | yes | `Status: configured and working:` |
+| n/a | yes | no | `Status: configured but not working:` |
+| n/a | no | — | `Status: not configured:` |
+
+*n/a* = `linkedFeature()` returned `null`, so enablement is never mentioned. Operational health is
+irrelevant when unconfigured (`getStatus()` is not called at all in that case).
+
+Matrix coverage lives in `tests/unit/test_statuspanel_summary.php`.

--- a/include/config_manager.class.php
+++ b/include/config_manager.class.php
@@ -54,7 +54,7 @@ class Config_Manager {
 
 	public static function migrateEnabledFeatures()
 	{
-		$value = explode(',', ENABLED_FEATURES);
+		$value = explode(',', ifdef('ENABLED_FEATURES', ''));
 		$value = array_diff($value, Array('DATES'));
 		self::saveSetting('ENABLED_FEATURES', implode(',', $value));
 

--- a/include/emailer.class.php
+++ b/include/emailer.class.php
@@ -79,4 +79,59 @@ class Emailer
 	static function validateAddress($email) {
 		return Swift_Validate::email($email);
 	}
+
+	/**
+	 * Test SMTP connectivity with a socket connect + EHLO.
+	 *
+	 * @return array{success: bool, error: string, greeting: string, ehlo: string}
+	 */
+	static function testConnection(): array
+	{
+		$server = ifdef('SMTP_SERVER', '');
+		if ($server === '') {
+			return ['success' => false, 'error' => 'SMTP_SERVER not configured', 'greeting' => '', 'ehlo' => ''];
+		}
+
+		$port = (int) ifdef('SMTP_PORT', 25);
+		$encryption = ifdef('SMTP_ENCRYPTION', '');
+		$host = ($encryption === 'ssl') ? 'ssl://' . $server : $server;
+
+		$errno = 0;
+		$errstr = '';
+		$socket = @stream_socket_client("$host:$port", $errno, $errstr, 10);
+
+		if (!$socket) {
+			return ['success' => false, 'error' => $errstr ?: "Error $errno", 'greeting' => '', 'ehlo' => ''];
+		}
+
+		$greeting = self::_readSmtp($socket);
+		if ($greeting === '' || $greeting[0] !== '2') {
+			fclose($socket);
+			return ['success' => false, 'error' => 'No SMTP greeting received', 'greeting' => $greeting, 'ehlo' => ''];
+		}
+
+		fwrite($socket, "EHLO jethro\r\n");
+		$ehlo = self::_readSmtp($socket);
+
+		fwrite($socket, "QUIT\r\n");
+		fclose($socket);
+
+		if ($ehlo === '' || $ehlo[0] !== '2') {
+			return ['success' => false, 'error' => 'EHLO rejected', 'greeting' => $greeting, 'ehlo' => $ehlo];
+		}
+
+		return ['success' => true, 'error' => '', 'greeting' => $greeting, 'ehlo' => $ehlo];
+	}
+
+	private static function _readSmtp($socket): string
+	{
+		$response = '';
+		while (!feof($socket) && ($line = fgets($socket, 512)) !== false) {
+			$response .= $line;
+			if (isset($line[3]) && $line[3] === ' ') {
+				break;
+			}
+		}
+		return trim($response);
+	}
 }

--- a/include/general.php
+++ b/include/general.php
@@ -1154,3 +1154,97 @@ function safe_subdirectory($base, $path) {
             ? false
             : substr($realpath, strlen($base) + 1);
 }
+
+// ---------------------------------------------------------------------------
+// Result monad
+// ---------------------------------------------------------------------------
+
+/**
+ * Result monad — a value that is either Success(T) or Failure(E).
+ *
+ * Failures carry an informational error payload (typically a string)
+ * describing what went wrong, so callers can present a meaningful
+ * message to the user without a separate error channel.
+ *
+ * Transform the value inside a Result with {@see map()}, which applies
+ * a function to the success value while automatically propagating
+ * failures.  Branch on success or failure with {@see isSuccess()} /
+ * {@see isFailure()}, then extract the inner value with
+ * {@see getValue()} or the error with {@see getError()}.
+ *
+ * @template T  The type of the success value.
+ * @template E  The type of the error payload (usually string).
+ *
+ */
+final class Result
+{
+	private function __construct(
+		private readonly mixed $value,
+		private readonly mixed $error,
+		private readonly bool $isSuccess,
+	) {
+	}
+
+	/**
+	 * @param T $value
+	 *
+	 * @return self<T, E>
+	 */
+	public static function success(mixed $value): self
+	{
+		return new self($value, null, true);
+	}
+
+	/**
+	 * @param E $error
+	 *
+	 * @return self<T, E>
+	 */
+	public static function failure(mixed $error): self
+	{
+		return new self(null, $error, false);
+	}
+
+	public function isSuccess(): bool
+	{
+		return $this->isSuccess;
+	}
+
+	public function isFailure(): bool
+	{
+		return !$this->isSuccess;
+	}
+
+	/**
+	 * @return T
+	 */
+	public function getValue(): mixed
+	{
+		return $this->value;
+	}
+
+	/**
+	 * @return E
+	 */
+	public function getError(): mixed
+	{
+		return $this->error;
+	}
+
+	/**
+	 * If success, apply $fn to the value and return a new Result.
+	 * If failure, propagate the error unchanged.
+	 *
+	 * @template U
+	 * @param callable(T): U $fn
+	 * @return Result<U, E>
+	 */
+	public function map(callable $fn): self
+	{
+		if ($this->isFailure()) {
+			return $this;
+		}
+		return self::success($fn($this->value));
+	}
+}
+

--- a/include/system_controller.class.php
+++ b/include/system_controller.class.php
@@ -77,8 +77,8 @@ class System_Controller
 	 * @return string A hash
 	 */
 	private function getViewHash(): string {
-        $currentUser = $GLOBALS['user_system']->getCurrentUser();
-        return sha1(ENABLED_FEATURES . ($currentUser ? $currentUser['permissions'] : ''));
+		$currentUser = $GLOBALS['user_system']->getCurrentUser();
+		return sha1(ifdef('ENABLED_FEATURES', '') . ($currentUser ? $currentUser['permissions'] : ''));
 	}
 
 	/**

--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -2639,3 +2639,100 @@ div#send-sms-modal div.results {
 		border-bottom: 2px solid;
 	}
 }
+/**
+ * Boolean state icons: green tick / red cross, e.g.:
+ *
+ * <p class="status-icon-yes">Configured</p>
+ *
+ * \2713 / \2717 are U+2713 CHECK MARK and U+2717 BALLOT X, written as CSS
+ * escapes because this stylesheet is served as text/plain with no charset and
+ * is compiled client-side by less.js.
+ */
+.status-icon-yes:before {
+	content: "\2713";
+	color: #468847;
+	margin-right: 0.4em;
+}
+.status-icon-no:before {
+	content: "\2717";
+	color: #b94a48;
+	margin-right: 0.4em;
+}
+
+/**
+ * Status panels on the system configuration page.
+ *
+ * Rendered by Call_Admin_Statuspanel::run(), loaded into the page by AJAX, so
+ * these rules cannot live in that view's inline <style> — the SMS constants
+ * table (Jethro\Sms\renderNotConfiguredHelp()) reuses them off-page too.
+ */
+.status-panel {
+	margin: 0.5rem 0 1rem 0;
+}
+.status-panel p {
+	margin: 0.15rem 0;
+}
+.status-panel .control-group {
+	margin-bottom: 0.25rem;
+}
+.status-panel .control-group:last-child {
+	margin-bottom: 0;
+}
+.status-panel .control-label {
+	padding-top: 0;
+}
+.status-panel-help {
+	font-style: italic;
+	color: #777;
+}
+.status-panel-loading {
+	color: #999;
+	font-style: italic;
+}
+.status-panel p.status-panel-summary {
+	margin-top: 0.5rem;
+}
+/* The checks are indented under the "Status: …" line that summarises them. */
+.status-panel-lines {
+	margin-left: 1.5em;
+}
+.collapse.in.status-panel-details {
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	padding: 0.5rem 0.75rem;
+}
+
+/**
+ * Status panel operation buttons and forms.
+ *
+ * Rendered by Call_Admin_Statuspanel::run() and
+ * Call_Admin_Statuspanel_Operation::buildFormHtml().
+ */
+.status-panel-operations {
+	margin-top: 8px;
+}
+.status-panel-op-container {
+	margin-top: 1em;
+	overflow: hidden;
+	max-height: 0;
+	transition: max-height 0.35s ease;
+}
+.status-panel-op-container.visible {
+	max-height: 2000px;
+}
+.status-panel-op-form {
+	margin-top: 8px;
+}
+.status-panel-op-result {
+	margin-top: 1em;
+	margin-left: 8px;
+	display: none;
+}
+.status-panel-op-result.error {
+	color: #b94a48;
+	display: inline;
+}
+.status-panel-op-result.success {
+	color: #468847;
+	display: inline;
+}

--- a/templates/person_list.template.php
+++ b/templates/person_list.template.php
@@ -3,10 +3,11 @@
 @var $persons
 @var $special_fields
 @var $show_actions	Whether to show the action links for each person
-@var $link_Class	Classname to add to all the action links (eg med-popup)
+@var $link_class		Classname to add to all the action links (eg med-popup)
 @var $view_tab		Which view-person tab to link to (eg attendance)
 @var $callbacks		Functions to call to render each column's value
 */
+$link_class = $link_class ?? '';
 $view_tab = empty($view_tab) ? '' : '#'.$view_tab;
 
 $GLOBALS['system']->includeDBClass('person');

--- a/views/view_10_admin__6_system_configuration.class.php
+++ b/views/view_10_admin__6_system_configuration.class.php
@@ -79,6 +79,7 @@ class View_Admin__System_Configuration extends View {
 			<div class="form-horizontal">
 			<?php
 			$headings = [];
+			$panelsRendered = [];
 			foreach (Config_Manager::getSettings() as $symbol => $details) {
 				if ($details['type'] == 'hidden') continue;
 				$details['note'] = str_replace('<system_url>', BASE_URL, $details['note']);
@@ -86,6 +87,7 @@ class View_Admin__System_Configuration extends View {
 					$slug = strtolower((string) preg_replace('/[^A-Za-z0-9]+/', '-', $details['heading']));
 					$headings[] = ['slug' => $slug, 'label' => $details['heading']];
 					echo '<hr /><h4 id="'.ents($slug).'">'.ents($details['heading']).'</h4>';
+					$this->printStatusPanel($symbol, $panelsRendered);
 				}
 				?>
 				<div class="control-group" id="<?php echo $symbol; ?>">
@@ -183,6 +185,28 @@ class View_Admin__System_Configuration extends View {
 			refresh();
 		})();
 		</script>
+		<script>
+		// Status panel AJAX loader
+		(function() {
+			document.querySelectorAll('.status-panel').forEach(function(panel) {
+				var prefix = panel.getAttribute('data-prefix');
+				if (!prefix) return;
+				var xhr = new XMLHttpRequest();
+				xhr.open('GET', '?call=admin_statuspanel_' + prefix);
+				xhr.onload = function() {
+					if (xhr.status === 200) {
+						panel.innerHTML = xhr.responseText;
+					} else {
+						panel.innerHTML = '';
+					}
+				};
+				xhr.onerror = function() {
+					panel.innerHTML = '';
+				};
+				xhr.send();
+			});
+		})();
+		</script>
 		<style>
 		.settings-page { display: flex; gap: 2rem; align-items: flex-start; }
 		.settings-nav { position: sticky; top: 10rem; width: 14rem; flex-shrink: 0; }
@@ -191,8 +215,40 @@ class View_Admin__System_Configuration extends View {
 		.settings-nav a.active { font-weight: 600; color: #08c; background: #e8f4fc; }
 		.settings-nav a.active::before { content: ''; display: none; }
 		.settings-form { flex: 1; min-width: 0; }
+
+		.status-panel { margin: 0.5rem 0 1rem 0; }
+		.status-panel .control-group { margin-bottom: 0.25rem; }
+		.status-panel .control-group:last-child { margin-bottom: 0; }
+		.status-panel .control-label { padding-top: 0; }
+		.collapse.in.status-panel-details { border: 1px solid #e0e0e0; border-radius: 4px; padding: 0.5rem 0.75rem; }
+		.status-panel p { margin: 0.15rem 0; }
+		.status-panel-help { font-style: italic; color: #777; }
+		.status-panel-loading { color: #999; font-style: italic; }
 		</style>
 		<?php
+	}
+
+	private function printStatusPanel(string $symbol, array &$panelsRendered): void
+	{
+		// Longest-match: progressively strip trailing _* from the symbol until a call class file is found.
+		$key = strtolower($symbol);
+		do {
+			if (!in_array($key, $panelsRendered, true)
+				&& file_exists(JETHRO_ROOT . '/calls/call_admin_statuspanel_' . $key . '.class.php')
+			) {
+				$panelsRendered[] = $key;
+?>
+				<div class="status-panel" id="status-panel-<?php echo ents($key); ?>" data-prefix="<?php echo ents($key); ?>">
+				    <div class="status-panel-loading">Loading&hellip;</div>
+				</div>
+<?php
+				return;
+			}
+			$pos = strrpos($key, '_');
+			if ($pos !== false) {
+				$key = substr($key, 0, $pos);
+			}
+		} while ($pos !== false);
 	}
 
 	private static function getParamsAndValue($symbol, $details)


### PR DESCRIPTION
In Jethro, external integrations (SMS, SMTP, Mailchimp, etc) are configured in sections of the System configuration page. However there is no feedback as to whether the settings are correct.

This change allows PHP snippets to be defined for any section (sms, smtp, mailchimp, bible_api, etc), showing information and the 'status' of the settings (e.g. the SMS balance), as well as configuration-adjacent one-off operations, like (for SMS) registering a Sender ID.

Currently implemented:
 - 'SMS Gateway' - prints '✓ Gateway is configured.' if correctly configured 
        <img width="605" height="384" alt="image" src="https://github.com/user-attachments/assets/62fcc883-cc10-4184-b712-c89a33d68e1e" />


 - 'SMTP Email Server' - prints '✓ SMTP server is reachable and responding. (details)'
        <img width="825" height="274" alt="image" src="https://github.com/user-attachments/assets/cdb9d617-67fb-4db0-9155-610ff1c1e962" />
 - 'Mailchimp Sync' - prints '✓ Connected to Mailchimp. 3 audience(s) found. (details)'
        <img width="546" height="394" alt="image" src="https://github.com/user-attachments/assets/6070ed99-d6dd-4d58-ba2e-c30ad2d3bcd0" />

These 'status panels' load asynchronously (AJAX), and are implemented as Calls:

```php
calls/call_admin_statuspanel_sms.class.php
calls/call_admin_statuspanel_smtp.class.php
calls/call_admin_statuspanel_mailchimp.class.php
```

Being asynchronous, they won't slow the page load if an external system is down, and being implemented as separate calls lets us add new help sections as settings are added, without hardcoding anything in View_Admin__System_Configuration. For instance, if [API.Bible integration](https://github.com/tbar0970/jethro-pmm/pull/1459) is added:

The implementation in View_Admin__System_Configuration is as follows: for each setting with a heading encountered (say, SMS_MAX_LENGTH), the first part of the symbol is isolated ('SMS') and is used to search for a matching Call class ('call_admin_statuspanel_sms.class.php'). The longest prefix wins, e.g. 'BIBLE_API_URL' would use call_admin_statuspanel_bible_api.class.php before call_admin_statuspanel_bible.class.php

The status_panel Calls all extend an abstract Call subclass, Call_Admin_Statuspanel that implements run(), enforcing a common HTML layout. Each status panel Call must implement:

```php
getHelpText()    // Help text displayed at the top of the panel
isConfigured()   // Whether the config settings are present
getStatus()      // Live operational check — is the feature actually working right now?
getOperations()     // Operations the admin can initiate from this status panel.
```