### PR TITLE
#1468: fix bug where clickable-rows js would guess the target incorrectly

### DIFF
--- a/db_objects/person_query.class.php
+++ b/db_objects/person_query.class.php
@@ -1972,7 +1972,7 @@ class Person_Query extends DB_Object
 								break;
 							case 'view_link':
 								?>
-								<a class="med-popup no-print" href="?view=persons&personid=<?php echo $row[$label]; ?>"><i class="icon-user"></i>View</a>
+								<a class="med-popup no-print rowlink" href="?view=persons&personid=<?php echo $row[$label]; ?>"><i class="icon-user"></i>View</a>
 								<?php
 								break;
 							case 'note_link':

--- a/resources/js/tb_lib.js
+++ b/resources/js/tb_lib.js
@@ -78,14 +78,18 @@ $(document).ready(function() {
 		history.back();
 	});
 
-	// Ability to click anywhere on a table row to activate the first link within it
+	// Ability to click anywhere on a table row to activate the primary link.
+	// If a <a class="rowlink"> exists in the row, it takes priority;
+	// otherwise the first <a> in the row is used (backwards-compatible).
 	$('table.clickable-rows td').click(function(e) {
 		var t = $(this);
 		var myLinks = t.find('a, input');
 		if (!myLinks.length) {
-			childLinks = $(this).parent('tr').find('td>a[href!=#]');
-			if (childLinks.length) {
-				self.location = childLinks[0].href;
+			var row = $(this).parent('tr');
+			var rowLinks = row.find('td>a[href!=#]');
+			if (rowLinks.length) {
+				var primary = rowLinks.filter('.rowlink');
+				self.location = (primary.length ? primary : rowLinks).first()[0].href;
 			}
 		} else if (myLinks.filter('a').length == 1) {
 			self.location = myLinks[0].href;

--- a/templates/person_list.template.php
+++ b/templates/person_list.template.php
@@ -7,7 +7,6 @@
 @var $view_tab		Which view-person tab to link to (eg attendance)
 @var $callbacks		Functions to call to render each column's value
 */
-$link_class = empty($link_class) ? '' : 'class="'.$link_class.'"';
 $view_tab = empty($view_tab) ? '' : '#'.$view_tab;
 
 $GLOBALS['system']->includeDBClass('person');
@@ -107,11 +106,11 @@ if ($show_actions) {
 
 			?>
 			<td class="narrow action-cell">
-				<a <?php echo $link_class; ?> href="?view=persons&personid=<?php echo $id; echo $view_tab ?>"><i class="icon-user"></i><?php echo _('View')?></a> &nbsp;
+					<a class="rowlink" href="?view=persons&personid=<?php echo $id; echo $view_tab ?>"><i class="icon-user"></i><?php echo _('View')?></a> &nbsp;
 			<?php
 			if ($GLOBALS['user_system']->havePerm(PERM_EDITPERSON) && !SizeDetector::isNarrow()) {
 				?>
-				<a <?php echo $link_class; ?> href="?view=_edit_person&personid=<?php echo $id; ?>"><i class="icon-wrench"></i><?php echo _('Edit')?></a> &nbsp;
+				<a href="?view=_edit_person&personid=<?php echo $id; ?>"><i class="icon-wrench"></i><?php echo _('Edit')?></a> &nbsp;
 				<?php
 			}
 			if ($GLOBALS['user_system']->havePerm(PERM_EDITNOTE) && !SizeDetector::isNarrow()) {


### PR DESCRIPTION
Adding .clickable-rows to a tr causes a click on the tr to be interpreted as a click on its first link. This is neat, but breaks when the first <a> element isn't a page link (#1396) or is the wrong link (#1468).

The real fix is not to guess. The correct link can now be labelled with a .rowlink class:
```html
  <a href="/.." class="rowlink">View</a>
```

The clickable-rows js will now look for .rowlink, before falling back to searching for the first <a>

Also, there was an unused `$link_class` variable that complicated the code, so it is now removed.