### PR TITLE
Notes: add checkboxes allowing filtering by status/assignee

### DIFF
--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -2134,3 +2134,42 @@ function updateTeams() {
 	const assign_multiple = document.querySelector('select[name=assign_multiple]').value == '1'
 	document.querySelector('#field-teams').hidden = !assign_multiple
 }
+
+/**
+ * Note list filtering — sidebar checkboxes to filter notes by status and assignee.
+ *
+ * Bound to .note-status-filter checkboxes (one per note status) and
+ * #note-assignee-filter checkbox.  Filters .history-entry elements within
+ * .notes-history-container, showing/hiding them with a slide animation.
+ *
+ * @param {number} currentUserId  The current user's person ID for assignee filtering.
+ */
+function initNoteFilters(currentUserId) {
+	var $statusFilters = $('.note-status-filter');
+	var $assigneeFilter = $('#note-assignee-filter');
+
+	function applyFilters() {
+		var activeStatuses = {};
+		$statusFilters.each(function() {
+			activeStatuses[this.value] = this.checked;
+		});
+		var showAllAssignees = !$assigneeFilter.length || !$assigneeFilter.prop('checked');
+
+		$('.notes-history-container .notes-history-entry').each(function() {
+			var $entry = $(this);
+			var $statusDiv = $entry.find('.status');
+			if (!$statusDiv.length) return;
+
+			var status = $statusDiv.attr('data-note-status');
+			var visible = activeStatuses[status];
+			if (visible && !showAllAssignees) {
+				var assignee = $statusDiv.attr('data-note-assignee');
+				visible = (assignee == currentUserId);
+			}
+
+			$entry.stop(true, true)[visible ? 'slideDown' : 'slideUp'](250);
+		});
+	}
+
+	$statusFilters.add($assigneeFilter).on('change', applyFilters);
+};

--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -1514,6 +1514,13 @@ ul.nav-tabs {
 	padding: 15px;
 	border-radius: 0px 0px 5px 5px;
 }
+/* Override Bootstrap's overflow:auto (which breaks position:sticky descendants) while
+   still containing floats via display:flow-root. Scoped to view-person to avoid
+   affecting service-planner which intentionally scrolls its tab-content. */
+.tab-content.view-person {
+	overflow: visible;
+	display: flow-root;
+}
 .preview-pane, .tab-content, .nav-tabs > .active > a, .nav-tabs > .active > a:hover, .nav-tabs > .active > a:focus {
 	background: @jethroLightest; /* lighter yellow */
 }
@@ -1838,6 +1845,29 @@ table.service-details td table td input {
 .notes-history-entry .comments {
 	margin-left: 25px;
 	margin-top: 15px;
+}
+
+/* Note filter sidebar — checkboxes to filter by status and assignee.
+   position:sticky keeps the panel visible while scrolling through long lists.
+   top:5px (not 80px) because #jethro-nav is not position:fixed — it scrolls away,
+   so there is no persistent header to clear. */
+.panel-sidebar {
+	border-left: 1px solid #ddd;
+	padding: 8px 8px 0 8px;
+	position: sticky;
+	top: 5px;
+}
+.panel-sidebar fieldset {
+	border: 0;
+	margin: 0;
+	padding: 0;
+}
+.panel-sidebar legend {
+	display: inline;
+	width: auto;
+	margin: 1em 0 0.5em 0;
+	padding-right: 8px;
+	font-size: 0.85em;
 }
 
 /********* ATTENDANCE AND COLOURED RADIO BUTTONS **********/

--- a/templates/list_notes.template.php
+++ b/templates/list_notes.template.php
@@ -3,7 +3,15 @@
 $GLOBALS['system']->includeDBClass('abstract_note');
 $dummy = new Abstract_Note();
 foreach ($notes as $id => $entry) {
+	$dummy->reset();
+	$dummy->populate($id, $entry);
 	include 'single_note.template.php';
 }
 ?>
 </div>
+
+<script>
+	$(function() {
+		initNoteFilters(<?php echo (int)$GLOBALS['user_system']->getCurrentUser('id'); ?>);
+	});
+</script>

--- a/templates/note_filters.template.php
+++ b/templates/note_filters.template.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Note sidebar: filter checkboxes and action links for the Notes section.
+ *
+ * Expected variables:
+ * @var string|null $add_note_html  HTML for the "Add Note" link, or null
+ */
+$GLOBALS['system']->includeDBClass('abstract_note');
+$statusDummy = new Abstract_Note();
+$statusOptions = $statusDummy->fields['status']['options'];
+?>
+<div class="panel-sidebar pull-right">
+	<i><?php if (!empty($add_note_html)) echo "<i>".$add_note_html."</i>"; ?></i>
+	<fieldset class="hidden-phone">
+		<legend><?php echo _('Status:'); ?></legend>
+		<?php foreach ($statusOptions as $value => $label): ?>
+		<label class="checkbox">
+			<i><input type="checkbox" class="note-status-filter" value="<?php echo $value; ?>" checked>
+			<?php echo ents($label); ?></i>
+		</label>
+		<?php endforeach; ?>
+		<legend><?php echo _('Assignee:'); ?></legend>
+		<label class="checkbox">
+			<i><input type="checkbox" id="note-assignee-filter">
+			<?php echo _('Assigned to me'); ?></i>
+		</label>
+	</fieldset>
+</div>

--- a/templates/single_note.template.php
+++ b/templates/single_note.template.php
@@ -6,13 +6,11 @@
  * @var $show_form
  * @var $show_edit_link
  */
-$dummy->reset();
-$dummy->populate($id, $entry);
 $type = (!empty($entry['familyid']) ? 'family' : 'person');
 include_once 'urllinker.php';
 ?>
 <a name="note_<?php echo $id; ?>"></a>
-<div class="notes-history-entry well <?php echo $type; ?>-note" id="note_<?php echo $id; ?>">
+<div class="notes-history-entry well <?php echo $type; ?>-note" id="note_<?php echo $id; ?>" data-note-id="<?php echo $id; ?>">
 
 
 	<?php
@@ -89,7 +87,7 @@ include_once 'urllinker.php';
 		<?php
 	} else {
 		?>
-		<div class="status">
+		<div class="status" data-note-status="<?php echo $dummy->getValue('status'); ?>" data-note-assignee="<?php echo (int)$entry['assignee']; ?>">
 			<?php
 			$back_to = array_get($_REQUEST, 'note_back_to', '');
 			if ($back_to) $back_to = '&back_to='.ents($back_to);

--- a/templates/view_family.template.php
+++ b/templates/view_family.template.php
@@ -167,24 +167,21 @@ echo $panel_footer;
 if ($GLOBALS['user_system']->havePerm(PERM_VIEWNOTE)) {
 	printf($panel_header, 'notes', 'Notes ('.count($notes).')', '');
 	$show_edit_link = FALSE;
+	$add_note_html = null;
 	if ($GLOBALS['user_system']->havePerm(PERM_EDITNOTE)) {
-		?>
-		<div class="align-right">
-			<?php
-			$members = $family->getMemberData();
-			if (count($members) > 1) {
-				?>
-				<a href="?view=_add_note_to_family&familyid=<?php echo $family->id; ?>"><i class="icon-plus-sign"></i><?php echo _('Add Family Note')?></a>
-				<?php
-			} else if (count($members) == 1) {
-				?>
-				<a href="?view=_add_note_to_person&personid=<?php $memberarray = array_keys($members); echo reset($memberarray); ?>"><?php echo _('Add Person Note')?></a>
-				<?php
-			}
-			?>
-		</div>
-		<?php
+		$members = $family->getMemberData();
+		if (count($members) > 1) {
+			$add_note_html = '<a href="?view=_add_note_to_family&familyid='.ents($family->id).'"><i class="icon-plus-sign"></i>'._('Add Family Note').'</a>';
+		} else if (count($members) == 1) {
+			$memberarray = array_keys($members);
+			$add_note_html = '<a href="?view=_add_note_to_person&personid='.ents(reset($memberarray)).'">'._('Add Person Note').'</a>';
+		}
 		$show_edit_link = TRUE;
+	}
+	if (!empty($notes)) {
+		?>
+<?php include __DIR__ . '/note_filters.template.php'; ?>
+		<?php
 	}
 	include 'list_notes.template.php';
 

--- a/templates/view_person.template.php
+++ b/templates/view_person.template.php
@@ -232,17 +232,22 @@ if (isset($tabs['notes'])) {
 	printf($panel_header, 'notes', _('Notes').' ('.count($notes).')', '');
 
 	if ($GLOBALS['user_system']->havePerm(PERM_EDITNOTE)) {
-		?>
-		<div class="pull-right"><a href="?view=_add_note_to_person&personid=<?php echo $person->id; ?>"><i class="icon-plus-sign"></i><?php echo _('Add Note')?></a></div>
-		<?php
 	}
 	if (empty($notes)) {
 		?>
 		<p><i><?php echo _('There are no person or family notes to show for ')?><?php $person->printFieldValue('name'); ?></i></p>
 		<?php
 	} else {
+		$add_note_html = null;
+		if ($GLOBALS['user_system']->havePerm(PERM_EDITNOTE)) {
+			$add_note_html = '<a href="#add-note-modal" class="note-link" data-toggle="note-modal" data-personid="'.ents($person->id).'" data-name="'.ents($person->getValue('first_name').' '.$person->getValue('last_name')).'"><i class="icon-plus-sign"></i>'._('Add Note').'</a>';
+		}
 		?>
-		<p><i><?php echo _('Person and Family Notes for ')?><?php $person->printFieldValue('name'); ?>:</i></p>
+
+        <?php include __DIR__ . '/note_filters.template.php'; ?>
+		<p>
+			<i><?php echo _('Person and Family Notes for ')?><?php $person->printFieldValue('name'); ?>:</i>
+        </p>
 		<?php
 	}
 	$show_edit_link = true;


### PR DESCRIPTION
Persons sometimes have hundreds of Notes, making it hard to find relevant ones. This commit allows Notes to be filtered, by clicking a set of checkboxes on the right:

```markdown
[ ] No Action Required
[ ] Requires Action
[ ] Failed
[ ] Complete
----
[ ] Assigned to me
```

Visually this is done in a sidebar, and the 'Add Note' button comes along for the ride.

<img width="2028" height="864" alt="image" src="https://github.com/user-attachments/assets/1d5092af-99b6-4f49-a81a-1f17c94a302f" />

Filtering is implemented for both Person and Family notes (reusing code).

[jethro_notes_filtering.webm](https://github.com/user-attachments/assets/fbc837a6-0a63-41b2-b988-d116114920d9)
