### PR TITLE
Fix spurious "group (ID 0) has been deleted" warnings on new Person Reports (#1472)

### DIFF
--- a/db_objects/person_group.class.php
+++ b/db_objects/person_group.class.php
@@ -471,7 +471,7 @@ class Person_Group extends db_object
 
 		$chosen = Array();
 		if (count(array_filter($value)) == 0) {
-			$chosen = Array(0 => Array('name' => '--Choose--'));
+			$chosen = Array('' => Array('name' => '--Choose--'));
 		} else {
 			// For each of our selected groups/categories, we print a select box contining a single option.
 			// The treeselect JS handles the rest.

--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -749,7 +749,7 @@ JethroGroupChooser.initMultiChooser = function() {
 		searchPlaceholder: "Search groups...",
 		onSelectionChange: (selectedNodesData) => {
 			if (selectedNodesData.length == 0) {
-				selectedNodesData = [{id:0,name:"--Choose--"}];
+				selectedNodesData = [{id:'',name:"--Choose--"}];
 			}
 			var name = selectContainer.find('select:first').attr('name');
 			var html = '';
@@ -763,7 +763,7 @@ JethroGroupChooser.initMultiChooser = function() {
 	});
 
 	$(this).find('option').each(function() {
-		if (this.value != 0) {
+		if (this.value !== '') {
 			tree1.selectNodeById(this.value);
 			tree1.expandToShowSelected();
 		}


### PR DESCRIPTION
In reports, where a group may be picked, the "no selection" option needs to be represented by a 'sentinel' value. Jethro has always used '' (blank) as the sentinel, until the recent introduction of a tree-based group picker (8574a276), which inadvertently changed the sentinel to '0'.

This change reverts the sentinel back to '', for general backwards-compatibility, and to avoid warnings about group 0 being invalid/deleted (introduced by 9d6239b).

The sentinel change from 0 to "" (empty string) is in three places:
- printMultiChooser: Array key from 0 to ""
- onSelectionChange callback: default id from 0 to ""
- treeview init loop: skip condition from != 0 to !== ""

Fixes #1472