### PR TITLE
Fix regression caused by #1451: links after bulk actions incorrectly floating right

### DIFF
--- a/templates/bulk_actions.template.php
+++ b/templates/bulk_actions.template.php
@@ -5,7 +5,7 @@ $groupid = array_get($_REQUEST, 'groupid', array_get($_REQUEST, 'person_groupid'
 $selected = Array(array_get($_REQUEST, 'bulk_action', '') => 'selected="selected"'); // email, sms or merge
 ?>
 
-<div class="form-horizontal bulk-actions pull-left">
+<div class="form-horizontal bulk-actions">
 	<?php echo _('With selected persons:')?>
 		<select id="bulk-action-chooser" class="no-autofocus">
 			<option><?php echo _('-- Choose Action --')?></option>


### PR DESCRIPTION
In #1451 (https://github.com/tbar0970/jethro-pmm/commit/09648cea2269a0bd6215cd5df5ec339d826d56e4) we applied `.pull-left` (CSS float:left) to the bulk actions div in order that, on the Family page, the family member action '@Email All' would appear on the right.


This was a bad idea. bulk_actions.template.php is reused in various places besides the Family page, and `.pull-left` broke other uses, such as bulk actions on Person Reports.

It turns out .pull-left isn't necessary even on the Family page, because '@Email All' has `.pull-right`. So the `.pull-left` was unnecessary to begin with.