### PR TITLE
On the error page, make 'Show Details' clickable even in conditions where HTML is messed-up.

### DIFF
--- a/include/system_controller.class.php
+++ b/include/system_controller.class.php
@@ -329,14 +329,14 @@ class System_Controller
 				echo _('An error occurred. Please contact your system administrator for help.');
 			}
 			if ($showTechDetails) {
-				?>
-				<u class="clickable" onclick="var parentDiv=this.parentNode; while (parentDiv.tagName != 'DIV') { parentDiv = parentDiv.parentNode; }; with (parentDiv.getElementsByTagName('PRE')[0].style) { display = (display == 'block') ? 'none' : 'block' }">Show Details</u>
-				<pre style="display: none; background: white; font-weight: normal; color: black"><b>Line <?php echo $errline; ?> of File <?php echo $errfile; ?></b>
-	<?php
-				print_r($bt);
-				?>
+?>
+			    <details>
+			    <summary class="clickable">Show Details</summary>
+				<pre style="background: white; font-weight: normal; color: black"><b>Line <?php echo $errline; ?> of File <?php echo $errfile; ?></b>
+				    <?php ents(print_r($bt)); ?>
 				</pre>
-				<?php
+			    </details>
+<?php
 			}
 			?>
 			</div>


### PR DESCRIPTION
On the error page clicking 'Show Details' exposes the tracktrace. The 'show tracktrace' functionality was previously implemented by Javascript navigating the DOM looking for the div to show. However when HTML is messed up, this didn't work. For example, 'Show Details' didn't work when there is a syntax error in templates/head.template.php:

	<meta name="jethro-test" content="<?php syntaxerror ?>

<img width=50% alt="image" src="https://github.com/user-attachments/assets/f08875d4-bfcf-46c5-98c2-5068dfcaa80e" />

This commit reimplements 'Show Details' using native HTML `<details><summary>...</details>` tags, which don't require Javascript and seem to render even with HTML corruptions like that above.

[jethro_errortoggle.webm](https://github.com/user-attachments/assets/37614cd5-f72a-445f-88cf-3864806945c0)

It works fine when the error occurs in other HTML contexts too:

[jethro_errortoggle2.webm](https://github.com/user-attachments/assets/028c7bd3-f398-4412-a4fd-068d3576a536)
