### PR TITLE
Deterministic order of congregations and groups

### DIFF
--- a/db_objects/person_group.class.php
+++ b/db_objects/person_group.class.php
@@ -456,7 +456,7 @@ class Person_Group extends db_object
 			// Save the groups tree in a JS variable for the treeselect to use
 			$cats = $GLOBALS['system']->getDBObjectData('person_group_category', Array(), 'OR', 'name');
 			$cats[0] = Array('name' => 'Uncategorised groups', 'parent_category' => NULL);
-			$groups = $GLOBALS['system']->getDBObjectData('person_group', Array('is_archived' => 0, 'id' => $value), 'OR', 'name');
+			$groups = $GLOBALS['system']->getDBObjectData('person_group', Array('is_archived' => 0, 'id' => $value), 'OR', 'name, person_group.id');
 			$groupsTreeCache[(int)$allow_category_select] = self::_getGroupTree($cats, $groups, $allow_category_select);
 			$gotGroups = !empty($groups);
 			?>
@@ -526,7 +526,7 @@ class Person_Group extends db_object
 			// Save the groups tree in a JS variable for the treeselect to use
 			$cats = $GLOBALS['system']->getDBObjectData('person_group_category', Array(), 'OR', 'name');
 			$cats[0] = Array('name' => 'Uncategorised groups', 'parent_category' => NULL);
-			$groups = $GLOBALS['system']->getDBObjectData('person_group', Array('is_archived' => 0, 'id' => $value), 'OR', 'name');
+			$groups = $GLOBALS['system']->getDBObjectData('person_group', Array('is_archived' => 0, 'id' => $value), 'OR', 'name, person_group.id');
 			$groupsTreeCache[0] = self::_getGroupTree($cats, $groups, 0);
 			$gotGroups = !empty($groups);
 			?>

--- a/views/view_10_admin__1_congregations.class.php
+++ b/views/view_10_admin__1_congregations.class.php
@@ -49,7 +49,7 @@ class View_Admin__Congregations extends View
 			</thead>
 			<tbody>
 			<?php
-			$congs = $GLOBALS['system']->getDBObjectData('congregation', Array(), 'OR', 'meeting_time');
+			$congs = $GLOBALS['system']->getDBObjectData('congregation', Array(), 'OR', 'meeting_time, id');
 			$deletePrinted = FALSE;
 			$congObject = new Congregation();
 			foreach ($congs as $id => $cong) {


### PR DESCRIPTION
Some Jethro content displays in random order, as SQL order is not fully deterministic. This messes up regression testing. Fixed in two commits:

### Make congregation list ordering deterministic by adding id as secondary sort key

The admin congregations view ordered by meeting_time alone, but meeting_time
is not unique - multiple congregations can have the same value.

[jethro_congregations_not_deterministic.webm](https://github.com/user-attachments/assets/ba454b12-ac6f-4feb-bce5-e38700987dd5)

Added id as a tiebreaker so the list order is stable across requests.

### Group picker: make order deterministic even if there are duplicate group names

Two groups with the same name would appear in arbitrary order in the JethroGroupChooser tree, because the person_group query ordered by name alone. The slight HTML change isn't visible but messes up regression testing.

This change makes order deterministic with a secondary ORDER BY on the group id.
