### PR TITLE
Require POST for destructive handlers so SameSite=Lax can protect them

### DIFF
--- a/views/view_0_generate_service_documents.class.php
+++ b/views/view_0_generate_service_documents.class.php
@@ -135,7 +135,7 @@ class View__Generate_Service_Documents extends View
 			return;
 		}
 		
-		if (!empty($_REQUEST['replacements'])) {
+		if (!empty($_POST['replacements'])) {
 			$method = '_process'.ucfirst($this->_action).'';
 			$this->$method();
 		} else {

--- a/views/view_10_admin__5_action_plans.class.php
+++ b/views/view_10_admin__5_action_plans.class.php
@@ -15,7 +15,7 @@ class View_Admin__Action_Plans extends View
 		if (isset($_REQUEST['planid'])) {
 			$this->_plan = new Action_Plan((int)$_REQUEST['planid']);
 		}
-		if ($this->_plan && !empty($_REQUEST['delete'])) {
+		if ($this->_plan && !empty($_POST['delete'])) {
 			if ($this->_plan->acquireLock()) {
 				$this->_plan->delete();
 				add_message('Action plan deleted');
@@ -107,7 +107,7 @@ class View_Admin__Action_Plans extends View
 							<td class="nowrap"><?php $dummy_plan->printFieldValue('modified'); ?> by <?php echo $dummy_plan->printFieldValue('modifier'); ?></td>
 							<td class="narrow action-cell">
 								<a href="?view=<?php echo ents($_REQUEST['view']); ?>&planid=<?php echo $id; ?>"><i class="icon-wrench"></i>Edit</a> &nbsp;
-								<a href="?view=<?php echo ents($_REQUEST['view']); ?>&planid=<?php echo $id; ?>&delete=1" class="confirm-title" title="Delete this action plan"><i class="icon-trash"></i>Delete</a>
+								<a href="?view=<?php echo ents($_REQUEST['view']); ?>&planid=<?php echo $id; ?>&delete=1" data-method="post" class="confirm-title" title="Delete this action plan"><i class="icon-trash"></i>Delete</a>
 							</td>
 						</tr>
 						<?php

--- a/views/view_3_persons__3_reports.class.php
+++ b/views/view_3_persons__3_reports.class.php
@@ -20,7 +20,7 @@ class View_Persons__Reports extends View
 				$this->_query->setValue('params', $params);
 			}
 		}
-		if ($this->_query && !empty($_REQUEST['delete'])) {
+		if ($this->_query && !empty($_POST['delete'])) {
 			$can_delete = FALSE;
 			if (($this->_query->getValue('creator') == $GLOBALS['user_system']->getCurrentUser('id')) || $GLOBALS['user_system']->havePerm(PERM_SYSADMIN)) {
 				$can_delete = true;

--- a/views/view_7_rosters__4_define_roster_views.class.php
+++ b/views/view_7_rosters__4_define_roster_views.class.php
@@ -8,8 +8,8 @@ class View_Rosters__Define_Roster_Views extends View
 
 	function processView()
 	{
-		if (!empty($_REQUEST['delete_viewid'])) {
-			$view = $GLOBALS['system']->getDBOBject('roster_view', (int)$_REQUEST['delete_viewid']);
+		if (!empty($_POST['delete_viewid'])) {
+			$view = $GLOBALS['system']->getDBOBject('roster_view', (int)$_POST['delete_viewid']);
 			if ($view) {
 				$view->delete();
 				add_message('View Deleted');
@@ -55,7 +55,7 @@ class View_Rosters__Define_Roster_Views extends View
 				<td><?php echo ents($details['members']); ?></td>
 				<td class="nowrap">
 					<a href="?view=_edit_roster_view&roster_viewid=<?php echo $id; ?>"><i class="icon-wrench"></i>Edit</a> &nbsp;
-					<a href="<?php echo build_url(Array('delete_viewid'=>$id)); ?>" class="confirm-title" title="Delete this roster view altogether"><i class="icon-trash"></i>Delete</a>
+					<a href="<?php echo build_url(Array('delete_viewid'=>$id)); ?>" data-method="post" class="confirm-title" title="Delete this roster view altogether"><i class="icon-trash"></i>Delete</a>
 				</td>
 			</tr>
 			<?php

--- a/views/view_8_services.class.php
+++ b/views/view_8_services.class.php
@@ -44,14 +44,14 @@ class View_services extends View
 					}
 				}
 
-				if (!empty($_REQUEST['action'])) {
-					$action = $_REQUEST['action'];
+				if (!empty($_POST['action'])) {
+					$action = $_POST['action'];
 					switch ($action) {
 						case "copy":
-							if (!empty($_REQUEST['copy_service_id']) && !empty($_REQUEST['copy_category_ids'])) {
-								$fromService = new Service((int)$_REQUEST['copy_service_id']);
+							if (!empty($_POST['copy_service_id']) && !empty($_POST['copy_category_ids'])) {
+								$fromService = new Service((int)$_POST['copy_service_id']);
 								if (!$fromService) {
-									trigger_error("Service ".(int)$_REQUEST['copy_service_id']." not found - could not copy");
+									trigger_error("Service ".(int)$_POST['copy_service_id']." not found - could not copy");
 									return;
 								}
 								$newItems = $fromService->getItems();
@@ -65,7 +65,7 @@ class View_services extends View
 									} else {
 										$v['categoryid'] = '!'; // magic value to match filtering of ad hoc items
 									}
-									if (!in_array($v['categoryid'], $_REQUEST['copy_category_ids'])) {
+									if (!in_array($v['categoryid'], $_POST['copy_category_ids'])) {
 										unset($newItems[$k]);
 									}
 								}
@@ -97,43 +97,45 @@ class View_services extends View
 							$this->service->releaseLock('items');
 							redirect("services", Array("date" => $this->date, "congregationid" => $this->congregationid, '*' => NULL));  // Redirecting clears &editing=1
 							break;
-						case strncmp($action, 'nav_', 4) === 0:
-							if ($this->editing) $this->service->releaseLock('items');
-							switch ($action) {
-								case "nav_allservices":
-									// 'All services' nav link clicked in edit mode. Release lock and redirect
-									redirect("services__list_all", Array('*' => null));  // Redirecting clears &editing=1
-									break;
-								case "nav_prevdate":
-									// 'Prev' link clicked in edit mode. Release lock, redirect to previous week, retaining
-									// other params.
-									$prevDate = $this->getPrevServiceDate();
-									redirect("services", Array("action" => null, "date" => $prevDate));  // Redirecting clears &editing=1
-									break;
-								case "nav_nextdate":
-									// 'Next' link clicked in edit mode. Release lock, redirect to next week, retaining
-									// other params.
-									$nextDate = $this->getNextServiceDate();
-									redirect("services", Array("action" => null, "date" => $nextDate));  // Redirecting clears &editing=1
-									break;
-								case "nav_prevservice":
-									// 'Prev' link clicked in edit mode. Release lock, redirect to previous week, retaining
-									// other params.
-									$prevCong = $this->getEarlierServiceCong();
-									redirect("services", Array("action" => null, "congregationid" => $prevCong["id"]));  // Redirecting clears &editing=1
-									break;
-								case "nav_nextservice":
-									// 'Next' link clicked in edit mode. Release lock, redirect to next week, retaining
-									// other params.
-									$nextCong = $this->getLaterServiceCong();
-									redirect("services", Array("action" => null, "congregationid" => $nextCong["id"]));  // Redirecting clears &editing=1
-									break;
-							}
 						default:
 							trigger_error("No 'action' parameter found");
 							break;
 					}
 
+				}
+				if (!empty($_REQUEST['action']) && strncmp($_REQUEST['action'], 'nav_', 4) === 0) {
+					$action = $_REQUEST['action'];
+					if ($this->editing) $this->service->releaseLock('items');
+					switch ($action) {
+						case "nav_allservices":
+							// 'All services' nav link clicked in edit mode. Release lock and redirect
+							redirect("services__list_all", Array('*' => null));  // Redirecting clears &editing=1
+							break;
+						case "nav_prevdate":
+							// 'Prev' link clicked in edit mode. Release lock, redirect to previous week, retaining
+							// other params.
+							$prevDate = $this->getPrevServiceDate();
+							redirect("services", Array("action" => null, "date" => $prevDate));  // Redirecting clears &editing=1
+							break;
+						case "nav_nextdate":
+							// 'Next' link clicked in edit mode. Release lock, redirect to next week, retaining
+							// other params.
+							$nextDate = $this->getNextServiceDate();
+							redirect("services", Array("action" => null, "date" => $nextDate));  // Redirecting clears &editing=1
+							break;
+						case "nav_prevservice":
+							// 'Prev' link clicked in edit mode. Release lock, redirect to previous week, retaining
+							// other params.
+							$prevCong = $this->getEarlierServiceCong();
+							redirect("services", Array("action" => null, "congregationid" => $prevCong["id"]));  // Redirecting clears &editing=1
+							break;
+						case "nav_nextservice":
+							// 'Next' link clicked in edit mode. Release lock, redirect to next week, retaining
+							// other params.
+							$nextCong = $this->getLaterServiceCong();
+							redirect("services", Array("action" => null, "congregationid" => $nextCong["id"]));  // Redirecting clears &editing=1
+							break;
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
Four state-changing actions accepted GET via $_REQUEST, bypassing SameSite=Lax cookie protection (which only blocks cross-site POST, not top-level GET navigation):

1. Delete action plan — added data-method="post" to the delete link and changed $_REQUEST to $_POST
2. Delete saved report — link already had data-method="post"; changed $_REQUEST to $_POST
3. Mutate service run sheet — destructive actions (save/copy/cancel) now require POST; nav_* GET links kept as-is (lock-release only, not destructive)
4. Generate service documents — form already post'ed but changed $_REQUEST to $_POST to disallow GET