### PR TITLE
Security: Add ents() to unescaped view param echoes

### DIFF
--- a/views/abstract_view_notes_list.class.php
+++ b/views/abstract_view_notes_list.class.php
@@ -62,7 +62,7 @@ abstract class Abstract_View_Notes_List extends View
 		}
 		?>
 		<form class="well well-small form-inline">
-		<input type="hidden" name="view" value="<?php echo $_REQUEST['view']; ?>" />
+		<input type="hidden" name="view" value="<?php echo ents($_REQUEST['view']); ?>" />
 		<?php
 		$string = "Show %s of notes assigned to %s with subject containing %s";
 

--- a/views/view_6_attendance__1_record.class.php
+++ b/views/view_6_attendance__1_record.class.php
@@ -483,7 +483,7 @@ class View_Attendance__Record extends View
 			$set->printStats();
 		}
 		?>
-		<p><a href="?view=<?php echo $_REQUEST['view']; ?>"><i class="icon-pencil"></i><?php echo _('Record more attendances');?></a></p>
+		<p><a href="?view=<?php echo ents($_REQUEST['view']); ?>"><i class="icon-pencil"></i><?php echo _('Record more attendances');?></a></p>
 		<p><a href="?view=persons__reports"><i class="icon-list"></i><?php echo _('Analyse attendance using a person report');?></a></p>
 		<?php
 	}

--- a/views/view_6_attendance__2_display.class.php
+++ b/views/view_6_attendance__2_display.class.php
@@ -83,7 +83,7 @@ class View_Attendance__Display extends View
 	{
 		?>
 		<form method="get" class="well well-small clearfix form-inline no-print">
-			<input type="hidden" name="view" value="<?php echo $_REQUEST['view']; ?>" />
+			<input type="hidden" name="view" value="<?php echo ents($_REQUEST['view']); ?>" />
 			<table class="attendance-config-table">
 				<tr>
 					<th><?php echo _('For');?></th>

--- a/views/view_6_attendance__3_statistics.class.php
+++ b/views/view_6_attendance__3_statistics.class.php
@@ -39,7 +39,7 @@ class View_Attendance__Statistics extends View
 	{
 		?>
 		<form method="get" style="line-height: 200%" class="well well-small form-inline">
-		<input type="hidden" name="view" value="<?php echo $_REQUEST['view']; ?>" />
+		<input type="hidden" name="view" value="<?php echo ents($_REQUEST['view']); ?>" />
 		<?php echo _('Show the attendance statistics for persons of each (current) status');?> <br />
 		<?php echo _('between');?> <?php print_widget('start_date', Array('type' => 'date'), $this->_start_date); ?>
 		<?php echo _('and');?>  <?php print_widget('end_date', Array('type' => 'date'), $this->_end_date); ?>


### PR DESCRIPTION
Although 'view' is set by the user, this isn't exploitable because system_controller routes on 'view' and would break on anything bad. Wrapping in ents() is just defense-in-depth.