### PR TITLE
Handle non-existent objects gracefully instead of showing stack traces

### DIFF
--- a/calls/call_display_roster.class.php
+++ b/calls/call_display_roster.class.php
@@ -20,6 +20,10 @@ class Call_Display_Roster extends Call
 		$roster_id = (int)array_get($_REQUEST, 'viewid');
 		if (empty($roster_id)) return;
 		$view = $GLOBALS['system']->getDBObject('roster_view', $roster_id);
+		if (!$view) {
+			trigger_error('Roster view #'.$roster_id.' not found', E_USER_WARNING);
+			return;
+		}
 
 		?>
 		<html>

--- a/calls/call_document_merge.class.php
+++ b/calls/call_document_merge.class.php
@@ -247,6 +247,10 @@ class Call_Document_Merge extends Call
 					// (eg "selected groups", "other family members" etc) to the merge data.
 					// Make sure the report returns a 'flat' array by removing grouping.
 					$query = $GLOBALS['system']->getDBObject('person_query',$_REQUEST['queryid']);
+					if (!$query) {
+						trigger_error('Report #'.(int)$_REQUEST['queryid'].' not found', E_USER_WARNING);
+						return;
+					}
 					$params = $query->getValue('params');
 					$params['group_by'] = NULL;
 					$query->setValue('params', $params);

--- a/calls/call_document_merge_rosters.class.php
+++ b/calls/call_document_merge_rosters.class.php
@@ -27,6 +27,10 @@ class Call_Document_merge_rosters extends Call
 			case 'xlsx':
 			case 'ppt':
 				$view = $GLOBALS['system']->getDBObject('roster_view', $roster_id);
+				if (!$view) {
+					trigger_error('Roster view #'.$roster_id.' not found', E_USER_WARNING);
+					return;
+				}
 				$start_date = substr(array_get($_REQUEST, 'start_date', ''), 0, 10);
 				$end_date = substr(array_get($_REQUEST, 'end_date', ''), 0, 10);
 				$data = $view->printCSV($start_date, $end_date, TRUE);

--- a/calls/call_email.class.php
+++ b/calls/call_email.class.php
@@ -10,12 +10,20 @@ class Call_email extends Call
 
 		if (!empty($_REQUEST['queryid'])) {
 			$query = $GLOBALS['system']->getDBObject('person_query', (int)$_REQUEST['queryid']);
+			if (!$query) {
+				trigger_error('Report #'.(int)$_REQUEST['queryid'].' not found', E_USER_WARNING);
+				return;
+			}
 			$personids = $query->getResultPersonIDs();
 			$recips = $GLOBALS['system']->getDBObjectData('person', Array('(id' => $personids, '!email' => '', '!(status' => Person_Status::getArchivedIDs()), 'AND');
 			$blanks = $GLOBALS['system']->getDBObjectData('person', Array('(id' => $personids, 'email' => '', '!(status' => Person_Status::getArchivedIDs()), 'AND');
 			$archived = $GLOBALS['system']->getDBObjectData('person', Array('(id' => $personids, '(status' => Person_Status::getArchivedIDs()), 'AND');
 		} else if (!empty($_REQUEST['groupid'])) {
 			$group = $GLOBALS['system']->getDBObject('person_group', (int)$_REQUEST['groupid']);
+			if (!$group) {
+				trigger_error('Group #'.(int)$_REQUEST['groupid'].' not found', E_USER_WARNING);
+				return;
+			}
 			$personids = array_keys($group->getMembers());
 			$recips = $GLOBALS['system']->getDBObjectData('person', Array('(id' => $personids, '!email' => '', '!(status' => Person_Status::getArchivedIDs()), 'AND');
 			$blanks = $GLOBALS['system']->getDBObjectData('person', Array('(id' => $personids, 'email' => '', '!(status' => Person_Status::getArchivedIDs()), 'AND');
@@ -24,6 +32,10 @@ class Call_email extends Call
 			$recips = Array();
 			foreach ((array)$_REQUEST['roster_view'] as $viewid) {
 				$view = $GLOBALS['system']->getDBObject('roster_view', (int)$viewid);
+				if (!$view) {
+					trigger_error('Roster view #'.(int)$viewid.' not found', E_USER_WARNING);
+					continue;
+				}
 				$recips += $view->getAssignees($_REQUEST['start_date'], $_REQUEST['end_date']);
 			}
 		} else {

--- a/calls/call_envelopes.class.php
+++ b/calls/call_envelopes.class.php
@@ -15,6 +15,10 @@ class Call_Envelopes extends Call
 		$GLOBALS['system']->includeDBClass('family');
 		if (!empty($_REQUEST['familyid'])) {
 			$family = $GLOBALS['system']->getDBObject('family', (int)$_REQUEST['familyid']);
+			if (!$family) {
+				trigger_error('Family #'.(int)$_REQUEST['familyid'].' not found', E_USER_WARNING);
+				return;
+			}
 			$env->addAddress($family->getAdultMemberNames()."\n".$family->getPostalAddress());
 		}
 		if (!empty($_REQUEST['personid'])) {
@@ -54,6 +58,10 @@ class Call_Envelopes extends Call
 				}
 			} else {
 				$person = $GLOBALS['system']->getDBObject('person', (int)$_REQUEST['personid']);
+				if (!$person) {
+					trigger_error('Person #'.(int)$_REQUEST['personid'].' not found', E_USER_WARNING);
+					return;
+				}
 				$family = $GLOBALS['system']->getDBObject('family', $person->getValue('familyid'));
 				$env->addAddress($person->toString()."\n".$family->getPostalAddress());
 			}

--- a/calls/call_report_csv.class.php
+++ b/calls/call_report_csv.class.php
@@ -8,6 +8,10 @@ class Call_Report_CSV extends Call
 			$queryid = ($queryid == 'TEMP') ? $queryid : (int)$queryid;
 			if ($queryid) {
 				$report = $GLOBALS['system']->getDBObject('person_query', $queryid);
+				if (!$report) {
+					trigger_error('Report #'.$queryid.' not found', E_USER_WARNING);
+					return;
+				}
 				$reportname = $report->getValue('name');
 				if (empty($reportname)) $reportname = 'Jethro-Report-'.date('Y-m-d_H:i');
 				header('Content-type: application/force-download');

--- a/calls/call_roster_csv.class.php
+++ b/calls/call_roster_csv.class.php
@@ -20,6 +20,10 @@ class Call_Roster_CSV extends Call
 		$roster_id = (int)array_get($_REQUEST, 'roster_view');
 		if (empty($roster_id)) return;
 		$view = $GLOBALS['system']->getDBObject('roster_view', $roster_id);
+		if (!$view) {
+			trigger_error('Roster view #'.$roster_id.' not found', E_USER_WARNING);
+			return;
+		}
 		$start_date = substr(array_get($_REQUEST, 'start_date', ''), 0, 10);
 		$end_date = substr(array_get($_REQUEST, 'end_date', ''), 0, 10);
 		header('Content-type: text/csv');

--- a/calls/call_service_content.class.php
+++ b/calls/call_service_content.class.php
@@ -10,6 +10,10 @@ class Call_Service_Content extends Call
 	function run()
 	{
 		$service = $GLOBALS['system']->getDBObject('service', (int)$_REQUEST['serviceid']);
+		if (!$service) {
+			trigger_error('Service #'.(int)$_REQUEST['serviceid'].' not found', E_USER_WARNING);
+			return;
+		}
 
 		?>
 		<html>

--- a/calls/call_service_plan.class.php
+++ b/calls/call_service_plan.class.php
@@ -10,6 +10,10 @@ class Call_Service_Plan extends Call
 	function run()
 	{
 		$service = $GLOBALS['system']->getDBObject('service', (int)$_REQUEST['serviceid']);
+		if (!$service) {
+			trigger_error('Service #'.(int)$_REQUEST['serviceid'].' not found', E_USER_WARNING);
+			return;
+		}
 
 		?>
 		<html>

--- a/calls/call_service_slides.class.php
+++ b/calls/call_service_slides.class.php
@@ -6,6 +6,10 @@ class Call_Service_slides extends Call
 	{
 		//get service data from database
 		$service = $GLOBALS['system']->getDBObject('service', (int)$_REQUEST['serviceid']);
+		if (!$service) {
+			trigger_error('Service #'.(int)$_REQUEST['serviceid'].' not found', E_USER_WARNING);
+			return;
+		}
 		$serviceContent = $service->getServiceContent();
 
 		//options

--- a/views/abstract_view_edit_object.class.php
+++ b/views/abstract_view_edit_object.class.php
@@ -25,7 +25,8 @@ class Abstract_View_Edit_Object extends View
 		}
 		$this->_edited_object = $GLOBALS['system']->getDBObject($this->_editing_type, (int)$_REQUEST[$this->_object_id_field]);
 		if (is_null($this->_edited_object)) {
-			trigger_error($this->getEditingTypeFriendly().' #'.(int)$_REQUEST[$this->_object_id_field].' does not exist', E_USER_WARNING);
+			if (!headers_sent()) http_response_code(404);
+			add_message($this->getEditingTypeFriendly().' #'.(int)$_REQUEST[$this->_object_id_field].' does not exist', 'error');
 			return false;
 		}
 		return true;

--- a/views/view_0_delete_person.class.php
+++ b/views/view_0_delete_person.class.php
@@ -25,7 +25,11 @@ class View__Delete_Person extends View
 		if ($_REQUEST['personid']) {
 			$this->_person = new Person((int)$_REQUEST['personid']);
 		}
-		if (empty($this->_person)) throw new \RuntimeException("Person not found"); // exits
+		if (empty($this->_person->id)) {
+			if (!headers_sent()) http_response_code(404);
+			add_message("Person not found", 'error');
+			return;
+		}
 		$this->_staff_member = $GLOBALS['system']->getDBObject('staff_member', $this->_person->id);
 
 		$this->_notes = $GLOBALS['system']->getDBObjectData(
@@ -81,11 +85,13 @@ class View__Delete_Person extends View
 
 	public function getTitle()
 	{
+		if (empty($this->_person->id)) return _('Person not found');
 		return _('Delete ').$this->_person->toString();
 	}
 
 	public function printView()
 	{
+		if (empty($this->_person->id)) return;
 		$buttons = Array(
 					'archive' => _('Archive only'),
 					'archiveclean' => _('Archive and Cleanse'),

--- a/views/view_0_edit_congregation.class.php
+++ b/views/view_0_edit_congregation.class.php
@@ -12,7 +12,8 @@ class View__Edit_Congregation extends View
 	{
 		$this->_congregation = $GLOBALS['system']->getDBObject('congregation', (int)$_REQUEST['congregationid']);
 		if (is_null($this->_congregation)) {
-			trigger_error('Congregation #'.(int)$_REQUEST['congregationid'].' does not exist', E_USER_WARNING);
+			if (!headers_sent()) http_response_code(404);
+			add_message('Congregation #'.(int)$_REQUEST['congregationid'].' does not exist', 'error');
 			return;
 		}
 


### PR DESCRIPTION
Requesting a non-existent object by ID (stale link, deleted record) now shows a user-friendly error message instead of a "SYSTEM ERROR" stack trace or a null-pointer crash:

<img width=300px alt="image" src="https://github.com/user-attachments/assets/5d6d8390-b8c8-4d4c-af9d-8901c23722e4" />


Views: replaced trigger_error()/RuntimeException with add_message() + HTTP 404 in abstract_view_edit_object.class.php (affects all 9 edit views), view_0_edit_congregation.class.php, view_0_delete_family.class.php, and view_0_delete_person.class.php. Added null guards to getTitle()/printView().  Fixed delete_person to check $this->_person->id (new Person() always returns an object even for non-existent IDs).

Calls: added null checks after getDBObject() in 10 call files that previously crashed with "Call to member function on null" when given non-existent IDs: call_service_content, call_service_slides, call_service_plan, call_envelopes, call_email, call_display_roster, call_roster_csv, call_document_merge_rosters, call_document_merge, and call_report_csv.  Handle non-existent objects gracefully instead of showing stack traces

URLs that previously broke:

?view=_edit_service_component&service_componentid=99999
?view=_edit_congregation&congregationid=99999
?view=_edit_person&personid=99999
?view=_edit_family&familyid=99999
?view=_edit_group&groupid=99999
?view=_edit_venue&venueid=99999
?view=_edit_roster_role&roster_roleid=99999
?view=_edit_roster_view&roster_viewid=99999
?view=_edit_group_category&categoryid=99999

?view=_delete_family&familyid=99999
?view=_delete_person&personid=99999

?call=service_content&serviceid=99999
?call=service_slides&serviceid=99999
?call=service_plan&serviceid=99999
?call=envelopes&familyid=99999
?call=envelopes&personid=99999
?call=email&queryid=99999&print_popup=1
?call=email&groupid=99999&print_popup=1
?call=email&roster_view[]=99999&print_popup=1
?call=display_roster&viewid=99999
?call=roster_csv&roster_view=99999
?call=report_csv&queryid=99999