### PR TITLE
On settings page, only hide actually sensitive credential settings

### DIFF
--- a/include/config_manager.class.php
+++ b/include/config_manager.class.php
@@ -36,6 +36,25 @@ class Config_Manager {
 		return FALSE;
 	}
 
+	/**
+	 * Whether a setting symbol names a credential that should never be
+	 * displayed on the config page (e.g. API keys, passwords).
+	 *
+	 * Uses a naming convention rather than a hardcoded list. Any setting
+	 * containing APIKEY, API_KEY, PASSWORD, SECRET, or TOKEN in its name
+	 * is treated as sensitive.
+	 */
+	public static function isCredentialSetting(string $symbol): bool
+	{
+		$upper = strtoupper($symbol);
+		return str_contains($upper, 'APIKEY')
+			|| str_contains($upper, 'API_KEY')
+			|| str_contains($upper, 'PASSWORD')
+			|| str_contains($upper, 'SECRET')
+			|| str_contains($upper, 'TOKEN');
+	}
+
+
 	public static function getSettings()
 	{
 		$SQL = 'SELECT symbol, s.* from setting s ORDER BY `rank`';

--- a/views/view_10_admin__6_system_configuration.class.php
+++ b/views/view_10_admin__6_system_configuration.class.php
@@ -92,7 +92,7 @@ class View_Admin__System_Configuration extends View {
 					<div class="controls">
 						<?php
 						if (defined($symbol.'_IN_CONFIG_FILE')) {
-							if (Config_Manager::allowSettingInFile($symbol) && constant($symbol)) {
+							if (Config_Manager::allowSettingInFile($symbol) && constant($symbol) && Config_Manager::isCredentialSetting($symbol)) {
 								// Don't show the value here - sensitive
 								print_message('This setting has been set in the system config file', 'warning');
 								if ($details['note']) echo '<p class="smallprint">'.ents($details['note']).'</p>';


### PR DESCRIPTION
Previously, any setting with a certain prefix (SMS_*, 2FA_*, SMTP*, MAILCHIMP_*) would be hidden on the settings page if set in conf.php. This was implemented as a simple constant() truthiness check. But that hides settings that are harmless and useful to show, like a custom SMS_MAX_LENGTH (e.g. '160') and SMTP_SERVER ('mail.example.com').

This change only hides prefixed settings whose names indicate they contain sensitive credentials: APIKEY, API_KEY, PASSWORD, SECRET, or TOKEN. This is done in Config_Manager::isCredentialSetting(). Just as Config_Manager::allowSettingInFile() checks prefixes (SMS_*, etc) so Config_Manager::isCredentialSetting() now checks suffixes, so the change is architecturally consistent.

Note: the motivation for this is that I have a pending PR that introduces another 10+ `SMS_*` constants that aren't sensitive and an administrator really does want to be able to see, that the current code hides, e.g. SMS sender options:

<img width="910" height="337" alt="image" src="https://github.com/user-attachments/assets/318651d9-a7c4-4c79-89b4-a3522ec01a3f" />