### PR TITLE
Bugfix: the installer breaks due to missing ENABLED_FEATURES

### DIFF
--- a/include/config_manager.class.php
+++ b/include/config_manager.class.php
@@ -54,7 +54,7 @@ class Config_Manager {
 
 	public static function migrateEnabledFeatures()
 	{
-		$value = explode(',', ENABLED_FEATURES);
+		$value = explode(',', ifdef('ENABLED_FEATURES', ''));
 		$value = array_diff($value, Array('DATES'));
 		self::saveSetting('ENABLED_FEATURES', implode(',', $value));
 

--- a/include/system_controller.class.php
+++ b/include/system_controller.class.php
@@ -77,8 +77,8 @@ class System_Controller
 	 * @return string A hash
 	 */
 	private function getViewHash(): string {
-        $currentUser = $GLOBALS['user_system']->getCurrentUser();
-        return sha1(ENABLED_FEATURES . ($currentUser ? $currentUser['permissions'] : ''));
+		$currentUser = $GLOBALS['user_system']->getCurrentUser();
+		return sha1(ifdef('ENABLED_FEATURES', '') . ($currentUser ? $currentUser['permissions'] : ''));
 	}
 
 	/**


### PR DESCRIPTION
Pull request #1456 (commit f471b46f) added a dependency on ENABLED_FEATURES in System_Controller, but ENABLED_FEATURES isn't defined when the database is empty, resulting in a fatal error on the installer:

```
Fatal error: Uncaught Error: Undefined constant
 "ENABLED_FEATURES" in /home/jethro/code/dev/include/system_controller.class.php:81 Stack trace: #0
 /home/jethro/code/dev/include/system_controller.class.php(90): System_Controller->getViewHash() #1
 /home/jethro/code/dev/include/system_controller.class.php(39): System_Controller->viewsAreStale() #2
 /home/jethro/code/dev/include/system_controller.class.php(26): System_Controller->__construct() #3
 /home/jethro/code/dev/include/installer.class.php(27): System_Controller::get() #4
 /home/jethro/code/dev/templates/installer.template.php(15): Installer->printBody() #5
 /home/jethro/code/dev/include/installer.class.php(20): include('...') #6 /home/jethro/code/dev/index.php(59): Installer->run() #7 {main}
thrown in /home/jethro/code/dev/include/system_controller.class.php on line 81 
```