### PR TITLE
Add optional Reply-To configuration to reminder scripts

### DIFF
--- a/scripts/date_reminder.php
+++ b/scripts/date_reminder.php
@@ -84,6 +84,9 @@ if (!empty($ini['SMS_MESSAGE'])) {
 	}
 }
 require_once JETHRO_ROOT.'/include/emailer.class.php';
+$replyToAddress = !empty($ini['REPLY_TO_ADDRESS']) ? $ini['REPLY_TO_ADDRESS'] : null;
+$replyToName    = !empty($ini['REPLY_TO_NAME'])    ? $ini['REPLY_TO_NAME']    : null;
+
 
 // Send individual reminders and collate summary info
 $summaries = Array();
@@ -119,6 +122,10 @@ foreach ($summaries as $supervisors => $remindees) {
 	} else {
 		$message->setTo(explode(';', $supervisors));
 	}
+
+	if ($replyToAddress) {
+		$message->setReplyTo($replyToAddress, $replyToName);
+	}
 	$res = Emailer::send($message);
 	if (!$res) {
 		echo "Failed to send summary email to $supervisors \n";
@@ -131,7 +138,7 @@ foreach ($summaries as $supervisors => $remindees) {
 
 function send_reminder($person, $expiryDate)
 {
-	global $ini;
+	global $ini, $replyToAddress, $replyToName;
 	
 	$sentSomething = FALSE;
 	if (!empty($ini['EMAIL_BODY'])) {
@@ -148,6 +155,10 @@ function send_reminder($person, $expiryDate)
 			  ->setTo(array($toEmail => $person['first_name'].' '.$person['last_name']))
 			  ->setBody($content)
 			  ->addPart($html, 'text/html');
+
+			if ($replyToAddress) {
+				$message->setReplyTo($replyToAddress, $replyToName);
+			}
 
 			$res = Emailer::send($message);
 			if (!$res) {

--- a/scripts/date_reminder_sample.ini
+++ b/scripts/date_reminder_sample.ini
@@ -13,6 +13,10 @@ FROM_ADDRESS = "noreply@example.com"
 ; Name from which the email will be sent
 FROM_NAME = "Safe Ministry Reminders"
 
+; Reply-To address for the emails (optional).  Replies will go here instead of the From address.
+;REPLY_TO_ADDRESS = "replies@example.com"
+;REPLY_TO_NAME = "Replies Here"
+
 ; Subject of the email to be sent
 ; Can include %CONGREGATIONID%, %EXPIRYDATE%, %FIRST_NAME%, %LAST_NAME% etc.
 SUBJECT = "%CONGREGATIONID% Safe Ministry Renewal Reminder"

--- a/scripts/roster_reminder.php
+++ b/scripts/roster_reminder.php
@@ -63,7 +63,7 @@ $ini = parse_ini_file($_SERVER['argv'][1]);
 function getvar($name, $default = null) {
 	global $ini;	// Access the $ini array from the global scope
 	if (!isset($ini[$name])) {
-		if ($default === null) {
+		if (func_num_args() < 2) {
 			throw new \RuntimeException("$name is required");
 		} else {
 			return $default;
@@ -83,6 +83,9 @@ if ($sendemail) {
 	$email_from=getvar('EMAIL_FROM');
 	$email_subject=getvar('EMAIL_SUBJECT');
 	$phpMail=getvar('PHP_MAIL', 0);
+	$reply_to_address = getvar('REPLY_TO_ADDRESS', null);
+	$reply_to_name = getvar('REPLY_TO_NAME', null);
+
 }
 if ($sendsms) {
 	$roster_coordinator_id=getvar('ROSTER_COORDINATOR_ID');
@@ -320,6 +323,9 @@ if ($sendemail) {
 			  ->addPart($longstring, 'text/html')
 			  ->setTo(explode(',',$roster_coordinator))
 			  ->setBcc($emails);
+			if ($reply_to_address) {
+				$message->setReplyTo($reply_to_address, $reply_to_name);
+			}
 			$res = Emailer::send($message);
 		  if (!$res) {
 				echo "Failed to send roster reminder (".$roster_name.")\n";
@@ -332,6 +338,10 @@ if ($sendemail) {
 		} else { // using php mail()
 		  $email_to=$roster_coordinator;
 		  $header = "From: \"".addslashes($email_from_name)."\" <".$email_from.">".$eol;
+		  if ($reply_to_address) {
+		  	$replyToHeader = $reply_to_name ? "\"".addslashes($reply_to_name)."\" <".$reply_to_address.">" : $reply_to_address;
+		  	$header .= "Reply-To: ".$replyToHeader.$eol;
+		  }
 		  $header .= "MIME-Version: 1.0".$eol;
 		  $header .= "Bcc: ".implode(',',$emails).$eol;
 		  $header .= "Content-Type: multipart/mixed; boundary=\"".$uid."\"";
@@ -373,6 +383,9 @@ if ($sendemail) {
 			->setBody($summary_notification_subject)
 			->addPart($summary, 'text/html')
 			->setTo(explode(',',$roster_coordinator));
+		if ($reply_to_address) {
+			$message2->setReplyTo($reply_to_address, $reply_to_name);
+		}
 		$res = Emailer::send($message2);
 		if (!$res) {
 			echo "Failed to send roster ($roster_name) reminder summary to coordinator\n";
@@ -386,7 +399,11 @@ if ($sendemail) {
 		$email_to=$roster_coordinator;
 		$header = "From: \"".addslashes($email_from_name)."\" <".$email_from.">".$eol;
 		$header .= "MIME-Version: 1.0".$eol;
-		$header .= "Content-Type: multipart/mixed; boundary=\"".$uid."\"";
+		$header .= "Content-Type: multipart/mixed; boundary=\"".$uid."\"".$eol;
+		if ($reply_to_address) {
+			$replyToHeader = $reply_to_name ? "\"".addslashes($reply_to_name)."\" <".$reply_to_address.">" : $reply_to_address;
+			$header .= "Reply-To: ".$replyToHeader.$eol;
+		}
 		$message = "--".$uid.$eol;
 		$message .= "Content-type:text/html; charset=iso-8859-1".$eol;
 		$message .= "Content-Transfer-Encoding: 8bit".$eol.$eol;

--- a/scripts/roster_reminder_sample.ini
+++ b/scripts/roster_reminder_sample.ini
@@ -38,6 +38,10 @@ LIST_NOT_TABLE=1
 EMAIL_FROM='no-reply@church.something'
 ; [Email only; required]
 EMAIL_FROM_NAME='no-reply'
+; Email only; optional. Reply-To address - replies will go here instead of the From address.
+;REPLY_TO_ADDRESS='replies@church.something'
+;REPLY_TO_NAME='Replies Here'
+
 ; [Email only; required]
 EMAIL_SUBJECT='roster reminder - Sunday'
 

--- a/scripts/task_reminder.php
+++ b/scripts/task_reminder.php
@@ -54,6 +54,8 @@ if (!defined('TASK_NOTIFICATION_FROM_ADDRESS')) {
 $reminders = Abstract_Note::getNotifications($minutes);
 $fromText = ifdef('TASK_NOTIFICATION_FROM_NAME', SYSTEM_NAME.' Jethro');
 $subject = ifdef('TASK_NOTIFICATION_SUBJECT', 'New notes assigned to you');
+$replyToAddress = ifdef('TASK_NOTIFICATION_REPLY_TO_ADDRESS', null);
+$replyToName = ifdef('TASK_NOTIFICATION_REPLY_TO_NAME', null);
 
 require_once JETHRO_ROOT.'/include/emailer.class.php';
 
@@ -79,6 +81,10 @@ foreach ($reminders as $reminder) {
 	  ->setTo(array($reminder['email'] => $reminder['first_name'].' '.$reminder['last_name']))
 	  ->setBody($content)
 	  ->addPart($html, 'text/html');
+
+	if ($replyToAddress) {
+		$message->setReplyTo($replyToAddress, $replyToName);
+	}
 
 	if ($DRYRUN) {
 		$res = TRUE;


### PR DESCRIPTION
Jethro hosters like easyjethro.com.au send emails on behalf of real churches. For example, they might send a 'WWCC Renewal Reminder' to church members:

  From: Jethro <noreply@easyjethro.com.au> 
  Subject: WWCC Renewal Reminder

Replies ought to go to a church Safe Ministry Rep. Previously this was only possible by faking the From: address:

```email
  From: Safe Ministry <safeministry@example.church> 
  Subject: WWCC Renewal Reminder
```

however in recent years almost all mail clients will reject this as spam unless DKIM + SPF records are set up to allow the Jethro hoster to send 'from' example.church.

This PR solves the problem by allowing a Reply-To: header to be set:

```email
  From: Jethro <noreply@easyjethro.com.au> 
  Subject: WWCC Renewal Reminder
  Reply-to: Safe Ministry <safeministry@example.church>
```

This is implemented for all email-sending scripts:

- date_reminder.php: REPLY_TO_ADDRESS and REPLY_TO_NAME from the INI file. Applied to both the individual reminder and the supervisor summary email paths.

- roster_reminder.php: REPLY_TO_ADDRESS and REPLY_TO_NAME from the INI file. Applied in all four email-sending sites (Emailer path for main email + summary; raw mail() path for main email + summary).

- task_reminder.php: TASK_NOTIFICATION_REPLY_TO_ADDRESS and TASK_NOTIFICATION_REPLY_TO_NAME from conf.php. Applied to the per-assignee notification loop.

All settings are optional — when absent, no Reply-To header is omitted, so existing configurations work unchanged.

Sample INI files (date_reminder_sample.ini, roster_reminder_sample.ini) include commented-out examples.