### PR TITLE
Add OVERRIDE_EMAIL_FROM_NAME to complement OVERRIDE_EMAIL_FROM

### DIFF
--- a/conf.php.sample
+++ b/conf.php.sample
@@ -266,9 +266,13 @@ define('2FA_ENABLED', true);
 // Write your own, or use the sample below to make sure all mailto links open in a new window.
 // function custom_email_extras() { return 'target="_mail"'; }
 
-// When Jethro sends an email itself (eg for member rego), force the From: address to this value,
-// and use the user-specified From address as a reply-to.
+// When Jethro sends an email itself (eg for member rego), force the From: address to be this 
+// and use the user-specified From address as a Reply-To.
+// Set this when the From address (set e.g. in script .ini file) is where we want replies to go, but we are not DKIM-authorized to send from its domain.
 //define('OVERRIDE_EMAIL_FROM', '');
+// Optionally override the display name that appears with OVERRIDE_EMAIL_FROM.
+// When not set, the From header has no display name (bare address).
+//define('OVERRIDE_EMAIL_FROM_NAME', '');
 
 // Pre-filled values for the login form.  Only use on demo systems etc.
 // define('PREFILL_USERNAME', '');

--- a/include/emailer.class.php
+++ b/include/emailer.class.php
@@ -13,7 +13,8 @@ class Jethro_Swift_Message extends Swift_Message
 		// and use the user-supplied address as Reply-to.
 		if (ifdef('OVERRIDE_EMAIL_FROM')) {
 			$this->addReplyTo($addresses, $name);
-			parent::setFrom(OVERRIDE_EMAIL_FROM, $name);
+			$fromName = ifdef('OVERRIDE_EMAIL_FROM_NAME', '');
+			parent::setFrom(OVERRIDE_EMAIL_FROM, $fromName);
 		} else {
 			parent::setFrom($addresses, $name);
 		}

--- a/scripts/date_reminder_sample.ini
+++ b/scripts/date_reminder_sample.ini
@@ -13,6 +13,9 @@ FROM_ADDRESS = "noreply@example.com"
 ; Name from which the email will be sent
 FROM_NAME = "Safe Ministry Reminders"
 
+; If OVERRIDE_EMAIL_FROM is set in conf.php, the FROM_ADDRESS/FROM_NAME here become Reply-To instead,
+; and the actual From address uses OVERRIDE_EMAIL_FROM (and OVERRIDE_EMAIL_FROM_NAME if set).
+
 ; Subject of the email to be sent
 ; Can include %CONGREGATIONID%, %EXPIRYDATE%, %FIRST_NAME%, %LAST_NAME% etc.
 SUBJECT = "%CONGREGATIONID% Safe Ministry Renewal Reminder"

--- a/scripts/roster_reminder.php
+++ b/scripts/roster_reminder.php
@@ -249,6 +249,25 @@ if ($sendemail) {
 	$eol = PHP_EOL;
 	$uid = md5(uniqid(time()));
 
+/**
+ * Compute From/Reply-To headers for the raw mail() path.
+ * Mirrors Jethro_Swift_Message::setFrom() behaviour.
+ *
+ * @return array{string, string, string} [$fromAddress, $fromName, $headerPrefix]
+ */
+function roster_raw_mail_from(string $from_address, string $from_name): array
+{
+    if (ifdef('OVERRIDE_EMAIL_FROM')) {
+        $actualFrom = OVERRIDE_EMAIL_FROM;
+        $actualName = ifdef('OVERRIDE_EMAIL_FROM_NAME', '');
+        $header = "From: \"".addslashes($actualName)."\" <".$actualFrom.">".PHP_EOL;
+        $replyToHeader = $from_name ? "\"".addslashes($from_name)."\" <".$from_address.">" : $from_address;
+        $header .= "Reply-To: ".$replyToHeader.PHP_EOL;
+        return [$actualFrom, $actualName, $header];
+    }
+    return [$from_address, $from_name, "From: \"".addslashes($from_name)."\" <".$from_address.">".PHP_EOL];
+}
+
 	if (count($assignees) > 0) {
 		// build the roster list to be included in the stream_context_set_params
 		if ((int)$list_not_table==1) {
@@ -331,7 +350,7 @@ if ($sendemail) {
 			}
 		} else { // using php mail()
 		  $email_to=$roster_coordinator;
-		  $header = "From: \"".addslashes($email_from_name)."\" <".$email_from.">".$eol;
+		  [$fromAddress, $fromName, $header] = roster_raw_mail_from($email_from, $email_from_name);
 		  $header .= "MIME-Version: 1.0".$eol;
 		  $header .= "Bcc: ".implode(',',$emails).$eol;
 		  $header .= "Content-Type: multipart/mixed; boundary=\"".$uid."\"";
@@ -340,7 +359,7 @@ if ($sendemail) {
 		  $message .= "Content-Transfer-Encoding: 8bit".$eol.$eol;
 		  $message .= $longstring.$eol;
 		  $message .= "--".$uid."--";
-		   if (mail($email_to, $email_subject . "$roster_date", "$message", $header, "-f ".$email_from)) {
+		   if (mail($email_to, $email_subject . "$roster_date", "$message", $header, "-f ".$fromAddress)) {
 		   	echo "Mail send roster reminder - ".$roster_name." sent OK <br>";
 		   } else {
 		   	echo "Mail send roster reminder - ".$roster_name." send ERROR!";
@@ -384,15 +403,15 @@ if ($sendemail) {
 		}
 	} else {
 		$email_to=$roster_coordinator;
-		$header = "From: \"".addslashes($email_from_name)."\" <".$email_from.">".$eol;
+		[$fromAddress, $fromName, $header] = roster_raw_mail_from($email_from, $email_from_name);
 		$header .= "MIME-Version: 1.0".$eol;
-		$header .= "Content-Type: multipart/mixed; boundary=\"".$uid."\"";
+		$header .= "Content-Type: multipart/mixed; boundary=\"".$uid."\"".$eol;
 		$message = "--".$uid.$eol;
 		$message .= "Content-type:text/html; charset=iso-8859-1".$eol;
 		$message .= "Content-Transfer-Encoding: 8bit".$eol.$eol;
 		$message .= $summary.$eol;
 		$message .= "--".$uid."--";
-		if (mail($email_to,$summary_notification_subject . "$roster_date","$message",$header, "-f ".$email_from)) {
+		if (mail($email_to,$summary_notification_subject . "$roster_date","$message",$header, "-f ".$fromAddress)) {
 			if (!empty($verbose)) {
 				echo "Sent roster ($roster_name) reminder notification to coordinator.\n";
 			}

--- a/scripts/roster_reminder_sample.ini
+++ b/scripts/roster_reminder_sample.ini
@@ -38,6 +38,10 @@ LIST_NOT_TABLE=1
 EMAIL_FROM='no-reply@church.something'
 ; [Email only; required]
 EMAIL_FROM_NAME='no-reply'
+
+; If OVERRIDE_EMAIL_FROM is set in conf.php, the EMAIL_FROM/EMAIL_FROM_NAME here become Reply-To instead,
+; and the actual From address uses OVERRIDE_EMAIL_FROM (and OVERRIDE_EMAIL_FROM_NAME if set).
+
 ; [Email only; required]
 EMAIL_SUBJECT='roster reminder - Sunday'
 


### PR DESCRIPTION
Following on from https://github.com/tbar0970/jethro-pmm/pull/1489:

This PR fixes two problems relating to the `OVERRIDE_EMAIL_FROM` setting.

## Background: what `OVERRIDE_EMAIL_FROM` does

Jethro hosters like easyjethro.com.au send emails on behalf of real churches. For example, they might use the
date_reminders.php script to send 'WWCC Renewal Reminder' emails to church members, with replies going to
safeministry@church.org.

Due to DKIM rules, all outgoing emails' From: address must be in the @easyjethro.com.au domain, not @church.org. Jethro
has a OVERRIDE_EMAIL_FROM setting which allows this. E.g. in date_reminder.ini:

```conf
FROM_ADDRESS = "safeministry@church.org"
FROM_NAME = "StJohns Safe Ministry"
```

and then in the Jethro conf.php:

```php
define('OVERRIDE_EMAIL_FROM', 'noreply@easyjethro.com.au');
```

The end result is:

```email
From: "StJohns Safe Ministry" <noreply@easyjethro.com.au>
Reply-To: "StJohns Safe Ministry" <safeministry@church.org>
```

## Problem

That is almost what we want, but with one problem: mail clients will see:

```email
From: "StJohns Safe Ministry" <noreply@easyjethro.com.au>
```

and store a contact "StJohns Safe Ministry" as having email 'noreply@easyjethro.com.au'. Next time that person contacts "StJohns Safe Ministry" their email will be silently lost.

## Fix

This PR introduces a `OVERRIDE_EMAIL_FROM_NAME` setting, so the override can have a more honest human-readable name:

```php
define('OVERRIDE_EMAIL_FROM', 'noreply@easyjethro.com.au');
define('OVERRIDE_EMAIL_FROM_NAME', 'StJohns Jethro');
```

resulting in:

```email
From: "StJohns Jethro" <noreply@easyjethro.com.au>
Reply-To: "StJohns Safe Ministry" <safeministry@church.org>
```

If `OVERRIDE_EMAIL_FROM_NAME` is omitted, the default is no longer to use `FROM_NAME`, but use nothing:

```email
From: noreply@easyjethro.com.au
Reply-To: "StJohns Safe Ministry" <safeministry@church.org>
```

# `roster_reminders.php` 

`roster_reminders.php` supports sending email via the SwiftMailer library, but also directly via php `mail()` function, if `PHP_MAIL=1` is set. The latter codepath did not implement `OVERRIDE_EMAIL_FROM`. 

The second commit in this PR fixes that codepath to implement both OVERRIDE_EMAIL_FROM` and `OVERRIDE_EMAIL_FROM_NAME`.