### PR TITLE
date_reminder: allow filtering by person status

### DIFF
--- a/scripts/date_reminder.php
+++ b/scripts/date_reminder.php
@@ -6,6 +6,9 @@
  * It can also send a summary of the reminders sent, to people in the same congregation
  * with a certain person status.
  *
+ * An optional PERSON_STATUS setting (comma-separated person_status IDs) limits
+ * recipients to persons with one of those statuses.
+ *
  * It is called with an ini file as first argument
  * eg: php date_reminder.php my-config-file.ini
  *
@@ -40,6 +43,22 @@ $GLOBALS['user_system']->setCLIScript();
 $GLOBALS['system'] = System_Controller::get();
 //error_reporting(E_ALL);
 
+$statusFilter = [];
+if (!empty($ini['PERSON_STATUS'])) {
+	$allStatusIds = array_column($GLOBALS['db']->queryAll('SELECT id FROM person_status'), 'id');
+	foreach (array_map('intval', explode(',', $ini['PERSON_STATUS'])) as $sid) {
+		if (in_array($sid, $allStatusIds)) {
+			$statusFilter[] = $sid;
+		} else {
+			echo "Warning: PERSON_STATUS includes unknown status id $sid -- ignoring\n";
+		}
+	}
+	if (empty($statusFilter)) {
+		echo "No valid status IDs in PERSON_STATUS -- nothing to do\n";
+		exit(0);
+	}
+}
+
 $expiryDate = date('Y-m-d', strtotime($ini['REMINDER_OFFSET'].' day'));
 $SQL = 'SELECT p.*';
 if (!empty($ini['SUMMARY_RECIPIENT_STATUS'])) {
@@ -64,7 +83,12 @@ if (!empty($ini['SUMMARY_RECIPIENT_STATUS'])) {
 }
 $SQL .= '
 		WHERE cfv.value_date = "'.$expiryDate.'"
-		AND p.status NOT IN (SELECT id FROM person_status WHERE is_archived)
+		AND p.status NOT IN (SELECT id FROM person_status WHERE is_archived)';
+if (!empty($statusFilter)) {
+	$SQL .= '
+		AND p.status IN ('.implode(',', $statusFilter).')';
+}
+$SQL .= '
 		GROUP BY p.id';
 $res = $GLOBALS['db']->queryAll($SQL);
 

--- a/scripts/date_reminder_sample.ini
+++ b/scripts/date_reminder_sample.ini
@@ -7,6 +7,11 @@ CUSTOM_FIELD_ID = "4"
 ; Number of days from now to look
 REMINDER_OFFSET = "28"
 
+; Optional: Limit recipients to persons with one of these person_status IDs.
+; Comma-separated list, e.g. "1,2" for Core and Crowd (run: SELECT id, label FROM person_status).
+; Unknown IDs produce a warning and are skipped. Archived persons are always excluded.
+PERSON_STATUS = ""
+
 ; Email address from which the email will be sent
 FROM_ADDRESS = "noreply@example.com"
 


### PR DESCRIPTION
The date_reminder.php script is useful for sending reminders of things like upcoming WWCC expiries. But sometimes we'd only want to email 'core' people. This PR adds a PERSON_STATUS field that limits who is notified to people with certain statuses.

If a non-existent status is specified, the script prints a warning but still continues. Non-integer text is ignored.