### PR TITLE
Add PREFILL_MEMBER_EMAIL / PREFILL_MEMBER_PASSWORD for member login

### DIFF
--- a/conf.php.sample
+++ b/conf.php.sample
@@ -274,6 +274,10 @@ define('2FA_ENABLED', true);
 // define('PREFILL_USERNAME', '');
 // define('PREFILL_PASSWORD', '');
 
+// Pre-filled values for the member login form.
+// define('PREFILL_MEMBER_EMAIL', '');
+// define('PREFILL_MEMBER_PASSWORD', '');
+
 // For troubleshooting you can use this to show error details in the browser
 // This is usually disabled in production versions but shown in dev.
 // define('SHOW_ERROR_DETAILS', TRUE);

--- a/members/templates/login_form.template.php
+++ b/members/templates/login_form.template.php
@@ -28,7 +28,7 @@
 
 			<div style="display:flex">
 				<label style="margin: 5px 5px 0 0"><b>Email: </b></label>
-				<input style="flex-grow:10" type="email" name="email" autofocus="autofocus" class="compulsory" value="<?php echo ents(array_get($_REQUEST, 'email', '')); ?>" placeholder="Email" />
+				<input style="flex-grow:10" type="email" name="email" autofocus="autofocus" class="compulsory" value="<?php echo ents(array_get($_REQUEST, 'email', defined('PREFILL_MEMBER_EMAIL') ? PREFILL_MEMBER_EMAIL : '')); ?>" placeholder="Email" />
 			</div>
 
 			<div id="member-login-options">
@@ -36,7 +36,7 @@
 					<b>Got a password?</b><br />
 					Enter your password to log in<br />
 						<div class="input-append">
-							<input type="password" name="password" value="" placeholder="Password"/><br>
+							<input type="password" name="password" value="<?php if (defined('PREFILL_MEMBER_PASSWORD')) echo ents(PREFILL_MEMBER_PASSWORD); ?>" placeholder="Password"/><br>
 							<input type="submit" name="login-request" class="btn" value="Log in" />
 						</div>
 				</div>


### PR DESCRIPTION
Analogous to `PREFILL_USERNAME` / `PREFILL_PASSWORD` for the control centre login, these constants pre-fill the email and password fields on the /members/ login form. Only useful on demo/dev systems like https://easyjethro.com.au/demo/members/

<img width="513" height="344" alt="image" src="https://github.com/user-attachments/assets/a2102ce2-cad7-470c-aa14-5671b53b0894" />
