### PR TITLE
Rename "planned absence" to "unavailability" in all user-facing text (#1494)

### DIFF
--- a/db_objects/attendance_record_set.class.php
+++ b/db_objects/attendance_record_set.class.php
@@ -166,7 +166,7 @@ class Attendance_Record_Set
 			}
 			foreach (Planned_Absence::getForDateAndCong($date, $this->congregationid) as $personid => $absences) {
 				if (isset($this->_persons[$personid])) {
-					$this->_persons[$personid]['assignments'] = '['._('Planned absence').']';
+					$this->_persons[$personid]['assignments'] = '['._('Unavailability').']';
 				}
 			}
 		} else {
@@ -175,7 +175,7 @@ class Attendance_Record_Set
 			$this->_persons = $group->getMembers($conds, $orderSQL);
 			foreach (Planned_Absence::getForDateAndGroup($date, $this->groupid) as $personid => $absences) {
 				if (isset($this->_persons[$personid])) {
-					$this->_persons[$personid]['assignments'] = '['._('Planned absence').']';
+					$this->_persons[$personid]['assignments'] = '['._('Unavailability').']';
 				}
 			}
 		}

--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -848,7 +848,7 @@ class Person extends DB_Object
 	 * Print a widget for choosing a person by name search
 	 * @param string	$name				Form element name
 	 * @param int		$currentval			PersonID
-	 * @param string	$plannedAbsenceDate	(optional) - if specified, planned absences on this date should be displayed in results
+	 * @param string	$plannedAbsenceDate	(optional) - if specified, unavailabilities on this date should be displayed in results
 	 */
 	static function printSingleFinder($name, $currentval, $plannedAbsenceDate=NULL)
 	{
@@ -877,7 +877,7 @@ class Person extends DB_Object
 	 * Print a widget for choosing multiple persons by name search
 	 * @param string	$name
 	 * @param array		$val				Array of IDs
-	 * @param string	$plannedAbsenceDate	(optional) - if specified, planned absences on this date should be displayed in results
+	 * @param string	$plannedAbsenceDate	(optional) - if specified, unavailabilities on this date should be displayed in results
 	 */
 	static function printMultipleFinder($name, $val=Array(), $plannedAbsenceDate=NULL)
 	{

--- a/db_objects/person_query.class.php
+++ b/db_objects/person_query.class.php
@@ -2267,7 +2267,7 @@ class Person_Query extends DB_Object
 								break;
 							case 'Attendance':
 								if ($row['_has_planned_absence']) {
-									echo '<span class="nowrap" title="Includes planned absence(s) in this period">';
+									echo '<span class="nowrap" title="Includes unavailabilities in this period">';
 								}
 								echo $val.'%';
 								if ($row['_has_planned_absence']) {

--- a/db_objects/roster_view.class.php
+++ b/db_objects/roster_view.class.php
@@ -593,7 +593,7 @@ class roster_view extends db_object
 				if ($withLinks) {
 					echo '</a>';
 					if ($asn['absenceid']) {
-						echo ' <span class="label label-important" title="Planned absence: '.ents($asn['absence_comment']).'">!</i></span>';
+						echo ' <span class="label label-important" title="Unavailability: '.ents($asn['absence_comment']).'">!</i></span>';
 					}
 					if (('' === $asn['email'])) echo ' <img class="visible-desktop" src="'.BASE_URL.'/resources/img/no_email.png" title="No Email Address" />';
 					if (('' === $asn['mobile']) && SMS_Sender::canSend()) {
@@ -837,7 +837,7 @@ class roster_view extends db_object
 									$n = '<span class="nowrap">';
 									$n .= '<a data-personid="'.$personid . '" href="'.$href.'" title="Assigned by '.ents($vs['assigner']).' on '.format_datetime($vs['assignedon']).'">'.ents($vs['name']).'</a>';
 									if (strlen(strval($vs['absenceid']))) {
-										$n .= ' <a href="'.$href.'#rosters" class="label label-important" title="Planned absence: '.ents($vs['absence_comment']).'">!</i></a>';
+										$n .= ' <a href="'.$href.'#rosters" class="label label-important" title="Unavailability: '.ents($vs['absence_comment']).'">!</i></a>';
 									}
 									if (('' === $vs['email'])) $n .= ' <img class="visible-desktop" src="'.BASE_URL.'/resources/img/no_email.png" title="No Email Address" />';
 									if (('' === $vs['mobile']) && SMS_Sender::canSend()) {

--- a/members/views/view_0_add_planned_absence.class.php
+++ b/members/views/view_0_add_planned_absence.class.php
@@ -2,11 +2,11 @@
 class View__Add_Planned_Absence extends View
 {
 	private $_create_type = 'planned_absence';
-	private $_success_message = 'Planned absence saved';
+	private $_success_message = 'Unavailability saved';
 	private $_on_success_view = 'persons';
-	private $_failure_message = 'Error saving planned absence';
+	private $_failure_message = 'Error saving unavailability';
 	private $_submit_label = 'Save';
-	private $_title = 'Add Planned Absence';
+	private $_title = 'Add Unavailability';
 
 	var $_new_object;
 
@@ -39,13 +39,13 @@ class View__Add_Planned_Absence extends View
 					return;
 				}
 				if (!$x->create()) {
-					add_message("Error saving planned absences", 'failure');
+					add_message("Error saving unavailabilities", 'failure');
 					$GLOBALS['system']->doTransaction('ROLLBACK');
 					return;
 				}
 			}
 			$GLOBALS['system']->doTransaction('COMMIT');
-			add_message("Planned absence saved", 'success');
+			add_message("Unavailability saved", 'success');
 			redirect('rosters');
 
 		}
@@ -100,7 +100,7 @@ class View__Add_Planned_Absence extends View
 	
 	function getTitle()
 	{
-		return 'Add Planned Absence';
+		return 'Add Unavailability';
 	}
 
 }

--- a/members/views/view_0_delete_planned_absence.class.php
+++ b/members/views/view_0_delete_planned_absence.class.php
@@ -13,10 +13,10 @@ class View__Delete_Planned_Absence extends View
 		}
 
 		if ($absence && $absence->delete()) {
-			add_message('Planned absence deleted', 'success');
+			add_message('Unavailability deleted', 'success');
 			redirect(-1, Array(), 'rosters');
 		} else {
-			add_message("Error while deleting planned absence");
+			add_message("Error while deleting unavailability");
 		}
 	}
 

--- a/members/views/view_3_rosters.class.php
+++ b/members/views/view_3_rosters.class.php
@@ -54,7 +54,7 @@ class View_Rosters extends View
 			$family = $person->getFamily();
 			$fmembers = $family->getMemberData();
 			?>
-			<h3>Planned absences for <?php $family->printFieldValue('family_name'); ?> family</h3>
+			<h3>Unavailabilities for <?php $family->printFieldValue('family_name'); ?> family</h3>
 			<?php
 			$params = Array(
 				'>=end_date' => date('Y-m-d'),
@@ -86,7 +86,7 @@ class View_Rosters extends View
 							<td><?php echo ents($row['comment']); ?></td>
 							<td>
 								<i class="icon-info-sign" title="<?php echo ents($tooltip); ?>"></i>
-								<a class="confirm-title" href="?view=_delete_planned_absence&id=<?php echo $id; ?>" title="Delete this planned absence" data-method="post"><i class="icon-trash"></i></a>
+								<a class="confirm-title" href="?view=_delete_planned_absence&id=<?php echo $id; ?>" title="Delete this unavailability" data-method="post"><i class="icon-trash"></i></a>
 							</td>
 						</tr>
 						<?php
@@ -97,11 +97,11 @@ class View_Rosters extends View
 				<?php
 			} else {
 				?>
-				<p><i>The <?php $family->printFieldValue('family_name'); ?> family has no upcoming planned absences</i></p>
+				<p><i>The <?php $family->printFieldValue('family_name'); ?> family has no upcoming unavailabilities</i></p>
 				<?php
 			}
 			?>
-			<p><i class="icon-plus-sign"></i> <a href="?view=_add_planned_absence">Add a planned absence</a></p>
+			<p><i class="icon-plus-sign"></i> <a href="?view=_add_planned_absence">Add an unavailability</a></p>
 			<?php
 		}
 	}

--- a/templates/view_person.template.php
+++ b/templates/view_person.template.php
@@ -482,10 +482,10 @@ if (isset($tabs['rosters'])) {
 		$absences_choice = array_get($_SESSION, 'person_absences_choice', 'upcoming');
 	}
 	if (array_get($_REQUEST, 'absences') == 'all') {
-		$absences_heading = _('All planned absences');
+		$absences_heading = _('All unavailabilities');
 		$absences_filter = Array();
 	} else {
-		$absences_heading = _('Upcoming planned absences');
+		$absences_heading = _('Upcoming unavailabilities');
 		$absences_filter = Array('>=end_date' => date('Y-m-d'));
 
 	}
@@ -518,7 +518,7 @@ if (isset($tabs['rosters'])) {
 				$warning = '';
 				foreach ($absences as $ab) {
 					if (($ab['start_date'] <= $date) && ($date <= $ab['end_date'])) {
-						$warning = '<br /><span class="label label-important">! Planned absence</span>';
+						$warning = '<br /><span class="label label-important">! Unavailability</span>';
 					}
 				}
 				?>
@@ -584,7 +584,7 @@ if (isset($tabs['rosters'])) {
 					<td><?php echo ents($row['comment']); ?></td>
 					<td>
 						<i class="icon-info-sign" title="<?php echo ents($tooltip); ?>"></i>
-						<a class="confirm-title" href="?view=_delete_planned_absence&id=<?php echo $id; ?>" title="Delete this planned absence" data-method="post"><i class="icon-trash"></i></a>
+						<a class="confirm-title" href="?view=_delete_planned_absence&id=<?php echo $id; ?>" title="Delete this unavailability" data-method="post"><i class="icon-trash"></i></a>
 					</td>
 				</tr>
 				<?php
@@ -595,7 +595,7 @@ if (isset($tabs['rosters'])) {
 		<?php
 	} else {
 		?>
-		<p><i><?php $person->printFieldValue('name'); ?> has no upcoming planned absences</i></p>
+		<p><i><?php $person->printFieldValue('name'); ?> has no upcoming unavailabilities</i></p>
 		<?php	
 	}
 

--- a/views/view_0_add_planned_absence.class.php
+++ b/views/view_0_add_planned_absence.class.php
@@ -3,11 +3,11 @@ require_once 'abstract_view_add_object.class.php';
 class View__Add_Planned_Absence extends Abstract_View_Add_Object
 {
 	var $_create_type = 'planned_absence';
-	var $_success_message = 'Planned absence saved';
+	var $_success_message = 'Unavailability saved';
 	var $_on_success_view = 'persons';
-	var $_failure_message = 'Error saving planned absence';
+	var $_failure_message = 'Error saving unavailability';
 	var $_submit_label = 'Save';
-	var $_title = 'Add Planned Absence';
+	var $_title = 'Add Unavailability';
 
 	static function getMenuPermissionLevel()
 	{
@@ -17,7 +17,7 @@ class View__Add_Planned_Absence extends Abstract_View_Add_Object
 	function getTitle()
 	{
 		$person = new Person((int)$_REQUEST['personid']);
-		return 'Add Planned Absence for '.$person->toString();
+		return 'Add Unavailability for '.$person->toString();
 	}
 
 	function processView() 

--- a/views/view_0_delete_planned_absence.class.php
+++ b/views/view_0_delete_planned_absence.class.php
@@ -5,10 +5,10 @@ class View__Delete_Planned_Absence extends View
 	{
 		$absence = new Planned_Absence((int)$_REQUEST['id']);
 		if ($absence && $absence->delete()) {
-			add_message('Planned absence deleted', 'success');
+			add_message('Unavailability deleted', 'success');
 			redirect(-1, Array(), 'rosters');
 		} else {
-			add_message("Error while deleting planned absence");
+			add_message("Error while deleting unavailability");
 		}
 	}
 	

--- a/views/view_6_attendance__2_display.class.php
+++ b/views/view_6_attendance__2_display.class.php
@@ -250,12 +250,12 @@ class View_Attendance__Display extends View
 					</td>
 				<?php
 				foreach ($dates as $date) {
-					$raw = array_get($record, $date, ''); // might have a trailing * to indicate planned absence
+					$raw = array_get($record, $date, ''); // might have a trailing * to indicate unavailability
 					$char = substr($raw, 0, 1);
 					$letter = $this->letters[$char];
 					$class = $this->classes[$char];
 					if ($raw == '0*') {
-						echo '<td class="'.$class.'" title="(Planned absence)">('.$letter.')</td>';
+						echo '<td class="'.$class.'" title="(Unavailability)">('.$letter.')</td>';
 					} else {
 						echo '<td class="'.$class.'">'.$letter.'</td>';
 					}
@@ -502,7 +502,7 @@ class View_Attendance__Display extends View
 						foreach ($this->cohortids as $cohortid) {
 							$catt = array_get($all_attendances[$personid], $cohortid, Array());
 							$x = (array_get($catt, $date, ''));
-							if (strlen($x)) $score = (int)$score + rtrim($x, '*'); // The '*' suffix indicates a planned absence
+							if (strlen($x)) $score = (int)$score + rtrim($x, '*'); // The '*' suffix indicates unavailability
 						}
 						$class = $this->classes[$score > 0 ? 1 : $score];
 						if ($score === '') $score = '?';
@@ -516,14 +516,14 @@ class View_Attendance__Display extends View
 							} else {
 								$catt = array_get($all_attendances[$personid], $cohortid, Array());
 								$v = array_get($catt, $date, '');
-								$pa = ($v == '0*'); // planned absence
+								$pa = ($v == '0*'); // unavailability
 								$v = substr($v, 0, 1);
 								$letter = $this->letters[$v];
 								$class = $this->classes[$v];
 							}
 							if ($first) $class .= ' new-cohort';
 							if ($pa) {
-								echo '<td class="'.$class.'" title="(Planned absence)">('.$letter.')';
+								echo '<td class="'.$class.'" title="(Unavailability)">('.$letter.')';
 							} else {
 								echo '<td class="'.$class.'">'.$letter;
 							}


### PR DESCRIPTION
Sometimes people will be present for worship, but unavailable to serve on rosters. 'Unavailable' is a more generic term that covers the 'present but cannot serve' as well as 'physically absent' cases. In my church, 'unavailabilities' is the colloquial term anyway ("please send me your unavailabilities").

In this change, user-facing strings (titles, headings, messages, tooltips, labels, comments) now use "unavailability" / "unavailabilities" instead of "planned absence" / "planned absences". Filenames and database tables/columns are unchanged, as well as view names (to avoid breaking links).

Fixes #1494