### PR TITLE
Allow Jethro to be symlinked into an alternate/safer webroot

### DIFF
--- a/index.php
+++ b/index.php
@@ -24,7 +24,7 @@
  * @package jethro-pmm
  */
 
-define('JETHRO_ROOT', dirname(__FILE__));
+define('JETHRO_ROOT', dirname($_SERVER['SCRIPT_FILENAME']));
 define('TEMPLATE_DIR', JETHRO_ROOT.'/templates/');
 
 // Load configuration

--- a/members/index.php
+++ b/members/index.php
@@ -24,13 +24,13 @@
  * @package jethro-pmm
  */
 
-define('THIS_DIR', str_replace('\\', '/', dirname(__FILE__)));
+define('THIS_DIR', str_replace('\\', '/', dirname($_SERVER['SCRIPT_FILENAME'])));
 define('JETHRO_ROOT', preg_replace('#/members$#', '', THIS_DIR));
 define('TEMPLATE_DIR', THIS_DIR.'/templates/');
 set_include_path(get_include_path().PATH_SEPARATOR.dirname(THIS_DIR));
 
 // Load configuration
-require_once dirname(THIS_DIR).'/conf.php';
+require_once JETHRO_ROOT.'/conf.php';
 
 // Initialise system
 define('IS_PUBLIC', true);

--- a/public/index.php
+++ b/public/index.php
@@ -24,13 +24,13 @@
  * @package jethro-pmm
  */
 
-define('THIS_DIR', str_replace('\\', '/', dirname(__FILE__)));
+define('THIS_DIR', str_replace('\\', '/', dirname($_SERVER['SCRIPT_FILENAME'])));
 define('JETHRO_ROOT', preg_replace('#/public$#', '', THIS_DIR));
 define('TEMPLATE_DIR', THIS_DIR.'/templates/');
 set_include_path(get_include_path().PATH_SEPARATOR.dirname(THIS_DIR));
 
 // Load configuration
-require_once dirname(THIS_DIR).'/conf.php';
+require_once JETHRO_ROOT.'/conf.php';
 
 // Initialise system
 define('IS_PUBLIC', true);

--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -25,7 +25,10 @@
 
 <?php
 /* Load any custom vars from conf.php */
-$confFile = dirname(dirname(dirname(__FILE__))).'/conf.php';
+if (!defined('JETHRO_ROOT')) {
+	define('JETHRO_ROOT', dirname($_SERVER['SCRIPT_FILENAME'], 3));
+}
+$confFile = JETHRO_ROOT.'/conf.php';
 if (is_readable($confFile)) {
 	require_once $confFile;
 	if (defined('CUSTOM_LESS_VARS')) echo CUSTOM_LESS_VARS;


### PR DESCRIPTION
Jethro's source distribution does not have a distinct web server document root (often called public/, web/, /webroot, /htdocs etc).  Simply deploying the source distribution exposes /vendor/, /scripts/ and other unwanted content. This problem is documented in #1402

This PR allows for a workaround to #1402, and an overall nice deployment approach: let users create their own webroot, e.g. `/srv/www/html/jethro/` containing symlinks to Jethro's source distribution files, but only for files/directories that ought to be in a webroot (not `upgrades/`, `scripts/` etc). For instance, we might have:

```sh
/srv/www/html/jethro/      # webroot that nginx/apache reads
/usr/src/jethro/2.38.0/    # Jethro source
/usr/src/jethro/current/   # symlink to ../2.38.0

/srv/www/html/jethro/index.php   # symlink to ../current/index.php
/srv/www/html/jethro/include/    # symlink to ../current/include/
...
/srv/www/html/jethro/conf.php    # NOT a symlink - our live config
```
To upgrade Jethro, just unzip the new version and update /usr/src/jethro/current/ symlink. Since conf.php lives only in our webroot it persists across upgrades.

This also makes separate test deployments possible. E.g. one can use https://www.jetify.com/devbox nginx + php-fpm + mariadb for development locally: create symlinks from `devbox.d/web/` to `../../`, and have a devbox.d/web/conf.php pointing to the Devbox mariadb instance.

So symlink deployments are great, but to work, Jethro can't use the real location (`__FILE__` / `__DIR__`) of index.php as its `JETHRO_ROOT` (used to find conf.php initially) - it must use the symlink location. This PR achieves that by using the `SCRIPT_FILENAME` superglobal ("the absolute pathname of the currently executing script") instead of `__DIR__` to figure out `JETHRO_ROOT`.  `SCRIPT_FILENAME` is set in CLI and web contexts. It should work just the same for the non-symlink case.