### PR TITLE
Add Nagios health check and status.php script showing Jethro runtime status

### DIFF
--- a/scripts/check_http_jethrostatus
+++ b/scripts/check_http_jethrostatus
@@ -1,0 +1,223 @@
+#!/usr/bin/env perl
+# check_http_jethrostatus - Nagios-compatible check for Jethro status.php
+# Fetches JSON from a Jethro status.php endpoint and validates PHP settings
+# critical to Jethro operation.
+#
+# Usage:
+#   check_http_jethrostatus -u http://localhost:8081/status.php
+
+use strict;
+use warnings;
+use Getopt::Long;
+use LWP::UserAgent;
+use JSON::PP ();
+use constant {
+    OK       => 0,
+    WARNING  => 1,
+    CRITICAL => 2,
+    UNKNOWN  => 3,
+};
+
+# ── defaults ────────────────────────────────────────────────────────────────
+my $opt_url;
+my $opt_timeout     = 15;
+my $opt_insecure    = 0;
+my $opt_help        = 0;
+my $opt_max_input_vars      = 10000;
+my $opt_post_max_size       = 20;       # MB
+my $opt_upload_max_filesize = 20;       # MB
+my $opt_db_charset_results  = 'utf8mb4';
+my $opt_require_jethro_version = 0;
+my $opt_required_runtime_user = undef;
+
+GetOptions(
+    'url|u=s'                   => \$opt_url,
+    'timeout|t=i'               => \$opt_timeout,
+    'insecure|k'                => \$opt_insecure,
+    'help|h'                    => \$opt_help,
+    'max-input-vars=i'          => \$opt_max_input_vars,
+    'post-max-size=i'           => \$opt_post_max_size,
+    'upload-max-filesize=i'     => \$opt_upload_max_filesize,
+    'db-charset-results=s'      => \$opt_db_charset_results,
+    'require-jethro-version'    => \$opt_require_jethro_version,
+    'expected-runtime-user=s'   => \$opt_required_runtime_user,
+) or exit UNKNOWN;
+
+if ($opt_help || !$opt_url) {
+    print "Usage: $0 -u <url> [-k] [-t <seconds>] [--max-input-vars N]\n";
+    print "       [--post-max-size N] [--upload-max-filesize N]\n";
+    print "       [--db-charset-results CHARSET]\n";
+    print "\n";
+    print "  -u, --url     URL to status.php (required)\n";
+    print "  -k, --insecure  Skip SSL certificate verification\n";
+    print "  -t, --timeout   HTTP request timeout (default: $opt_timeout)\n";
+    print "  --max-input-vars          Minimum max_input_vars (default: $opt_max_input_vars)\n";
+    print "  --post-max-size           Minimum post_max_size in MB (default: $opt_post_max_size)\n";
+    print "  --db-charset-results      Required db_charset_results (default: $opt_db_charset_results)\n";
+    print "  --require-jethro-version  Require jethroversion field in response\n";
+    print "  --expected-runtime-user   Required OS user (e.g. 'jethro', not 'root')\n";
+    exit UNKNOWN;
+}
+
+# ── fetch ───────────────────────────────────────────────────────────────────
+my $ua = LWP::UserAgent->new(
+    timeout => $opt_timeout,
+    ssl_opts => {
+        verify_hostname => $opt_insecure ? 0 : 1,
+        SSL_verify_mode => $opt_insecure ? 0 : 1,
+    },
+);
+$ua->agent("check_http_jethrostatus/1.0");
+$ua->env_proxy;
+
+my $response = $ua->get($opt_url);
+unless ($response->is_success) {
+    printf "CRITICAL - HTTP %s %s\n", $response->code, $response->message;
+    exit CRITICAL;
+}
+
+# ── parse ───────────────────────────────────────────────────────────────────
+my $status;
+eval {
+    $status = JSON::PP::decode_json($response->decoded_content);
+    1;
+} or do {
+    my $err = $@;
+    printf "CRITICAL - JSON parse error: %s\n", $err;
+    exit CRITICAL;
+};
+
+# Helper: status fields now use "true if good, error string if bad"
+sub is_good { my $v = shift; return JSON::PP::is_bool($v) && $v; }
+
+# ── validate ────────────────────────────────────────────────────────────────
+my @errs;
+
+# max_input_vars
+{
+    my $val = $status->{max_input_vars};
+    if (!defined $val) {
+        push @errs, "max_input_vars is missing from response";
+    } elsif ($val < $opt_max_input_vars) {
+        push @errs, sprintf("max_input_vars is %s, must be >= %s", $val, $opt_max_input_vars);
+    }
+}
+
+# post_max_size
+{
+    my $val = $status->{post_max_size};
+    if (!defined $val) {
+        push @errs, "post_max_size is missing from response";
+    } elsif ($val < $opt_post_max_size) {
+        push @errs, sprintf("post_max_size is %sM, must be >= %sM", $val, $opt_post_max_size);
+    }
+}
+
+# upload_max_filesize
+{
+    my $val = $status->{upload_max_filesize};
+    if (!defined $val) {
+        push @errs, "upload_max_filesize is missing from response";
+    } elsif ($val < $opt_upload_max_filesize) {
+        push @errs, sprintf("upload_max_filesize is %sM, must be >= %sM", $val, $opt_upload_max_filesize);
+    }
+}
+
+# db_charset_results
+{
+    my $val = $status->{db_charset_results};
+    if (!defined $val) {
+        push @errs, "db_charset_results is missing from response";
+    } elsif ($val ne $opt_db_charset_results) {
+        push @errs, sprintf("db_charset_results is '%s', must be '%s'", $val, $opt_db_charset_results);
+    }
+}
+
+# runtime_user — validated only when --expected-runtime-user is set
+if (defined $opt_required_runtime_user) {
+    my $val = $status->{user};
+    if (!defined $val) {
+        push @errs, "user is missing from response";
+    } elsif ($val ne $opt_required_runtime_user) {
+        push @errs, sprintf("runtime user is '%s', must be '%s'", $val, $opt_required_runtime_user);
+    }
+}
+# xdebug.start_with_request — must be off (0 / false)
+{
+    my $val = $status->{"xdebug.start_with_request"};
+    if (!defined $val) {
+        # Not having the key is fine — xdebug likely not loaded
+    } elsif ($val) {
+        push @errs, sprintf("xdebug.start_with_request is '%s', must be off", $val);
+    }
+}
+
+# opcache_jit_impact — true if JIT disabled (good), else error string
+{
+    my $val = $status->{opcache_jit_impact};
+    if (!defined $val) {
+        push @errs, "opcache_jit_impact is missing from response";
+    } elsif (!is_good($val)) {
+        push @errs, JSON::PP::is_bool($val) ? "opcache_jit_impact is false" : $val;
+    }
+}
+
+# php_compatible_version — true if PHP > 8.1, else error string
+{
+    my $val = $status->{php_compatible_version};
+    if (!defined $val) {
+        push @errs, "php_compatible_version is missing from response";
+    } elsif (!is_good($val)) {
+        push @errs, JSON::PP::is_bool($val) ? "php_compatible_version is false" : $val;
+    }
+}
+
+# php_extensions_installed — true if all required loaded, else error string
+{
+    my $val = $status->{php_extensions_installed};
+    if (!defined $val) {
+        push @errs, "php_extensions_installed is missing from response";
+    } elsif (!is_good($val)) {
+        push @errs, JSON::PP::is_bool($val) ? "php_extensions_installed is false" : $val;
+    }
+}
+
+# mod_unique_id_loaded — true if loaded, else error string
+{
+    my $val = $status->{mod_unique_id_loaded};
+    if (!defined $val) {
+        push @errs, "mod_unique_id_loaded is missing from response";
+    } elsif (!is_good($val)) {
+        push @errs, JSON::PP::is_bool($val) ? "mod_unique_id_loaded is false" : $val;
+    }
+}
+
+# session_gc_misconfigured — true if GC config is fine, else error string
+{
+    my $val = $status->{session_gc_misconfigured};
+    if (!defined $val) {
+        push @errs, "session_gc_misconfigured is missing from response";
+    } elsif (!is_good($val)) {
+        push @errs, JSON::PP::is_bool($val) ? "session_gc_misconfigured is false" : $val;
+    }
+}
+
+
+# jethroversion — conditionally checked when status.php has SHOW_JETHRO_VERSION=true
+if ($opt_require_jethro_version) {
+    my $val = $status->{jethroversion};
+    if (!defined $val || $val eq '') {
+        push @errs, "jethroversion is missing or empty (use --require-jethro-version only when SHOW_JETHRO_VERSION=true)";
+    }
+}
+# ── output ──────────────────────────────────────────────────────────────────
+if (!@errs) {
+    printf "OK - all checks passed | max_input_vars=%d post_max_size=%d upload_max_filesize=%d\n",
+        $status->{max_input_vars},
+        $status->{post_max_size},
+        $status->{upload_max_filesize};
+    exit OK;
+} else {
+    printf "WARNING - %s\n", join("; ", @errs);
+    exit WARNING;
+}

--- a/status.php
+++ b/status.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Jethro runtime health endpoint — returns JSON describing PHP/Database/Apache
+ * configuration suitable for monitoring systems (e.g. Nagios).
+ *
+ * Companion Nagios check plugin: scripts/check_http_jethrostatus
+ *
+ * Example JSON output:
+ *
+ *     {
+ *       "user": "jethro",
+ *       "php_compatible_version": true,
+ *       "max_input_vars": 1000,
+ *       "xdebug_loaded": false,
+ *       "xdebug.mode": false,
+ *       "xdebug.start_with_request": false,
+ *       "xdebug_performance_impact": true,
+ *       "opcache_jit_impact": true,
+ *       "post_max_size": 8,
+ *       "upload_max_filesize": 2,
+ *       "db_charset_results": "utf8mb4",
+ *       "session_gc_maxlifetime": 5400,
+ *       "session_gc_probability": 1,
+ *       "session_gc_misconfigured": true,
+ *       "php_extensions_installed": true,
+ *       "mod_unique_id_loaded": true,
+ *       "log_errors": "0"
+ *     }
+ *
+ * For the above JSON, check_http_jethrostatus would report:
+ *
+ *     WARNING - max_input_vars is 1000, must be >= 10000;
+ *              post_max_size is 8M, must be >= 20M;
+ *              upload_max_filesize is 2M, must be >= 20M
+ *
+ * There are many ways to mess up a Jethro installation, particularly across
+ * upgrades. Key fields to watch:
+ *
+ *     Field                       | Expected  | Problem                                      | Explanation
+ *     ----------------------------|-----------|----------------------------------------------|--------------------------------------------------------------------------
+ *     `user`                      | "jethro"  | "root"                                       | Ensure PHP is running as the correct OS user (e.g. not root)
+ *     `php_compatible_version`    | true      | "PHP 8.0.30 is not > 8.1"                    | Ensure the expected PHP version is used
+ *     `php_extensions_installed`  | true      | "Missing extensions: exif, gd"               | Jethro requires `curl`, `gd`, `zip`, etc as documented in README.md
+ *     `max_input_vars`            | 10000     | 1000                                         | Default 1000 is too few for large attendances (#6) or many custom fields (#152)
+ *     `post_max_size`             | 20        | 8                                            | Default 8MB is too small; contact photos may exceed it (#949)
+ *     `upload_max_filesize`       | 20        | 2                                            | Default 2MB is too small for common uploads
+ *     `db_charset_results`        | `utf8mb4` | `utf8`, `latin1`                             | Old MySQL `utf8` isn't real UTF-8 — causes upgrade mess (#754, #1088)
+ *     `opcache_jit_impact`        | true      | "opcache JIT is enabled"                     | JIT burns CPU on warmup; pointless for short-lived PHP processes — returns true when JIT is off (good)
+ *     `session_gc_misconfigured`  | true      | "Session GC misconfigured: …"               | Debian/Ubuntu sessionclean trap: cron GC with low maxlifetime causes premature session expiry (#1088)
+ *     `mod_unique_id_loaded`      | true      | "mod_unique_id Apache module not enabled"    | Apache unique request IDs for log correlation and request tracing
+ *     `xdebug_performance_impact` | true      | "xdebug performance impact: mode=debug…"    | Xdebug overhead even when not debugging — returns true when safe, error string when impacting performance
+ *
+ * @see scripts/check_http_jethrostatus
+ */
+define('JETHRO_ROOT', dirname($_SERVER['SCRIPT_FILENAME']));
+require_once JETHRO_ROOT.'/conf.php';
+require_once JETHRO_ROOT.'/include/init.php';
+define('SHOW_JETHRO_VERSION', false);
+
+// If we can't connect to the database or something else is majorly wrong, we would have returned a 200 HTML error page to the caller by now.
+// I have considered setting a custom error handler with set_error_handler() and returning HTTP 500 with a json response, but the caller should
+// be treating any failure to return JSON as critical anyway.
+$result = [];
+if (SHOW_JETHRO_VERSION) $result['jethroversion'] = JETHRO_VERSION;
+$result['user'] = $_SERVER['USER'];
+$result['php_compatible_version'] = version_compare(PHP_VERSION, '8.1', '>') ? true : "PHP " . PHP_VERSION . " is not > 8.1";
+$result['max_input_vars'] = (int)ini_get('max_input_vars');
+// Xdebug runtime status — these settings affect production performance
+$result['xdebug_loaded'] = extension_loaded('xdebug');
+$result['xdebug.mode'] = ini_get('xdebug.mode');                    // e.g. 'off', 'develop', 'debug', 'trace', 'profile'
+$result['xdebug.start_with_request'] = ini_get('xdebug.start_with_request'); // e.g. 'default', 'yes', 'no', 'trigger'
+// Derived: xdebug is "hot" (may slow things down) if loaded *and* mode is not off/empty *and* start_with_request isn't 'no'
+$result['xdebug_performance_impact'] = (extension_loaded('xdebug')
+    && ini_get('xdebug.mode') !== 'off'
+    && ini_get('xdebug.mode') !== ''
+    && ini_get('xdebug.start_with_request') !== 'no')
+    ? "xdebug performance impact: mode=" . ini_get('xdebug.mode') . ", start_with_request=" . ini_get('xdebug.start_with_request')
+    : true;
+$result['opcache_jit_impact'] = opcache_get_status()['jit']['enabled'] ? "opcache JIT is enabled" : true;
+$result['post_max_size'] = (int)ini_get('post_max_size');
+$result['upload_max_filesize'] = (int)ini_get('upload_max_filesize');
+$result['db_charset_results'] =  $GLOBALS['db']->queryOne('select @@character_set_results');
+// Session GC config — check for Debian/Ubuntu sessionclean misconfiguration
+// Ref: https://github.com/tbar0970/jethro-pmm/issues/1088#issuecomment-2436805398
+$result['session_gc_maxlifetime'] = (int)ini_get('session.gc_maxlifetime');
+$result['session_gc_probability'] = (int)ini_get('session.gc_probability');
+$result['session_gc_misconfigured'] = ((int)ini_get('session.gc_probability') === 0)
+    && ((int)ini_get('session.gc_maxlifetime') < (defined('SESSION_TIMEOUT_MINS') ? SESSION_TIMEOUT_MINS * 60 : PHP_INT_MAX))
+    ? "Session GC misconfigured: gc_probability=0, gc_maxlifetime=" . ini_get('session.gc_maxlifetime') . "s < SESSION_TIMEOUT_MINS*60"
+    : true;
+# Required PHP extensions per README.md
+$required_extensions = ['gettext', 'zip', 'xmlwriter', 'gd', 'curl', 'exif'];
+$missing = array_values(array_filter($required_extensions, fn($ext) => !extension_loaded($ext)));
+$result['php_extensions_installed'] = empty($missing) ? true : "Missing extensions: " . join(', ', $missing);
+$result['mod_unique_id_loaded'] = array_key_exists('HTTP_X_REQUEST_ID', $_SERVER) ? true : "mod_unique_id Apache module not enabled";
+$result['log_errors'] = ini_get('log_errors');
+header('Content-Type: application/json');
+print(json_encode($result, JSON_PRETTY_PRINT));
+session_destroy(); // Don't accumulate sessions unnecessarily
+?>


### PR DESCRIPTION
Add Nagios health check and status.php script showing Jethro runtime status

This adds a /status.php script, returning JSON with useful info about the Jethro deployment, e.g.:

```json
{
  "user": "jethro",
  "php_compatible_version": true,
  "max_input_vars": 1000,
  "xdebug_loaded": false,
  "xdebug.mode": false,
  "xdebug.start_with_request": false,
  "xdebug_performance_impact": true,
  "opcache_enabled": true,
  "post_max_size": 8,
  "upload_max_filesize": 2,
  "db_charset_results": "utf8mb4",
  "session_gc_maxlifetime": 5400,
  "session_gc_probability": 1,
  "session_gc_misconfigured": true,
  "php_extensions_installed": true,
  "mod_unique_id_loaded": true,
  "log_errors": "0"
}
```

`/status.php` is intended to be queried by a monitoring system like Nagios. A Nagios-compatible
`scripts/check_http_jethrostatus` is also provided that translates the output into healthy/not healthy status.

For the JSON above, scripts/check_http_jethrostatus would report:

```
WARNING - max_input_vars is 1000, must be >= 10000; post_max_size is 8M, must be >= 20M; upload_max_filesize is 2M, must be >= 20M
```

`/status.php` returns lots of details beyond just "it's up", because there are lots of ways to mess up a Jethro
installation, particularly across upgrades. Of note in the JSON:

| Field                       | Expected | Problem                                                      | Explanation                                                    |
|-----------------------------|----------|--------------------------------------------------------------|----------------------------------------------------------------|
| `user`                      | "jethro" | "root"                                                       | Ensure PHP is running as the correct OS user (e.g. not root)   |
| `php_compatible_version`    | true     | "PHP 8.0.30 is not > 8.1"                                    | Ensure the expected PHP version is used                        |
| `php_extensions_installed`  | true     | "Missing extensions: exif, gd"                               | Jethro requires some extensions (`curl`, `gd`, `zip`, etc) as documented in the README.md |
| `max_input_vars`            | 10000    | 1000                                                         | PHP restricts the number of params submitted, defaulting to 1000. This is too few for most Jethros when marking large attendances (#6) or running reports on systems with many custom fields (#152). The max_input_vars should almost always be increased from its default |
| `post_max_size`             | 20       | 8                                                            | PHP `post_max_size` governs the HTTP POST size, with 8Mb being the default. Sometimes contact photos exceed 8Mb (see related #949), so the operator might want to increase `post_max_size` and validate it is increased |
| `upload_max_filesize`       | 20       | 2                                                            | Similar to `post_max_size`, often the default 2MB is too small |
| `db_charset_results`        | `utf8mb4`| `utf8`, `latin1`                                             | Old MySQL defaulted to `utf8` which isn't real UTF-8 and causes a giant mess on upgrades. See [this comment](https://github.com/tbar0970/jethro-pmm/pull/754#issuecomment-2382842676) and [this](https://github.com/tbar0970/jethro-pmm/issues/1088#issuecomment-2436805398). |
| `opcache_enabled`           | true     | "opcache JIT is enabled"                                     | opcache JIT is pointless for apps like Jethro where the PHP process lifetime is one request — it just burns CPU on warmup. Returns `true` when JIT is off (good), error string when on. |
| `session_gc_misconfigured`  | true     | "Session GC misconfigured: gc_probability=0, gc_maxlifetime=1440s < ..." | Detects the Debian/Ubuntu `sessionclean` trap: the system cron job handles GC instead of PHP (`gc_probability=0`), but `gc_maxlifetime` is left at the low default (1440s). Sessions then expire before `SESSION_TIMEOUT_MINS`, logging users out prematurely. Fix: raise `session.gc_maxlifetime` to at least `SESSION_TIMEOUT_MINS*60`. Ref [#1088](https://github.com/tbar0970/jethro-pmm/issues/1088). |
| `mod_unique_id_loaded`      | true     | "mod_unique_id Apache module not enabled"                    | Apache's `mod_unique_id` generates a unique-per-request ID forwarded as `X-Request-ID`. Jethro uses this for log correlation and request tracing. Without it, requests can't be individually distinguished in logs. |
| `xdebug_performance_impact` | true     | "xdebug performance impact: mode=debug, start_with_request=yes" | Xdebug adds significant overhead even when not actively debugging. This flags when xdebug is loaded AND `mode` is not `off`/empty AND `start_with_request` is not `no` — meaning virtually every request pays a performance penalty. Returns `true` when safe, error string when performance is impacted. |

