### PR TITLE
Support multi-segment URL path prefixes when inferring the base URL, and make BASE_URL authoritative

### DIFF
--- a/include/general.php
+++ b/include/general.php
@@ -756,6 +756,8 @@ function build_url($params)
 
 /**
  * * Get the relative 'base URL' path below which Jethro lives, e.g. '' or '/jethro'. No trailing slash. This is the default value for BASE_URL, and is used to link to root-relative resources. Unlike get_url_pathprefix, there is no '/members' or '/public' part - just the base.
+ * The base is inferred from SCRIPT_NAME, which may contain any number of leading
+ * path segments (e.g. '/a/b/jethro/index.php' => '/a/b/jethro').
  *  - 'https://jethro.mychurch.org'   returns ''
  *  - 'https://jethro.mychurch.org/'   returns ''
  *  - 'https://jethro.mychurch.org//'   returns ''
@@ -767,14 +769,16 @@ function build_url($params)
 function baseurl_relative()
 {
     // SCRIPT_NAME is the path part of the URL, e.g. /index.php or /jethro/index.php, or /jethro/members/index.php
-    $parts = explode('/', $_SERVER['SCRIPT_NAME']);
-    end($parts);  // Move internal pointer to the end (likely 'index.php').
-    $lastdir=prev($parts); // Get path segment before 'index.php'
-    if ($lastdir == 'members' or $lastdir == 'public') $lastdir=prev($parts); // Look one earlier than /members / /public
-    if (empty($lastdir)) return '';
-    else return '/'.$lastdir;
+    $dir = rtrim(str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'])), '/');
+    // The '/members' and '/public' areas sit one level below the base.
+    foreach (Array('/members', '/public') as $area) {
+        if (str_ends_with($dir, $area)) {
+            $dir = substr($dir, 0, -strlen($area));
+            break;
+        }
+    }
     // Note that this cannot return '/', because its value becomes BASE_URL which gets prepended to '/resources/...' in many places.
-//    return rtrim(str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'])), '/');
+    return $dir;
 }
 
 /**
@@ -791,8 +795,15 @@ function baseurl_relative()
 function get_url_pathprefix()
 {
     $relbase = baseurl_relative(); // e.g. '' or '/jethro'
-    $subdir = dirname(substr($_SERVER['SCRIPT_NAME'], strlen($relbase))); // e.g. '/', '/members' or '/public'
-    return rtrim($relbase.$subdir, '/').'/'; // e.g. '/members/', '/public/', '/jethro/', '/jethro/members/', '/jethro/members/public/'
+    $dir = rtrim(str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'])), '/');
+    $area = ''; // '/members' or '/public' if we're in one of those areas
+    foreach (Array('/members', '/public') as $a) {
+        if (str_ends_with($dir, $a)) {
+            $area = $a;
+            break;
+        }
+    }
+    return $relbase.$area.'/'; // e.g. '/members/', '/public/', '/jethro/', '/jethro/members/'
 }
 
 /**

--- a/include/general.php
+++ b/include/general.php
@@ -756,7 +756,8 @@ function build_url($params)
 
 /**
  * * Get the relative 'base URL' path below which Jethro lives, e.g. '' or '/jethro'. No trailing slash. This is the default value for BASE_URL, and is used to link to root-relative resources. Unlike get_url_pathprefix, there is no '/members' or '/public' part - just the base.
- * The base is inferred from SCRIPT_NAME, which may contain any number of leading
+ * If BASE_URL is already defined (e.g. in conf.php), its path component is authoritative.
+ * Otherwise the base is inferred from SCRIPT_NAME, which may contain any number of leading
  * path segments (e.g. '/a/b/jethro/index.php' => '/a/b/jethro').
  *  - 'https://jethro.mychurch.org'   returns ''
  *  - 'https://jethro.mychurch.org/'   returns ''
@@ -768,6 +769,11 @@ function build_url($params)
  */
 function baseurl_relative()
 {
+    if (defined('BASE_URL')) {
+        // BASE_URL may be absolute ('https://church.org/jethro/') or a bare path ('/jethro').
+        $path = parse_url(BASE_URL, PHP_URL_PATH);
+        return is_string($path) ? rtrim($path, '/') : '';
+    }
     // SCRIPT_NAME is the path part of the URL, e.g. /index.php or /jethro/index.php, or /jethro/members/index.php
     $dir = rtrim(str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'])), '/');
     // The '/members' and '/public' areas sit one level below the base.


### PR DESCRIPTION
Jethro can now run at /church/jethro/ whereas previously this wasn't possible.

In reality I'm using this so a single Jethro can be multi-homed to http://localhost:8089/tests/functional/test1/ and
http://localhost:8089/tests/functional/test2/ and conf.php sources the ./tests/functional/test1.conf /
tests/functional/test2.conf file to alter behaviour.