### PR TITLE
Fix undefined variable $link_class warning in person_list.template.php

### DIFF
--- a/templates/person_list.template.php
+++ b/templates/person_list.template.php
@@ -3,10 +3,11 @@
 @var $persons
 @var $special_fields
 @var $show_actions	Whether to show the action links for each person
-@var $link_Class	Classname to add to all the action links (eg med-popup)
+@var $link_class		Classname to add to all the action links (eg med-popup)
 @var $view_tab		Which view-person tab to link to (eg attendance)
 @var $callbacks		Functions to call to render each column's value
 */
+$link_class = $link_class ?? '';
 $view_tab = empty($view_tab) ? '' : '#'.$view_tab;
 
 $GLOBALS['system']->includeDBClass('person');


### PR DESCRIPTION
"Also, there was an unused $link_class variable that complicated the code, so it is now removed.", said someone on https://github.com/tbar0970/jethro-pmm/pull/1469

It turns out the variable was needed. Without it we get `E_WARNING "Undefined variable $link_class"` on the persons__list_all view and anywhere else the template is included.

<img width="1221" height="486" alt="image" src="https://github.com/user-attachments/assets/acd753bd-bc05-4c89-8a68-9af008d37b31" />

Also fix docblock typo: $link_Class -> $link_class.