### PR TITLE
Add scripts to process LESS files into CSS and generate bundled js for releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bun.lock
 /conf.php
 # /conf.php anchors conf.php to allow devbox.d/web/conf.php and others
 devbox.d/bin/devbox
@@ -7,4 +8,7 @@ devbox.d/nginx/nginx*.conf
 /files/
 .idea/
 /nbproject/
+node_modules/
 .php-cs-fixer.cache
+resources/css/jethro-*-DEV.css
+resources/js/jethro-*-DEV.js

--- a/devbox.d/bin/jethro_compile
+++ b/devbox.d/bin/jethro_compile
@@ -1,0 +1,57 @@
+#!/bin/bash -eu
+
+# Compiles the css + js resources for a given version and, with --use,
+# activates them by writing the version to include/version.txt.
+
+fail() { echo >&2 "$*"; exit 1; }
+
+usage() {
+  echo "Usage: $0 [--use] [version]"
+  echo "  version  version string (default: \$JETHRO_VERSION)"
+  echo "  --use    write the version to include/version.txt so the app uses the compiled assets"
+  exit 0
+}
+
+main() {
+  [[ -d resources/js ]] || fail "Must be invoked in the project root"
+
+  local version=""
+  local use=false
+
+  while (($#)); do
+    case "$1" in
+      --use)
+        use=true
+        ;;
+      -h|--help)
+        usage
+        ;;
+      -*)
+        fail "Unknown option: $1"
+        ;;
+      *)
+        [[ -z "$version" ]] || fail "Version specified more than once: '$version' and '$1'"
+        version=$1
+        ;;
+    esac
+    shift
+  done
+
+  version=${version:-${JETHRO_VERSION:-}}
+  [[ -n "$version" ]] || fail "No version supplied: pass one as an argument or set JETHRO_VERSION"
+
+  local script_dir
+  script_dir=$(cd "$(dirname "$0")" && pwd)
+
+  "$script_dir/jethro_compile_css" "$version"
+  "$script_dir/jethro_compile_js" "$version"
+
+  if $use; then
+    printf '%s\n' "$version" > include/version.txt
+    echo "Wrote include/version.txt — the app now uses jethro-${version}.css/.js"
+  else
+    echo "To use compiled resources, run: $0 --use \"$version\""
+  fi
+}
+
+main "$@"

--- a/devbox.d/bin/jethro_compile_css
+++ b/devbox.d/bin/jethro_compile_css
@@ -1,0 +1,35 @@
+#!/bin/bash -eu
+
+# Generates resources/css/jethro-$version.css by minifying less output
+
+main() {
+  local version=${1:-${JETHRO_VERSION:-}}
+  [[ -n "$version" ]] || { echo >&2 "No version supplied: pass one as an argument or set JETHRO_VERSION"; exit 1; }
+  #devbox init
+  #devbox -q add nodejs
+  #grep -qF 'less.js/1.7.5/less.min.js' templates/head.template.php || fail "Cannot validate that Jethro is still using less 1.7.5. Check templates/header.template.php where it used to be included"
+  #[[ -f package.json ]] || devbox -q run -- npm init -y
+  #devbox -q run npm add less@1.7.5
+
+  # Add via npm instead of devbox because devbox doesn't have v1.7.5, and we'd have to patch variables.css
+  #devbox -q add nodePackages.less
+
+  bun add less@1.7.5
+  rm -rf buildenv
+  mkdir buildenv
+  # A fake conf.php to keep jethro.less.php happy
+  touch buildenv/conf.php
+  cp -r resources/ buildenv  # a symlink won't fool php
+  cd buildenv
+  # This doesn't produce byte-for-byte identical output. We can get closer with --compress
+  HTTP_HOST=fakejethro.local php resources/less/jethro.less.php > lessoutput.css
+  bunx lessc --compress --include-path=resources/less lessoutput.css > ../resources/css/"jethro-${version}.css.new"
+  cd ..
+  #> resources/css/"jethro-${version}.css.new"
+  mv resources/css/jethro-${version}.css{.new,}
+  # Clean up after ourselves
+  rm -rf buildenv
+  echo "Generated: $(ls resources/css/jethro-${version}.css)"
+}
+
+main "$@"

--- a/devbox.d/bin/jethro_compile_js
+++ b/devbox.d/bin/jethro_compile_js
@@ -1,0 +1,46 @@
+#!/bin/bash -eu
+
+fail() { echo >&2 "$*"; exit 1; }
+warn() { echo "$*"; }
+
+warn_if_extra_js_files_found() {
+  local version=$1
+  local allowed=(
+    "jethro-sms-test.js"   # Get rid of this later
+    "jquery.js"
+    "jquery-ui.min.js"
+    "bootstrap.js"
+    "jquery.min.js"
+    "bootstrap.min.js"
+    "tb_lib.js"
+    "bsn_autosuggest.js"
+    "jethro.js"
+    "jethro-sms.js"
+    "jquery-ui.js"
+    "jquery.ui.touch-punch.min.js"
+    "stupidtable.min.js"
+    "treeview.js"
+  )
+
+  # Exclude generated bundles (jethro-<version>.js) plus the explicit allowlist below.
+  pattern="jethro-.*\.js|$(printf "%s\n" "${allowed[@]}" | sed 's/\./\\./g' | paste -sd'|')"
+  #shellcheck disable=SC2010,SC2143
+  if find . -maxdepth 1 -type f -name "*.js" -printf "%f\n" | grep -vP "^(${pattern})$"; then
+    warn "Extra js files (printed above) have been added. These will NOT be bundled into jethro-${version}.js unless $0 is edited."
+  fi
+}
+
+main() {
+  local version=${1:-${JETHRO_VERSION:-}}
+  [[ -n "$version" ]] || { echo >&2 "No version supplied: pass one as an argument or set JETHRO_VERSION"; exit 1; }
+  [[ -d resources/js ]] || { echo "Must be invoked in the project root"; exit 1; }
+  cd resources/js
+  warn_if_extra_js_files_found "$version"
+  # shellcheck disable=SC2016
+  php -r '$files=["jquery.min.js", "bootstrap.min.js", "tb_lib.js", "bsn_autosuggest.js", "jethro.js", "jquery-ui.js", "jquery.ui.touch-punch.min.js", "stupidtable.min.js", "treeview.js"]; echo implode("/* --- */\n", array_map(fn($f)=>file_get_contents($f), $files));' > "jethro-${version}.js.new"
+  mv "jethro-${version}.js.new" "jethro-${version}.js"
+  cd ../..
+  echo "Generated: $(ls resources/js/jethro-${version}.js)"
+}
+
+main "$@"

--- a/devbox.json
+++ b/devbox.json
@@ -11,14 +11,18 @@
     "php85Extensions.curl@latest",
     "php85Extensions.exif@latest",
     "mariadb@latest",
-    "nginx@latest"
+    "nginx@latest",
+    "bun@latest"
   ],
   "env": {
+    "JETHRO_VERSION":         "2.39-DEV",
     "NGINX_WEB_PORT":         "8081",
     "PATH":                   "$PWD/devbox.d/bin:$PATH"
   },
   "shell": {
     "scripts": {
+      "compile":              "devbox.d/bin/jethro_compile",
+      "initdb":               "devbox.d/bin/mariadb_recreate_db jethro",
       "initdb":               "devbox.d/bin/mariadb_recreate_db jethro",
       "lint":                 "php -l *.php calls/*.php db_objects/*.php hooks/**/*.php include/*.php members/*.php members/**/*.php public/*.php public/**/*.php scripts/*.php templates/*.php upgrades/*.php upgrades/**/*.php views/*.php",
       "mariadb_as_root":      "devbox.d/bin/mariadb_as_root"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "less": "1.7.5"
+  }
+}


### PR DESCRIPTION
The frontend to this is `./devbox run compile`, which invokes:

 - devbox.d/bin/jethro_compile_js
 - devbox.d/bin/jethro_compile_css

LESS processing is done with lessc, a Javascript tool, so devbox has the 'bun' JS runtime added, and devbox.d/bin/jethro_compile_css runs 'bunx lessc' to compile the *.less files into a single jethro-$VER.css

jethro_compile_js merges *.js into one jethro-$VER.js