### PR TITLE
Notes: restore missing "Add Note" link when a person or family has no notes (fixes #1512)

### DIFF
--- a/templates/view_family.template.php
+++ b/templates/view_family.template.php
@@ -178,7 +178,13 @@ if ($GLOBALS['user_system']->havePerm(PERM_VIEWNOTE)) {
 		}
 		$show_edit_link = TRUE;
 	}
-	if (!empty($notes)) {
+	if (empty($notes)) {
+		if ($add_note_html) {
+			?>
+			<div class="pull-right"><?php echo $add_note_html; ?></div>
+			<?php
+		}
+	} else {
 		?>
 <?php include __DIR__ . '/note_filters.template.php'; ?>
 		<?php

--- a/templates/view_person.template.php
+++ b/templates/view_person.template.php
@@ -231,23 +231,25 @@ if (isset($tabs['notes'])) {
 
 	printf($panel_header, 'notes', _('Notes').' ('.count($notes).')', '');
 
+	$add_note_html = null;
 	if ($GLOBALS['user_system']->havePerm(PERM_EDITNOTE)) {
+		$add_note_html = '<a href="?view=_add_note_to_person&personid='.ents($person->id).'"><i class="icon-plus-sign"></i>'._('Add Note').'</a>';
 	}
 	if (empty($notes)) {
+		if ($add_note_html) {
+			?>
+			<div class="pull-right"><?php echo $add_note_html; ?></div>
+			<?php
+		}
 		?>
 		<p><i><?php echo _('There are no person or family notes to show for ')?><?php $person->printFieldValue('name'); ?></i></p>
 		<?php
 	} else {
-		$add_note_html = null;
-		if ($GLOBALS['user_system']->havePerm(PERM_EDITNOTE)) {
-			$add_note_html = '<a href="#add-note-modal" class="note-link" data-toggle="note-modal" data-personid="'.ents($person->id).'" data-name="'.ents($person->getValue('first_name').' '.$person->getValue('last_name')).'"><i class="icon-plus-sign"></i>'._('Add Note').'</a>';
-		}
 		?>
-
-        <?php include __DIR__ . '/note_filters.template.php'; ?>
+		<?php include __DIR__ . '/note_filters.template.php'; ?>
 		<p>
 			<i><?php echo _('Person and Family Notes for ')?><?php $person->printFieldValue('name'); ?>:</i>
-        </p>
+		</p>
 		<?php
 	}
 	$show_edit_link = true;


### PR DESCRIPTION
Regression from 44b0ef4 (Notes: add checkboxes allowing filtering by status/assignee): the "Add Note" link moved into the new note_filters.template.php sidebar, which is only rendered in the else branch (when notes exist). If a person or family had no notes, the link disappeared entirely, leaving no way to add the first note from the person/family page.

<img width="1087" height="243" alt="image" src="https://github.com/user-attachments/assets/29e5e476-49eb-4ce6-88c8-9acf6b6b54c7" />
<img width="1090" height="259" alt="image" src="https://github.com/user-attachments/assets/a724997f-9f76-435b-b31d-e094a0c2a46d" />

Visually identical to 2.38.0 - see:

https://easyjethro.com.au/demo/?view=families&familyid=76#notes https://easyjethro.com.au/demo/?view=persons&personid=168#notes