### PR TITLE
Fix ReferenceError on delete-list-item click in person chooser (#1515)

### DIFF
--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -846,7 +846,7 @@ JethroSearchChooserMulti.init = function(inputBox) {
 		callback: function(item) {
 					var myInput = document.getElementById(stem+'-input');
 					if (item.id != 0) {
-						$(document.getElementById(stem+'-list')).append('<li><div class=\"delete-list-item\" title=\"Remove inputBox item\" onclick=\"deletePersonChooserListItem(inputBox);\" />'+item.value+'<input type=\"hidden\" name=\"'+stem+'[]\" value=\"'+item.id+'\" /></li>');
+						$(document.getElementById(stem+'-list')).append('<li><div class=\"delete-list-item\" title=\"Remove inputBox item\" onclick=\"deletePersonChooserListItem(this);\" />'+item.value+'<input type=\"hidden\" name=\"'+stem+'[]\" value=\"'+item.id+'\" /></li>');
 					} else {
 						$(myInput).addClass('error');
 						setTimeout(function() { $(myInput).removeClass('error'); }, 1000);


### PR DESCRIPTION
The inline onclick handler passed `inputBox` (a closure variable from `JethroSearchChooserMulti.init`), but inline handlers only have access to the global scope. Changed to `this`, which is exactly what `deletePersonChooserListItem(elt)` expects — it uses `elt` to find the parent `<li>`.

Bug introduced by commit 566d642a (Issue #831), which added `deletePersonChooserListItem` along with two call sites. One passed `this` correctly; the other, likely from copy-paste, passed `inputBox` by mistake.

Fixes #1515