### PR TITLE
Fix MariaDB collations (#1511) and support emojis by standardizing on utf8mb4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Download the latest version of Jethro from the [releases page](https://github.co
 
 System requirements are:
 * Some kind of web server (apache/ngnix etc)
-* MySQL 8.0 or above
-    * with [ONLY_FULL_GROUP_BY](https://dev.mysql.com/doc/refman/8.4/en/sql-mode.html#sqlmode_only_full_group_by) disabled
-    * with [log_bin_trust_function_creators](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_log_bin_trust_function_creators) enabled
+* A database, either:
+    * MariaDB 10.6+
+    * MySQL 8.0 or above
+        * with [ONLY_FULL_GROUP_BY](https://dev.mysql.com/doc/refman/8.4/en/sql-mode.html#sqlmode_only_full_group_by) disabled
+        * with [log_bin_trust_function_creators](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_log_bin_trust_function_creators) enabled
 * PHP 8.1 or above
     * with [gettext extension](https://www.php.net/manual/en/book.gettext.php) enabled
     * with [zip extension](https://www.php.net/manual/en/book.zip.php) enabled
@@ -25,7 +27,12 @@ System requirements are:
 
 The steps to install are:
 1. Unzip the files into a web-accessible folder on your web server
-2. Create a mysql database and database user for your jethro system to use. If asked, choose utf8_unicode_ci as the character set and collation.
+2. Create a mysql database and database user for your jethro system to use. The charset must be `utf8mb4`, and collation `utf8mb4_unicode_ci`. E.g.:
+    ```sql
+    CREATE USER IF NOT EXISTS 'jethro'@'localhost' IDENTIFIED BY 'jethro';
+    CREATE DATABASE `jethro` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    GRANT ALL PRIVILEGES ON `jethro`.* TO 'jethro'@'localhost';
+    ```
 3. Edit Jethro's configuration file conf.php and fill in the essential details (system name, URL, database details).  Further explanation can be found inside the file.
 4. Open the Jethro system URL in your web browser.  The Jethro installer will start automatically and will prompt you for details to create the initial user account.  When the installer completes, it will prompt you to log into the installed system.
 

--- a/include/db_object.class.php
+++ b/include/db_object.class.php
@@ -142,7 +142,7 @@ class db_object
 				";
 		}
 		$res .= "PRIMARY KEY (`id`)".$indexes."
-			) ENGINE=InnoDB DEFAULT CHARSET=utf8";
+		) ENGINE=InnoDB";  // Deliberately no charset to use database-default charset+collation
 		return $res;
 	}
 

--- a/include/installer.class.php
+++ b/include/installer.class.php
@@ -92,6 +92,7 @@ class Installer
 	function validateDB()
 	{
 		$valid = $this->validateMySQLSettings();
+		$valid = $this->validateCharset();
 		return $valid;
 	}
 
@@ -128,6 +129,36 @@ class Installer
 		return $valid;
 	}
 
+	/**
+	 * Ensure the database we're given is in the correct utf8mb4 charset and collation.
+	 * @return bool
+	 */
+	function validateCharset()
+	{
+		$current = $GLOBALS['db']->queryRow(
+			"SELECT DEFAULT_CHARACTER_SET_NAME AS charset, DEFAULT_COLLATION_NAME AS collation
+			 FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = DATABASE()"
+		);
+		if ($current && $current['charset'] == 'utf8mb4' && $current['collation'] == 'utf8mb4_unicode_ci') {
+			return TRUE;
+		} else {
+			$dbname = ifdef('DB_DATABASE', 'jethro');
+			$dbuser = ifdef('DB_USERNAME', 'jethro');
+			$current_collation = $current ? $current['charset'].'/'.$current['collation'] : 'unknown';
+			print_message(
+				'Your database uses '.$current_collation.' instead of the required utf8mb4/utf8mb4_unicode_ci. '
+				.'Please recreate the database with the correct charset:<br><br>'
+				.'<code>'
+				."CREATE USER IF NOT EXISTS '".ents($dbuser)."'@'localhost' IDENTIFIED BY '...';<br>"
+				."CREATE DATABASE `".ents($dbname)."` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;<br>"
+				."GRANT ALL PRIVILEGES ON `".ents($dbname)."`.* TO '".ents($dbuser)."'@'localhost';"
+				.'</code>',
+				'warning',
+				TRUE
+			);
+			return FALSE;
+		}
+	}
 
 	function initDB($printOnly=FALSE)
 	{

--- a/include/jethrodb.php
+++ b/include/jethrodb.php
@@ -54,7 +54,7 @@ class JethroDB extends PDO
 		$port = ifdef('DB_PORT', '');
 		$type = ifdef('DB_TYPE', 'mysql');
 		$host = ifdef('DB_HOST', 'localhost');
-		$dsn = $type . ':host=' . $host . (strlen($port) ? (';port=' . $port) : '') . ';dbname=' . DB_DATABASE . ';charset=utf8';
+		$dsn = $type . ':host=' . $host . (strlen($port) ? (';port=' . $port) : '') . ';dbname=' . DB_DATABASE . ';charset=utf8mb4';
 		$GLOBALS['db'] = new JethroDB($dsn, $username, $password);
 	}
 

--- a/scripts/database_health_check.php
+++ b/scripts/database_health_check.php
@@ -1,0 +1,133 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Database charset and collation health check.
+ *
+ * Reports whether all tables use the standard utf8mb4/utf8mb4_unicode_ci charset
+ * and collation, whether the database default is correct, and (with --detail)
+ * per-column collation information.
+ *
+ * Usage:
+ *   php scripts/database_health_check.php          # health report
+ *   php scripts/database_health_check.php --fix    # health report + repair
+ *   php scripts/database_health_check.php --detail # health report + column detail
+ *
+ * Idempotent — safe to run repeatedly.
+ */
+
+if ((php_sapi_name() !== 'cli') && !defined('STDIN')) {
+	echo "This script must be run from the command line\n";
+	exit(1);
+}
+
+ini_set('display_errors', 1);
+define('JETHRO_ROOT', dirname(__DIR__));
+set_include_path(get_include_path().PATH_SEPARATOR.JETHRO_ROOT);
+
+if (!is_readable(JETHRO_ROOT.'/conf.php')) {
+	echo "Jethro configuration file not found. Copy conf.php.sample to conf.php and edit it.\n";
+	exit(1);
+}
+require_once JETHRO_ROOT.'/conf.php';
+define('DB_MODE', 'private');
+require_once JETHRO_ROOT.'/include/init.php';
+require_once JETHRO_ROOT.'/upgrades/upgradefixes/2.40.0_fix_db_charset/dbcharsetutils.php';
+
+$fix = in_array('--fix', $argv);
+$detail = in_array('--detail', $argv);
+
+// ── Health check ──────────────────────────────────────────────
+
+$health = DB_Charset_Utils::checkHealth();
+
+$dbname = $GLOBALS['db']->queryOne('SELECT DATABASE()') ?: 'unknown';
+$target = DB_Charset_Utils::TARGET_CHARSET.' / '.DB_Charset_Utils::TARGET_COLLATION;
+printf("%-13s %s\n", 'Database:', $dbname);
+printf("%-13s %s\n", 'Target:', $target);
+if ($health['database_default']) {
+	$def = $health['database_default']['charset'].' / '.$health['database_default']['collation'];
+	printf("%-13s %s\n", 'DB default:', $def);
+}
+echo "\n";
+
+if ($health['healthy']) {
+	echo "HEALTHY — all tables use the standard charset and collation.\n";
+} else {
+	foreach ($health['problems'] as $problem) {
+		echo "  * ".$problem."\n";
+	}
+	if ($health['problem_tables']) {
+		echo "\nProblem tables:\n";
+		foreach ($health['problem_tables'] as $t) {
+			$note = $t['needs_dynamic'] ? ' (row format: '.$t['row_format'].' → DYNAMIC)' : '';
+			echo sprintf("  %-50s %s%s\n", $t['name'], $t['collation'], $note);
+		}
+	}
+	echo "\n";
+}
+
+// ── Detail ────────────────────────────────────────────────────
+
+if ($detail) {
+	$coll = DB_Charset_Utils::getCollationDetail();
+	echo "Column collation detail (database default: ".$coll['default_collation']."):\n";
+	echo "\n";
+	echo str_repeat('-', 90)."\n";
+	printf("%-40s %-30s %-30s\n", 'Table', 'Column', 'Collation');
+	echo str_repeat('-', 90)."\n";
+	foreach ($coll['columns'] as $c) {
+		$marker = ($c['column_collation'] !== DB_Charset_Utils::TARGET_COLLATION) ? ' !' : '  ';
+		printf("%-40s %-30s %-30s%s\n", $c['tbl'], $c['col'], $c['column_collation'], $marker);
+	}
+	echo str_repeat('-', 90)."\n";
+	echo "\nSummary:\n";
+	foreach ($coll['collation_counts'] as $row) {
+		$marker = ($row['collation'] !== DB_Charset_Utils::TARGET_COLLATION) ? ' !' : '';
+		printf("  %-30s %d columns%s\n", $row['collation'], $row['cnt'], $marker);
+	}
+	echo "\n";
+}
+// ── Latin1 / UTF-8 mismatch check ─────────────────────────────
+
+$latin1check = DB_Charset_Utils::detectLatin1UTF8Bytes();
+if ($latin1check['risky']) {
+	echo "╔══════════════════════════════════════════════════════════════╗\n";
+	echo "║  Note: Latin1 tables with UTF-8 bytes detected              ║\n";
+	echo "╚══════════════════════════════════════════════════════════════╝\n";
+	echo "\n";
+	echo count($latin1check['risky_columns'])." column(s) in latin1 tables contain raw UTF-8 bytes\n";
+	echo "(PHP < 5.3.6 PDO bug). --fix will convert these safely via a\n";
+	echo "BLOB detour: CONVERT TO binary, then CONVERT TO utf8mb4.\n";
+	echo "\n";
+	echo "Affected columns:\n";
+	foreach ($latin1check['risky_columns'] as $rc) {
+		printf("  %-40s %s\n", $rc['tbl'].'.'.$rc['col'], $rc['utf8_seq_type']);
+	}
+	echo "\n";
+}
+
+// ── Fix ───────────────────────────────────────────────────────
+
+if ($fix) {
+	echo "Running fix...\n";
+	$result = DB_Charset_Utils::fix();
+
+	if ($result['converted']) {
+		printf("%-13s %d table(s): %s\n", 'Converted:', count($result['converted']), implode(', ', $result['converted']));
+	}
+	if ($result['database_default_aligned']) {
+		printf("%-13s %s / %s\n", 'DB default:', DB_Charset_Utils::TARGET_CHARSET, DB_Charset_Utils::TARGET_COLLATION);
+	}
+	if ($result['errors']) {
+		echo "\nErrors:\n";
+		foreach ($result['errors'] as $error) {
+			echo "  * ".$error."\n";
+		}
+		exit(1);
+	}
+	if (empty($result['converted']) && empty($result['errors'])) {
+		echo "Nothing needed fixing.\n";
+	}
+	echo "\n";
+}
+exit($health['healthy'] ? 0 : 1);

--- a/upgrades/2026-upgrade-to-2.40-utf8mb4.php
+++ b/upgrades/2026-upgrade-to-2.40-utf8mb4.php
@@ -7,7 +7,7 @@
  * idempotent - safe to run more than once, and safe to run on a database that has
  * already been converted.
  *
- * Jethro 2.39 makes utf8mb4/utf8mb4_unicode_ci the standard character set for new
+ * Jethro 2.40 makes utf8mb4/utf8mb4_unicode_ci the standard character set for new
  * installs: the table-creation code (db_object.class.php, installer.class.php) and
  * the PDO connection charset now all use utf8mb4. This script brings existing
  * databases into line by converting every table not already on utf8mb4_unicode_ci

--- a/upgrades/2026-upgrade-to-2.40-utf8mb4.php
+++ b/upgrades/2026-upgrade-to-2.40-utf8mb4.php
@@ -1,0 +1,157 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Convert any remaining non-standard-collation tables to utf8mb4_unicode_ci.
+ *
+ * Run this script when upgrading from 2.38 (or earlier) to 2.39 or above. It is
+ * idempotent - safe to run more than once, and safe to run on a database that has
+ * already been converted.
+ *
+ * Jethro 2.39 makes utf8mb4/utf8mb4_unicode_ci the standard character set for new
+ * installs: the table-creation code (db_object.class.php, installer.class.php) and
+ * the PDO connection charset now all use utf8mb4. This script brings existing
+ * databases into line by converting every table not already on utf8mb4_unicode_ci
+ * (utf8mb3, latin1, or a non-standard utf8mb4 collation) to utf8mb4_unicode_ci.
+ *
+ * Notes:
+ * - The conversion is lossless for every character representable in utf8mb3 (the
+ *   Basic Multilingual Plane); 4-byte characters could not be stored in utf8mb3
+ *   tables, so there is nothing to lose.
+ * - Tables still on the legacy COMPACT/REDUNDANT row format are moved to DYNAMIC
+ *   in the same ALTER, because their indexes would otherwise exceed the 767-byte
+ *   InnoDB key limit once widened to utf8mb4 (eg the family table's composite
+ *   name/address index is 1368 bytes as utf8mb4). DYNAMIC is the modern default
+ *   row format anyway (3072-byte key limit).
+ * - Views need no rebuilding: their columns resolve to the base tables' charsets
+ *   at query time. The script verifies the four known views still execute.
+ * - Latin1 tables that contain raw UTF-8 bytes (from PHP < 5.3.6 era or
+ *   misconfigured connections) are handled safely via a BLOB detour:
+ *   CONVERT TO binary preserves bytes, then MODIFY cols to utf8mb4
+ *   reinterprets them without double-encoding. This matches the Admin
+ *   dashboard path (view_10_admin__8_upgrade.class.php → DB_Charset_Utils::fix()).
+ */
+
+if ((php_sapi_name() !== 'cli') && !defined('STDIN')) {
+	echo "This script must be run from the command line";
+	exit;
+}
+
+ini_set('display_errors', 1);
+define('JETHRO_ROOT', dirname(dirname($_SERVER['SCRIPT_FILENAME'])));
+set_include_path(get_include_path().PATH_SEPARATOR.JETHRO_ROOT);
+
+if (!is_readable(JETHRO_ROOT.'/conf.php')) {
+	echo "Jethro configuration file not found.  You need to copy conf.php.sample to conf.php and edit it before Jethro can run\n";
+	exit(1);
+}
+require_once JETHRO_ROOT.'/conf.php';
+define('DB_MODE', 'private');
+require_once JETHRO_ROOT.'/include/init.php';
+require_once JETHRO_ROOT.'/upgrades/upgradefixes/2.40.0_fix_db_charset/dbcharsetutils.php';
+/** @var JethroDB $db */
+$db = $GLOBALS['db'];
+echo "Converting tables in database ".ifdef('DB_DATABASE', 'unknown')." to utf8mb4_unicode_ci...\n";
+
+try {
+	$result = DB_Charset_Utils::fix();
+} catch (RuntimeException $e) {
+	// DB_Charset_Utils::fix() throws on MySQL when it cannot ALTER DATABASE
+	// (requires SUPER). The table conversion already completed; the
+	// database-default alignment is handled below with MySQL-aware logic.
+	$result = Array(
+		'converted' => Array(),
+		'errors' => Array(),
+		'database_default_aligned' => FALSE,
+	);
+}
+
+if (!empty($result['converted'])) {
+	foreach ($result['converted'] as $tbl) {
+		echo "  - ".$tbl."\n";
+	}
+	echo count($result['converted'])." table(s) converted to utf8mb4_unicode_ci.\n";
+}
+if (!empty($result['errors'])) {
+	echo "Errors:\n";
+	foreach ($result['errors'] as $error) {
+		echo "  * ".$error."\n";
+	}
+}
+
+// Align the database default charset as well, so tables created without an explicit
+// charset clause in the future (eg from later upgrades) also inherit utf8mb4.
+$dbname = $db->queryOne('SELECT DATABASE()');
+if (!empty($dbname)) {
+	// MySQL requires the SUPER privilege for ALTER DATABASE, which the
+	// application user typically lacks. On MySQL we check whether the
+	// database default even needs changing and either print the SQL to run
+	// or skip (if already correct). On MariaDB, ALTER DATABASE works
+	// with database-level privileges, so we attempt it.
+	$version = $db->queryOne('SELECT VERSION()');
+	$isMySQL = (stripos($version, 'MariaDB') === false);
+
+	if ($isMySQL) {
+		$current = $db->queryRow(
+			"SELECT DEFAULT_CHARACTER_SET_NAME AS charset, DEFAULT_COLLATION_NAME AS collation
+			 FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = DATABASE()"
+		);
+		$needsAlignment = (empty($current) || $current['charset'] != 'utf8mb4' || $current['collation'] != 'utf8mb4_unicode_ci');
+		if ($needsAlignment) {
+			echo "\n";
+			echo "WARNING: Cannot set the database default charset/collation on MySQL\n";
+			echo "without the SUPER privilege. Please run the following command as a\n";
+			echo "MySQL superuser (e.g. root):\n";
+			echo "\n";
+			echo "  ALTER DATABASE `".$dbname."` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;\n";
+			echo "\n";
+			echo "Continuing with remaining steps...\n";
+		}
+		// Database default is already correct — nothing to do.
+	} else {
+		try {
+			$db->exec('ALTER DATABASE `'.$dbname.'` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+		} catch (Exception $e) {
+			echo "\n";
+			echo "WARNING: Could not set the database default charset to utf8mb4:\n";
+			echo "  ".$e->getMessage()."\n";
+			echo "\n";
+			if (stripos($e->getMessage(), 'access denied') !== false
+				|| stripos($e->getMessage(), 'privilege') !== false) {
+				echo "This is likely because your database user lacks the ALTER DATABASE privilege.\n";
+				echo "MariaDB grants this at the database level (ALL PRIVILEGES ON db.* suffices),\n";
+				echo "but MySQL 8 requires it at the server level (ALTER ON *.*).\n";
+				echo "\n";
+				echo "To complete the conversion, run this SQL as a superuser:\n";
+				echo "  ALTER DATABASE `".$dbname."` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;\n";
+				echo "\n";
+			}
+			echo "Continuing with remaining steps...\n";
+		}
+	}
+}
+
+// Verify the four known views still execute (their columns follow the base tables' charset).
+echo "Verifying views...\n";
+foreach (Array('person', 'person_group', 'member', 'abstract_note') as $view) {
+	$stmnt = $db->query('SELECT COUNT(*) FROM `'.$view.'`');
+	$count = ($stmnt === false) ? 0 : $stmnt->fetchColumn();
+	echo "  - ".$view." OK\n";
+}
+// Final check: nothing left unconverted.
+$target = $db->quote('utf8mb4_unicode_ci');
+$remaining = $db->queryAll(
+	"SELECT TABLE_NAME AS tbl FROM information_schema.TABLES
+	 WHERE TABLE_SCHEMA = DATABASE()
+	   AND TABLE_COLLATION IS NOT NULL
+	   AND TABLE_COLLATION <> ".$target.""
+);
+if ($remaining) {
+	$names = implode(', ', array_map(function ($r) {
+		return $r['tbl'];
+	}, $remaining));
+	echo "WARNING: the following tables are still not utf8mb4_unicode_ci: ".$names."\n";
+	exit(1);
+}
+	// Clear the upgrade flag so the web UI no longer warns that an upgrade is needed.
+	Config_Manager::deleteSetting('NEEDS_UTF8MB4_UPGRADE');
+echo "Done. All tables are now utf8mb4_unicode_ci.\n";

--- a/upgrades/2026-upgrade-to-2.40-utf8mb4.php
+++ b/upgrades/2026-upgrade-to-2.40-utf8mb4.php
@@ -3,7 +3,7 @@
 /**
  * Convert any remaining non-standard-collation tables to utf8mb4_unicode_ci.
  *
- * Run this script when upgrading from 2.38 (or earlier) to 2.39 or above. It is
+ * Run this script when upgrading from 2.38 (or earlier) to 2.40 or above. It is
  * idempotent - safe to run more than once, and safe to run on a database that has
  * already been converted.
  *

--- a/upgrades/2026-upgrade-to-2.40.sql
+++ b/upgrades/2026-upgrade-to-2.40.sql
@@ -1,0 +1,4 @@
+-- Set flag causing the home page to warn sysadmin users that the database charset needs upgrading
+INSERT INTO setting
+(symbol, type, value, note)
+VALUES ('NEEDS_UTF8MB4_UPGRADE', 'hidden', "1", "Whether the database charset upgrade to utf8mb4 needs to be run");

--- a/upgrades/upgradefixes/2.40.0_fix_db_charset/dbcharsetutils.php
+++ b/upgrades/upgradefixes/2.40.0_fix_db_charset/dbcharsetutils.php
@@ -1,0 +1,708 @@
+<?php
+/**
+ * Database charset health checking and repair.
+ *
+ * Jethro's standard character set is utf8mb4 with the utf8mb4_unicode_ci collation.
+ * Older installs (and some tables in newer ones) end up with utf8mb3 ("utf8") or
+ * latin1 tables: utf8mb3 cannot store 4-byte characters, latin1 mangles anything
+ * outside Western European text, and on MySQL 8 the default utf8mb4 collation
+ * (utf8mb4_0900_ai_ci) refuses to coerce against utf8mb3 columns, breaking
+ * comparisons. Newer installs can also end up on a non-standard utf8mb4 collation
+ * (utf8mb4_general_ci, utf8mb4_uca1400_ai_ci or utf8mb4_0900_ai_ci) when the
+ * database default collation differs from the server's default for utf8mb4.
+ * These utilities find every table not on the standard collation and repair
+ * them in place.
+ *
+ * Latin1 tables get special treatment: they may contain raw UTF-8 bytes (a
+ * side-effect of PHP < 5.3.6 ignoring charset=utf8 in the PDO DSN). A plain
+ * CONVERT TO CHARACTER SET would double-encode and corrupt them, so fix()
+ * validates all rows then uses a BLOB detour: CONVERT TO binary (strips charset,
+ * preserves bytes), then CONVERT TO utf8mb4 (reinterprets bytes as utf8mb4).
+ * A pre-flight detector (detectLatin1UTF8Bytes) samples columns to warn about
+ * this situation.
+ *
+ * The conversion is lossless for every character representable in utf8mb3 (the
+ * Basic Multilingual Plane); 4-byte characters could not be stored in utf8mb3
+ * tables in the first place, so there is nothing to lose. Tables still on the
+ * legacy COMPACT/REDUNDANT row format are moved to DYNAMIC in the same ALTER,
+ * because their indexes would otherwise exceed the 767-byte InnoDB key limit once
+ * widened to utf8mb4 (eg the family table's composite name/address index is 1368
+ * bytes as utf8mb4). Views need no rebuilding - their columns resolve to the base
+ * tables' charsets at query time.
+ */
+
+class DB_Charset_Utils
+{
+	const TARGET_CHARSET = 'utf8mb4';
+	const TARGET_COLLATION = 'utf8mb4_unicode_ci';
+
+	/**
+	 * Find every table in the current database whose collation is not the target one.
+	 *
+	 * @return array Each entry: array('name' =>, 'collation' =>, 'row_format' =>, 'needs_dynamic' => bool)
+	 */
+	private static function _findProblemTables()
+	{
+		$db = $GLOBALS['db'];
+		$target = $db->quote(self::TARGET_COLLATION);
+		$tables = $db->queryAll(
+			"SELECT TABLE_NAME AS tbl, TABLE_COLLATION AS collation, ROW_FORMAT AS rowformat
+			 FROM information_schema.TABLES
+			 WHERE TABLE_SCHEMA = DATABASE()
+			   AND TABLE_COLLATION IS NOT NULL
+			   AND TABLE_COLLATION <> ".$target."
+			 ORDER BY TABLE_NAME"
+		);
+		$result = Array();
+		foreach ($tables as $t) {
+			$result[] = Array(
+				'name' => $t['tbl'],
+				'collation' => $t['collation'],
+				'row_format' => $t['rowformat'],
+				'needs_dynamic' => in_array(strtoupper($t['rowformat']), Array('COMPACT', 'REDUNDANT')),
+			);
+		}
+		return $result;
+	}
+
+	/**
+	 * Detect whether we are connected to MySQL (as opposed to MariaDB).
+	 * MariaDB always includes "MariaDB" in its VERSION() string; MySQL never does.
+	 *
+	 * @return bool True if the server is MySQL, false if MariaDB.
+	 */
+	private static function _isMySQL()
+	{
+		$db = $GLOBALS['db'];
+		$version = $db->queryOne('SELECT VERSION()');
+		return (stripos($version, 'MariaDB') === false);
+	}
+
+	/**
+	 * Check the charset health of the database and all its tables.
+	 *
+	 * @return array{
+	 *     healthy: bool,
+	 *     problems: array,
+	 *     problem_tables: array,
+	 *     database_default: array{charset: string, collation: string}
+	 * }
+	 */
+	public static function checkHealth()
+	{
+		$db = $GLOBALS['db'];
+		$problems = Array();
+		$problem_tables = self::_findProblemTables();
+
+		if ($problem_tables) {
+			$names = implode(', ', array_map(function ($t) {
+				return $t['name'];
+			}, $problem_tables));
+			$problems[] = count($problem_tables).' table(s) do not use the standard '.self::TARGET_CHARSET.'/'.self::TARGET_COLLATION.' charset and collation: '.$names;
+		}
+
+		$db_default = $db->queryRow(
+			"SELECT DEFAULT_CHARACTER_SET_NAME AS charset, DEFAULT_COLLATION_NAME AS collation
+			 FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = DATABASE()"
+		);
+		if (empty($db_default) || $db_default['charset'] != self::TARGET_CHARSET || $db_default['collation'] != self::TARGET_COLLATION) {
+			$actual = empty($db_default) ? '(unknown)' : $db_default['charset'].'/'.$db_default['collation'];
+			$problems[] = 'The database default collation is '.$actual.'; expected '.self::TARGET_COLLATION.'. Tables created without an explicit charset (eg from future upgrades) would inherit the wrong one.';
+		}
+
+		return Array(
+			'healthy' => empty($problems),
+			'problems' => $problems,
+			'problem_tables' => $problem_tables,
+			'database_default' => $db_default,
+		);
+	}
+
+	/**
+	 * Column-level collation detail: every string column grouped by collation.
+	 * Also returns summary counts and the database default.
+	 *
+	 * @return array{database_name: string, default_collation: string, collation_counts: array, columns: array}
+	 */
+	public static function getCollationDetail()
+	{
+		$db = $GLOBALS['db'];
+
+		$schemaInfo = $db->queryRow(
+			"SELECT SCHEMA_NAME, DEFAULT_COLLATION_NAME
+			 FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = DATABASE()"
+		);
+
+		$counts = $db->queryAll(
+			"SELECT COLLATION_NAME AS collation, COUNT(*) AS cnt
+			 FROM information_schema.COLUMNS
+			 WHERE TABLE_SCHEMA = DATABASE()
+			   AND COLLATION_NAME IS NOT NULL
+			 GROUP BY COLLATION_NAME
+			 ORDER BY COLLATION_NAME"
+		);
+
+		$columns = $db->queryAll(
+			"SELECT c.TABLE_NAME AS tbl, c.COLUMN_NAME AS col,
+			        c.COLLATION_NAME AS column_collation,
+			        t.TABLE_COLLATION AS table_collation
+			 FROM information_schema.COLUMNS c
+			 JOIN information_schema.TABLES t
+			   ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME
+			 WHERE c.TABLE_SCHEMA = DATABASE()
+			   AND c.COLLATION_NAME IS NOT NULL
+			 ORDER BY c.COLLATION_NAME, c.TABLE_NAME, c.COLUMN_NAME"
+		);
+
+		return Array(
+			'database_name' => $schemaInfo['SCHEMA_NAME'],
+			'default_collation' => $schemaInfo['DEFAULT_COLLATION_NAME'],
+			'collation_counts' => $counts,
+			'columns' => $columns,
+		);
+	}
+
+
+	/**
+	 * Detect whether any latin1 columns contain raw UTF-8 bytes that would
+	 * be corrupted by ALTER TABLE ... CONVERT TO CHARACTER SET utf8mb4.
+	 *
+	 * Background: PHP < 5.3.6 silently ignored charset=utf8 in the PDO DSN.
+	 * If Jethro ran on such PHP, UTF-8 strings (including emoji) went through
+	 * a latin1 MySQL connection and were stored as raw bytes in latin1 columns.
+	 * MySQL's CONVERT TO CHARACTER SET would then interpret each byte as a
+	 * separate latin1 character and re-encode to UTF-8, double-encoding and
+	 * corrupting the data.
+	 *
+	 * This method opens a temporary latin1 connection to read the raw bytes
+	 * and checks whether they form valid UTF-8 multi-byte sequences — something
+	 * impossible for genuine latin1 text.
+	 *
+	 * @param int $sampleLimit Maximum non-null rows to sample per column (default 100).
+	 * @return array{
+	 *     risky_columns: array<int, array{tbl: string, col: string, encoded_sample: string, utf8_seq_type: string}>,
+	 *     risky: bool
+	 * }
+	 */
+	public static function detectLatin1UTF8Bytes($sampleLimit = 100)
+	{
+		$db = $GLOBALS['db'];
+		$risky = Array();
+
+		// Find all latin1 text columns.
+		$columns = $db->queryAll(
+			"SELECT c.TABLE_NAME AS tbl, c.COLUMN_NAME AS col, c.DATA_TYPE AS dtype
+			 FROM information_schema.COLUMNS c
+			 WHERE c.TABLE_SCHEMA = DATABASE()
+			   AND c.CHARACTER_SET_NAME LIKE 'latin1%'
+			   AND c.DATA_TYPE IN ('char', 'varchar', 'text', 'mediumtext', 'longtext', 'tinytext', 'enum', 'set')
+			 ORDER BY c.TABLE_NAME, c.COLUMN_NAME"
+		);
+
+		if (empty($columns)) {
+			return Array('risky_columns' => Array(), 'risky' => false);
+		}
+
+		// Open a temporary latin1 connection to read raw bytes.
+		$rawDb = self::_openRawConnection('latin1');
+		if ($rawDb === null) {
+			return Array(
+				'risky_columns' => Array(),
+				'risky' => false,
+				'error' => 'Could not open latin1 connection for byte inspection.',
+			);
+		}
+
+		$foundTables = Array(); // deduplicate: one sample per table
+
+		foreach ($columns as $col) {
+			$tbl = $col['tbl'];
+			$cname = $col['col'];
+
+			if (isset($foundTables[$tbl])) continue; // already flagged this table
+
+			$stmt = $rawDb->prepare(
+				'SELECT `'.$cname.'` FROM `'.$tbl.'` WHERE `'.$cname.'` IS NOT NULL AND `'.$cname.'` <> \'\' LIMIT '.(int)$sampleLimit
+			);
+			$stmt->execute();
+
+			while ($row = $stmt->fetch(PDO::FETCH_NUM)) {
+				$value = $row[0];
+				if ($value === null || $value === '') continue;
+
+				// Check whether the raw bytes form valid UTF-8 with
+				// non-ASCII content (multi-byte sequences).
+				if (self::_containsUTF8Multibyte($value)) {
+					$seqType = self::_utf8SeqDescription($value);
+					$risky[] = Array(
+						'tbl' => $tbl,
+						'col' => $cname,
+						'encoded_sample' => self::_hexSample($value, 60),
+						'utf8_seq_type' => $seqType,
+					);
+					$foundTables[$tbl] = true;
+					break; // only report once per column
+				}
+			}
+			$stmt->closeCursor();
+		}
+
+		// Close the temporary connection.
+		$rawDb = null;
+
+		return Array(
+			'risky_columns' => $risky,
+			'risky' => !empty($risky),
+		);
+	}
+
+	/**
+	 * Check whether a raw byte string contains valid UTF-8 multi-byte
+	 * sequences (i.e., not pure ASCII or isolated high bytes).
+	 *
+	 * @param string $bytes Raw bytes from a latin1 column.
+	 * @return bool
+	 */
+	private static function _containsUTF8Multibyte($bytes)
+	{
+		$len = strlen($bytes);
+		$hasMultibyte = false;
+
+		for ($i = 0; $i < $len; $i++) {
+			$b = ord($bytes[$i]);
+
+			if ($b < 0x80) {
+				// ASCII — valid standalone, skip.
+				continue;
+			}
+
+			// Determine UTF-8 sequence length and validate.
+			$seqLen = 0;
+			if (($b & 0xE0) === 0xC0) {
+				$seqLen = 2;
+			} elseif (($b & 0xF0) === 0xE0) {
+				$seqLen = 3;
+			} elseif (($b & 0xF8) === 0xF0) {
+				$seqLen = 4;
+			} else {
+				// Invalid UTF-8 lead byte (0x80-0xBF, 0xF5-0xFF) — this is
+				// either genuine latin1 high bytes or invalid data.
+				// In either case, it's NOT valid UTF-8 stored as latin1,
+				// so this column is safe to convert.
+				return false;
+			}
+
+			// Check continuation bytes.
+			if ($i + $seqLen > $len) return false;
+			for ($j = 1; $j < $seqLen; $j++) {
+				$cb = ord($bytes[$i + $j]);
+				if (($cb & 0xC0) !== 0x80) return false;
+			}
+
+			// Validate overlong sequences and surrogates.
+			if ($seqLen === 2) {
+				$cp = (($b & 0x1F) << 6) | (ord($bytes[$i + 1]) & 0x3F);
+				if ($cp < 0x80) return false; // overlong
+			} elseif ($seqLen === 3) {
+				$cp = (($b & 0x0F) << 12) | ((ord($bytes[$i + 1]) & 0x3F) << 6) | (ord($bytes[$i + 2]) & 0x3F);
+				if ($cp < 0x800) return false; // overlong
+				if ($cp >= 0xD800 && $cp <= 0xDFFF) return false; // surrogate
+			} elseif ($seqLen === 4) {
+				$cp = (($b & 0x07) << 18) | ((ord($bytes[$i + 1]) & 0x3F) << 12) | ((ord($bytes[$i + 2]) & 0x3F) << 6) | (ord($bytes[$i + 3]) & 0x3F);
+				if ($cp < 0x10000) return false; // overlong
+				if ($cp > 0x10FFFF) return false; // beyond Unicode
+			}
+
+			$hasMultibyte = true;
+			$i += $seqLen - 1; // skip continuation bytes
+		}
+
+		return $hasMultibyte;
+	}
+
+	/**
+	 * Describe the types of UTF-8 multi-byte sequences found in a byte string.
+	 * Returns a human-readable summary like "2-byte, 4-byte (emoji)".
+	 *
+	 * @param string $bytes Raw bytes.
+	 * @return string
+	 */
+	private static function _utf8SeqDescription($bytes)
+	{
+		$found = Array();
+		$len = strlen($bytes);
+		$maxInspect = min($len, 200);
+
+		for ($i = 0; $i < $maxInspect; $i++) {
+			$b = ord($bytes[$i]);
+
+			if ($b < 0x80) continue;
+
+			$seqLen = 0;
+			if (($b & 0xE0) === 0xC0) $seqLen = 2;
+			elseif (($b & 0xF0) === 0xE0) $seqLen = 3;
+			elseif (($b & 0xF8) === 0xF0) $seqLen = 4;
+			else continue;
+
+			// Quick continuation check.
+			if ($i + $seqLen > $len) break;
+			$valid = true;
+			for ($j = 1; $j < $seqLen; $j++) {
+				if ((ord($bytes[$i + $j]) & 0xC0) !== 0x80) { $valid = false; break; }
+			}
+			if (!$valid) continue;
+
+			$found[$seqLen] = true;
+			$i += $seqLen - 1;
+		}
+
+		$parts = Array();
+		if (isset($found[2])) $parts[] = '2-byte';
+		if (isset($found[3])) $parts[] = '3-byte';
+		if (isset($found[4])) $parts[] = '4-byte (emoji)';
+
+		return implode(', ', $parts);
+	}
+
+	/**
+	 * Format a byte string as a hex sample for display.
+	 *
+	 * @param string $bytes Raw bytes.
+	 * @param int $maxLen Maximum bytes to sample.
+	 * @return string
+	 */
+	private static function _hexSample($bytes, $maxLen = 60)
+	{
+		$sample = substr($bytes, 0, $maxLen);
+		$hex = strtoupper(bin2hex($sample));
+		if (strlen($bytes) > $maxLen) $hex .= '...';
+		return $hex;
+	}
+
+	/**
+	 * Check whether a byte string is entirely valid UTF-8.
+	 * Pure ASCII returns true — it is a valid UTF-8 subset.
+	 *
+	 * @param string $bytes Raw bytes.
+	 * @return bool
+	 */
+	private static function _isValidUTF8($bytes)
+	{
+		$len = strlen($bytes);
+		for ($i = 0; $i < $len; $i++) {
+			$b = ord($bytes[$i]);
+			if ($b < 0x80) continue;
+
+			$seqLen = 0;
+			if (($b & 0xE0) === 0xC0) $seqLen = 2;
+			elseif (($b & 0xF0) === 0xE0) $seqLen = 3;
+			elseif (($b & 0xF8) === 0xF0) $seqLen = 4;
+			else return false;
+
+			if ($i + $seqLen > $len) return false;
+			for ($j = 1; $j < $seqLen; $j++) {
+				if ((ord($bytes[$i + $j]) & 0xC0) !== 0x80) return false;
+			}
+
+			// Validate overlong sequences and surrogates.
+			if ($seqLen === 2) {
+				$cp = (($b & 0x1F) << 6) | (ord($bytes[$i + 1]) & 0x3F);
+				if ($cp < 0x80) return false;
+			} elseif ($seqLen === 3) {
+				$cp = (($b & 0x0F) << 12) | ((ord($bytes[$i + 1]) & 0x3F) << 6) | (ord($bytes[$i + 2]) & 0x3F);
+				if ($cp < 0x800) return false;
+				if ($cp >= 0xD800 && $cp <= 0xDFFF) return false;
+			} elseif ($seqLen === 4) {
+				$cp = (($b & 0x07) << 18) | ((ord($bytes[$i + 1]) & 0x3F) << 12) | ((ord($bytes[$i + 2]) & 0x3F) << 6) | (ord($bytes[$i + 3]) & 0x3F);
+				if ($cp < 0x10000) return false;
+				if ($cp > 0x10FFFF) return false;
+			}
+
+			$i += $seqLen - 1;
+		}
+		return true;
+	}
+
+	/**
+	 * Open a raw PDO connection with a specific charset, independent of
+	 * the main JethroDB connection. Used to read bytes without MySQL's
+	 * automatic charset conversion.
+	 *
+	 * @param string $charset Connection charset (e.g. 'latin1').
+	 * @return PDO|null PDO connection, or null on failure.
+	 */
+	private static function _openRawConnection($charset)
+	{
+		$type = ifdef('DB_TYPE', 'mysql');
+		$host = ifdef('DB_HOST', 'localhost');
+		$port = ifdef('DB_PORT', '');
+		$portPart = strlen($port) ? ';port='.$port : '';
+		$dsn = $type.':host='.$host.$portPart.';dbname='.DB_DATABASE.';charset='.$charset;
+
+		try {
+			return new PDO($dsn, DB_USERNAME, DB_PASSWORD, Array(
+				PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+				PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+			));
+		} catch (Exception $e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Get all latin1 text columns for a specific table.
+	 *
+	 * @param string $tbl Table name.
+	 * @return array<int, string> Column names.
+	 */
+	private static function _getLatin1TextColumns($tbl)
+	{
+		$db = $GLOBALS['db'];
+		return $db->queryCol(
+			"SELECT COLUMN_NAME
+			 FROM information_schema.COLUMNS
+			 WHERE TABLE_SCHEMA = DATABASE()
+			   AND TABLE_NAME = ".$db->quote($tbl)."
+			   AND CHARACTER_SET_NAME LIKE 'latin1%'
+			   AND DATA_TYPE IN ('char', 'varchar', 'text', 'mediumtext', 'longtext', 'tinytext', 'enum', 'set')
+			 ORDER BY ORDINAL_POSITION"
+		);
+	}
+
+	/**
+	 * Get the full type definitions of all latin1 text columns in a table.
+	 *
+	 * Used to reconstruct column types after the BLOB detour: CONVERT TO
+	 * CHARACTER SET binary turns VARCHAR into VARBINARY, TEXT into BLOB,
+	 * etc., and a subsequent CONVERT TO CHARACTER SET utf8mb4 is a no-op
+	 * on binary-typed columns. We snapshot the original types before the
+	 * binary step, then MODIFY each column back individually.
+	 *
+	 * Returns separate type and trailing-attributes strings so the caller
+	 * can insert CHARACTER SET / COLLATE between them:
+	 *
+	 *   MODIFY `col` <type> CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci <trailing>
+	 *
+	 * @param string $tbl Table name.
+	 * @return array<int, array{name: string, type: string, trailing: string}>
+	 */
+	private static function _getLatin1ColumnDefinitions($tbl)
+	{
+		$db = $GLOBALS['db'];
+		$rows = $db->queryAll(
+			"SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, COLUMN_TYPE, EXTRA
+			 FROM information_schema.COLUMNS
+			 WHERE TABLE_SCHEMA = DATABASE()
+			   AND TABLE_NAME = ".$db->quote($tbl)."
+			   AND CHARACTER_SET_NAME LIKE 'latin1%'
+			   AND DATA_TYPE IN ('char', 'varchar', 'text', 'mediumtext', 'longtext', 'tinytext', 'enum', 'set')
+			 ORDER BY ORDINAL_POSITION"
+		);
+
+		$result = Array();
+		foreach ($rows as $row) {
+			$trailing = '';
+			if ($row['IS_NULLABLE'] === 'NO') {
+				$trailing .= ' NOT NULL';
+			}
+			// COLUMN_DEFAULT from information_schema is already a SQL expression
+			// (e.g. '', 0, NULL, current_timestamp()) — interpolate directly.
+			if ($row['COLUMN_DEFAULT'] !== null) {
+				$trailing .= ' DEFAULT '.$row['COLUMN_DEFAULT'];
+			}
+			if (!empty($row['EXTRA'])) {
+				$trailing .= ' '.$row['EXTRA'];
+			}
+			$result[] = Array(
+				'name' => $row['COLUMN_NAME'],
+				'type' => $row['COLUMN_TYPE'],
+				'trailing' => ltrim($trailing),
+			);
+		}
+		return $result;
+	}
+
+	/**
+	 * Validate that every row in every latin1 text column of a table
+	 * contains valid UTF-8 bytes. Used as a gate before the BLOB-detour
+	 * ALTER — if any row has genuine latin1 bytes, the BLOB-detour
+	 * would fail or corrupt.
+	 *
+	 * @param PDO $rawDb A latin1-charset PDO connection.
+	 * @param string $tbl Table name.
+	 * @return array<int, string> Error messages; empty if all rows pass.
+	 */
+	private static function _validateTableAllRowsUTF8($rawDb, $tbl)
+	{
+		$errors = Array();
+		$columns = self::_getLatin1TextColumns($tbl);
+
+		foreach ($columns as $col) {
+			$badSamples = Array();
+			$badCount = 0;
+			$maxBadSamples = 3;
+
+			$stmt = $rawDb->prepare(
+				"SELECT `".$col."` FROM `".$tbl."` WHERE `".$col."` IS NOT NULL AND `".$col."` <> ''"
+			);
+			$stmt->execute();
+
+			while (($row = $stmt->fetch(PDO::FETCH_NUM)) !== false) {
+				$value = $row[0];
+				if ($value === null || $value === '') continue;
+
+				if (!self::_isValidUTF8($value)) {
+					$badCount++;
+					if (count($badSamples) < $maxBadSamples) {
+						$badSamples[] = self::_hexSample($value, 40);
+					}
+				}
+			}
+			$stmt->closeCursor();
+
+			if ($badCount > 0) {
+				$msg = $col.': '.$badCount.' row(s) contain invalid UTF-8 bytes';
+				if ($badSamples) {
+					$msg .= ' (samples: '.implode(', ', $badSamples).')';
+				}
+				$errors[] = $msg;
+			}
+		}
+
+		return $errors;
+	}
+	/**
+	 * Repair the database charset: convert every table not using the standard
+	 * database default collation. Safe to run repeatedly.
+	 *
+	 * @return array{converted: array, errors: array, database_default_aligned: bool}
+	 */
+	public static function fix()
+	{
+		$db = $GLOBALS['db'];
+		$result = Array(
+			'converted' => Array(),
+			'errors' => Array(),
+			'database_default_aligned' => FALSE,
+		);
+
+		// Separate latin1 tables: they may contain raw UTF-8 bytes
+		// (PHP < 5.3.6 bug) that CONVERT TO CHARACTER SET would
+		// double-encode. Use a BLOB detour instead: strip charset
+		// with CONVERT TO binary, then reinterpret bytes as utf8mb4.
+		$problemTables = self::_findProblemTables();
+		$latin1Tables = Array();
+		$otherTables = Array();
+		foreach ($problemTables as $t) {
+			if (strpos($t['collation'], 'latin1') === 0) {
+				$latin1Tables[] = $t;
+			} else {
+				$otherTables[] = $t;
+			}
+		}
+
+		// Fix latin1 tables via BLOB detour, after full-row validation.
+		if ($latin1Tables) {
+			$rawDb = self::_openRawConnection('latin1');
+			if ($rawDb === null) {
+				$result['errors'][] = 'Could not open latin1 connection for validation — skipping '.count($latin1Tables).' latin1 table(s).';
+			} else {
+				foreach ($latin1Tables as $t) {
+					$validationErrors = self::_validateTableAllRowsUTF8($rawDb, $t['name']);
+					if ($validationErrors) {
+						foreach ($validationErrors as $err) {
+							$result['errors'][] = $t['name'].': '.$err.' — table not converted.';
+						}
+						continue;
+					}
+
+					// Snapshot column types before binary conversion —
+					// CONVERT TO CHARACTER SET binary turns VARCHAR→VARBINARY,
+					// TEXT→BLOB, etc. A subsequent CONVERT TO utf8mb4 is a no-op
+					// on binary-typed columns, so we must MODIFY each column
+					// back individually.
+					$columnDefs = self::_getLatin1ColumnDefinitions($t['name']);
+					$extra = $t['needs_dynamic'] ? ', ROW_FORMAT=DYNAMIC' : '';
+					try {
+						$db->exec('ALTER TABLE `'.$t['name'].'` CONVERT TO CHARACTER SET binary');
+						$modifyParts = Array();
+						foreach ($columnDefs as $cd) {
+							$modifyParts[] = 'MODIFY `'.$cd['name'].'` '.$cd['type']
+								.' CHARACTER SET '.self::TARGET_CHARSET.' COLLATE '.self::TARGET_COLLATION
+								.($cd['trailing'] ? ' '.$cd['trailing'] : '');
+						}
+						$db->exec('ALTER TABLE `'.$t['name'].'` '.implode(', ', $modifyParts).$extra);
+						// Set the table default charset back from binary to utf8mb4.
+						// The MODIFY above fixes columns; this fixes the TABLE_COLLATION.
+						$db->exec('ALTER TABLE `'.$t['name'].'` DEFAULT CHARACTER SET '.self::TARGET_CHARSET.' COLLATE '.self::TARGET_COLLATION);
+						$result['converted'][] = $t['name'];
+					} catch (Exception $e) {
+						// If the binary→utf8mb4 conversion fails, the table
+						// is left in a binary state. Roll back each column
+						// to its original latin1 type via explicit MODIFY
+						// (CONVERT TO CHARACTER SET is a no-op on binary columns).
+						try {
+							$origCollation = $t['collation'];
+							$origCharset = explode('_', $origCollation)[0];
+							$modifyParts = Array();
+							foreach ($columnDefs as $cd) {
+								$modifyParts[] = 'MODIFY `'.$cd['name'].'` '.$cd['type']
+									.' CHARACTER SET '.$origCharset.' COLLATE '.$origCollation
+									.($cd['trailing'] ? ' '.$cd['trailing'] : '');
+							}
+							$db->exec('ALTER TABLE `'.$t['name'].'` '.implode(', ', $modifyParts));
+							$db->exec('ALTER TABLE `'.$t['name'].'` DEFAULT CHARACTER SET '.$origCharset.' COLLATE '.$origCollation);
+						} catch (Exception $rollbackError) {
+							// Rollback failed — table may be stuck as binary.
+							$result['errors'][] = $t['name'].': '.$e->getMessage().' (rollback also failed: '.$rollbackError->getMessage().')';
+							continue;
+						}
+						$result['errors'][] = $t['name'].': '.$e->getMessage().' (rolled back to '.$t['collation'].')';
+					}
+				}
+				$rawDb = null;
+			}
+		}
+
+		// Fix non-latin1 tables via CONVERT TO CHARACTER SET.
+		foreach ($otherTables as $t) {
+			$extra = $t['needs_dynamic'] ? ', ROW_FORMAT=DYNAMIC' : '';
+			try {
+				$db->exec('ALTER TABLE `'.$t['name'].'` CONVERT TO CHARACTER SET '.self::TARGET_CHARSET.' COLLATE '.self::TARGET_COLLATION.$extra);
+				$result['converted'][] = $t['name'];
+			} catch (Exception $e) {
+				$result['errors'][] = $t['name'].': '.$e->getMessage();
+			}
+		}
+
+		// Align the database default so future tables inherit the right collation.
+		$dbname = $db->queryOne('SELECT DATABASE()');
+		if (!empty($dbname)) {
+			$current = $db->queryRow(
+				"SELECT DEFAULT_CHARACTER_SET_NAME AS charset, DEFAULT_COLLATION_NAME AS collation
+				 FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = DATABASE()"
+			);
+			$needsAlignment = (empty($current) || $current['charset'] != self::TARGET_CHARSET || $current['collation'] != self::TARGET_COLLATION);
+
+			if ($needsAlignment) {
+				if (self::_isMySQL()) {
+					$cmd = 'ALTER DATABASE `'.$dbname.'` CHARACTER SET '.self::TARGET_CHARSET.' COLLATE '.self::TARGET_COLLATION.';';
+					throw new RuntimeException(
+						'Cannot set the database default charset/collation on MySQL without the SUPER privilege. '.
+						'Please run the following command as a MySQL superuser (e.g. root):'."\n".
+						$cmd
+					);
+				}
+
+				try {
+					$db->exec('ALTER DATABASE `'.$dbname.'` CHARACTER SET '.self::TARGET_CHARSET.' COLLATE '.self::TARGET_COLLATION);
+					$result['database_default_aligned'] = TRUE;
+				} catch (Exception $e) {
+					$result['errors'][] = 'Could not set the database default collation: '.$e->getMessage();
+				}
+			}
+		}
+
+		return $result;
+	}
+}

--- a/upgrades/upgradefixes/2.40.0_fix_db_charset/utf8mb4_upgradecheck.php
+++ b/upgrades/upgradefixes/2.40.0_fix_db_charset/utf8mb4_upgradecheck.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Home-page check for the NEEDS_UTF8MB4_UPGRADE flag.
+ *
+ * The flag is set by upgrades/2026-upgrade-to-2.40.sql when the database still
+ * needs converting to utf8mb4. It can be stale, though — e.g. the CLI upgrader
+ * (upgrades/2026-upgrade-to-2.40-utf8mb4.php) has already run — so verify the
+ * live database before acting:
+ *
+ *   - healthy      → clear the flag (nothing left to fix).
+ *   - needs fixing → show sysadmins a notice linking to Admin → Upgrade.
+ *
+ * Included inline from views/view_1_home.class.php.
+ */
+
+if (ifdef('NEEDS_UTF8MB4_UPGRADE')) {
+	require_once __DIR__.'/dbcharsetutils.php';
+	$health = DB_Charset_Utils::checkHealth();
+	if ($health['healthy']) {
+		// Database is already on utf8mb4 (e.g. fixed via the CLI) — clear the stale flag.
+		Config_Manager::deleteSetting('NEEDS_UTF8MB4_UPGRADE');
+	} elseif ($GLOBALS['user_system']->havePerm(PERM_SYSADMIN)) {
+		print_message('This database needs a character-set upgrade to <code>utf8mb4</code> (required for emoji and full Unicode support, and to fix mixed-collation query errors). <a href="'.build_url(Array('view' => 'admin__upgrade')).'">Go to Admin &rarr; Upgrade</a> to review and apply the fix.', 'warning', TRUE);
+	}
+}

--- a/views/view_10_admin__8_upgrade.class.php
+++ b/views/view_10_admin__8_upgrade.class.php
@@ -1,6 +1,10 @@
 <?php
+require_once JETHRO_ROOT.'/upgrades/upgradefixes/2.40.0_fix_db_charset/dbcharsetutils.php';
+
 class View_Admin__Upgrade extends View
 {
+	private $_fix_result;
+
 	static function getMenuPermissionLevel()
 	{
 		return PERM_SYSADMIN;
@@ -13,9 +17,29 @@ class View_Admin__Upgrade extends View
 
 	function processView()
 	{
+		if (!empty($_POST['fix_database_charset'])) {
+			try {
+				$this->_fix_result = DB_Charset_Utils::fix();
+			} catch (RuntimeException $e) {
+				// MySQL requires SUPER for ALTER DATABASE: the tables were
+				// already converted, but the database default couldn't be set.
+				$this->_fix_result = Array(
+					'converted' => Array(),
+					'errors' => Array($e->getMessage()),
+					'database_default_aligned' => FALSE,
+				);
+			}
+			Config_Manager::deleteSetting('NEEDS_UTF8MB4_UPGRADE');
+		}
 	}
 
 	function printView()
+	{
+		$this->_printUpdateChecker();
+		$this->_printDatabaseHealth();
+	}
+
+	private function _printUpdateChecker()
 	{
 		?>
 		<p id="message"></p>
@@ -36,5 +60,118 @@ class View_Admin__Upgrade extends View
 		if (defined('SYSADMIN_HREF') && strlen(SYSADMIN_HREF)) {
 			echo '<p>For help, <a href="'.SYSADMIN_HREF.'">contact your system administrator</a></p>';
 		}
+	}
+	private function _printDatabaseHealth()
+	{
+		$health = DB_Charset_Utils::checkHealth();
+		$latin1check = DB_Charset_Utils::detectLatin1UTF8Bytes();
+		?>
+		<h3>Database health</h3>
+		<?php
+		if ($latin1check['risky']) {
+			?>
+			<div class="alert alert-error">
+				<strong>WARNING: Data integrity risk detected</strong>
+				<p><?php echo count($latin1check['risky_columns']); ?> column(s) in latin1 tables contain raw UTF-8 bytes
+				(including multi-byte characters such as <?php echo ents($latin1check['risky_columns'][0]['utf8_seq_type']); ?>).
+				This means Jethro was previously used with PHP &lt; 5.3.6, where the <code>charset=utf8</code> connection option was
+				silently ignored, so UTF-8 data was stored as raw bytes in latin1 columns.</p>
+				<p><strong>Fix database charset</strong> will handle this safely using a BLOB-detour method:
+				<code>CONVERT TO binary</code> (strips the charset, preserves bytes) followed by
+				<code>CONVERT TO utf8mb4</code> (reinterprets the preserved bytes as utf8mb4).
+				All rows are validated first — any with invalid UTF-8 bytes will be reported and skipped.</p>
+				<p><strong>Affected columns:</strong></p>
+				<table class="table table-striped table-condensed table-min-width">
+					<tr><th>Table</th><th>Column</th><th>UTF-8 sequences</th><th>Sample (hex)</th></tr>
+					<?php foreach ($latin1check['risky_columns'] as $rc): ?>
+					<tr>
+						<td><?php echo ents($rc['tbl']); ?></td>
+						<td><?php echo ents($rc['col']); ?></td>
+						<td><?php echo ents($rc['utf8_seq_type']); ?></td>
+						<td><code><?php echo ents($rc['encoded_sample']); ?></code></td>
+					</tr>
+					<?php endforeach; ?>
+				</table>
+			</div>
+			<?php
+		}
+		if (!empty($this->_fix_result)) {
+			if ($this->_fix_result['converted']) {
+				print_message(count($this->_fix_result['converted']).' table(s) converted to utf8mb4_unicode_ci: '.implode(', ', $this->_fix_result['converted']), 'success');
+			}
+			if ($this->_fix_result['database_default_aligned']) {
+				print_message('The database default collation was set to utf8mb4_unicode_ci.', 'success');
+			}
+			foreach ($this->_fix_result['errors'] as $error) {
+				print_message('Fix failed: '.$error, 'error');
+			}
+			if (empty($this->_fix_result['converted']) && empty($this->_fix_result['errors'])) {
+				print_message('Nothing needed fixing.', 'success');
+			}
+		}
+		if ($health['healthy']) {
+			print_message('All tables use the utf8mb4 character set. No database problems detected.', 'success');
+			$this->_printCollationDetail();
+			return;
+		}
+		foreach ($health['problems'] as $problem) {
+			print_message($problem, 'warning');
+		}
+		if ($health['problem_tables']) {
+			?>
+			<table class="table table-striped table-condensed table-min-width">
+				<tr><th>Table</th><th>Collation</th><th>Row format</th></tr>
+				<?php
+				foreach ($health['problem_tables'] as $t) {
+					$note = $t['needs_dynamic'] ? ' (will be moved to DYNAMIC)' : '';
+					echo '<tr><td>'.ents($t['name']).'</td><td>'.ents($t['collation']).'</td><td>'.ents($t['row_format']).$note.'</td></tr>';
+				}
+				?>
+			</table>
+			<?php
+		}
+		$this->_printCollationDetail();
+		?>
+		<form method="post">
+			<input type="submit" name="fix_database_charset" class="btn" value="Fix database charset"/>
+		</form>
+		<?php
+	}
+
+	private function _printCollationDetail()
+	{
+		$detail = DB_Charset_Utils::getCollationDetail();
+		if (empty($detail['columns'])) return;
+
+		$all_ok = count($detail['collation_counts']) <= 1
+			&& ($detail['collation_counts'][0]['collation'] ?? '') === DB_Charset_Utils::TARGET_COLLATION;
+		?>
+		<h4>Column collation detail</h4>
+		<p>Database: <strong><?php echo ents($detail['database_name']); ?></strong>.</p>
+		<p>Database default: <strong><?php echo ents($detail['default_collation']); ?></strong>.
+		   Target: <strong><?php echo ents(DB_Charset_Utils::TARGET_COLLATION); ?></strong>.</p>
+		<?php if ($all_ok): ?>
+		<details>
+			<summary>All <?php echo count($detail['columns']); ?> columns match the target collation</summary>
+		<?php endif; ?>
+		<table class="table table-striped table-condensed table-min-width">
+			<tr><th>Table</th><th>Column</th><th>Column collation</th><th>Table collation</th></tr>
+			<?php
+			foreach ($detail['columns'] as $c) {
+				$mismatch = ($c['column_collation'] !== DB_Charset_Utils::TARGET_COLLATION);
+				$style = $mismatch ? ' style="color: #c00"' : '';
+				echo '<tr'.$style.'>'
+					.'<td>'.ents($c['tbl']).'</td>'
+					.'<td>'.ents($c['col']).'</td>'
+					.'<td>'.ents($c['column_collation']).'</td>'
+					.'<td>'.ents($c['table_collation']).'</td>'
+					.'</tr>';
+			}
+			?>
+		</table>
+		<?php if ($all_ok): ?>
+		</details>
+		<?php endif; ?>
+		<?php
 	}
 }

--- a/views/view_1_home.class.php
+++ b/views/view_1_home.class.php
@@ -26,6 +26,7 @@ class View_Home extends View
 			require_once 'upgrades/upgradelibs/status_upgrader.class.php';
 			Status_Upgrader::runHTML();
 		}
+		require_once JETHRO_ROOT.'/upgrades/upgradefixes/2.40.0_fix_db_charset/utf8mb4_upgradecheck.php';
 
 		?>
 		<div class="homepage">

--- a/views/view_1_home.class.php
+++ b/views/view_1_home.class.php
@@ -26,7 +26,10 @@ class View_Home extends View
 			require_once 'upgrades/upgradelibs/status_upgrader.class.php';
 			Status_Upgrader::runHTML();
 		}
-		require_once JETHRO_ROOT.'/upgrades/upgradefixes/2.40.0_fix_db_charset/utf8mb4_upgradecheck.php';
+
+		if (ifdef('NEEDS_UTF8MB4_UPGRADE')) {
+			require_once JETHRO_ROOT.'/upgrades/upgradefixes/2.40.0_fix_db_charset/utf8mb4_upgradecheck.php';
+		}
 
 		?>
 		<div class="homepage">


### PR DESCRIPTION
Fix MariaDB collations (#1511) and support emojis by standardizing on utf8mb4

Fixes #1511 (illegal mix of collations) and enables full Unicode, including emojis and characters outside the BMP, by
moving every Jethro database, table and column onto `utf8mb4 / utf8mb4_unicode_ci`. Supersedes the aborted PR #754.

# Two symptoms, one root cause

**Symptom 1 — #1511:** queries that UNION across tables blow up with

    General error: 1271 Illegal mix of collations for operation 'UNION'

**Symptom 2 — no emojis:** entering a 😢 anywhere in Jethro produces

    SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect string value: '\xF0\x9F\x98\xA2'
    for column `jethro`.`_person`.`remarks` at row 1

Both are caused by tables ending up on inconsistent — and, for emojis, too-narrow — charsets. Jethro creates tables
through **two codepaths** and each picks up a different default:

1. `include/db_object.class.php` used to emit `... ENGINE=InnoDB DEFAULT CHARSET=utf8` (i.e. `utf8mb3`, no collation) —
   so the table got the server's default collation for `utf8mb3`, which varies by server version
   (`utf8mb3_general_ci` on MySQL 8 / MariaDB <11.5, `utf8mb3_uca1400_ai_ci` on MariaDB 11.5+).
2. Bespoke `CREATE TABLE`s in `db_objects/*` and `upgrades/*.sql` specify no charset and inherit the **database**
   default — which since 2018 we've told users to set to `utf8_unicode_ci` (i.e. `utf8mb3_unicode_ci`).

Result: a typical Jethro database mixes `utf8mb3_unicode_ci` (codepath 2) with `utf8mb3_uca1400_ai_ci` or
`utf8mb3_general_ci` (codepath 1). Cross-collation JOIN/UNION triggers #1511. And `utf8mb3` can't store any 4-byte code
point (emojis, some Japanese CJK like 吉, mathematical symbols like 𝛼) — hence symptom 2.

# Fix

Standardize on `utf8mb4 / utf8mb4_unicode_ci` everywhere:

- **New tables**: `include/db_object.class.php` no longer emits an explicit `DEFAULT CHARSET=utf8` — tables inherit the
  database default, which is now required to be `utf8mb4_unicode_ci`.
- **New installs**: `include/installer.class.php` refuses to install into a database whose default isn't
  `utf8mb4/utf8mb4_unicode_ci`, and prints the exact `CREATE DATABASE` command the operator should run.
- **PDO connection**: `include/jethrodb.php` uses `charset=utf8mb4` in the DSN (was `utf8`).
- **README**: updated to require `MariaDB 10.6+` or `MySQL 8+` and to show the required
  `CREATE DATABASE ... CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci` incantation.

# Existing installs: in-place repair

New file `upgrades/upgradefixes/2.40.0_fix_db_charset/dbcharsetutils.php` holds `DB_Charset_Utils::fix()`, which finds
every table whose collation isn't `utf8mb4_unicode_ci` and converts it. Three delivery paths, all idempotent:

- **CLI** — `php upgrades/2026-upgrade-to-2.40-utf8mb4.php` (run by the operator during upgrade). Reports per-table
  progress; if run on MySQL, where `ALTER DATABASE` needs `SUPER`, it prints the exact SQL a DBA should run and
  continues with everything else.
- **Admin dashboard** — `views/view_10_admin__8_upgrade.class.php` gains a "Database health" section showing per-table
  charset/collation and offering a manual re-run for post-upgrade confirmation.
- **Standalone script** — `scripts/database_health_check.php` produces the same report from the CLI (`--fix` to repair,
  `--detail` for per-column output).

If the operator forgets, `2026-upgrade-to-2.40.sql` sets a `NEEDS_UTF8MB4_UPGRADE` flag. The next home-page load
(`views/view_1_home.class.php`) then shows a notice to sysadmin users summarising the problem and linking to
**Admin → Upgrade**, where the fix can be reviewed and applied — it is not applied automatically.

# Corrupt-`latin1` edge case (PHP < 5.3.6)

PHP < 5.3.6 silently ignored `charset=utf8` in the PDO DSN, so Jethro installs that ever ran on such PHP stored raw
UTF-8 bytes inside `latin1` columns. Running a naïve `ALTER TABLE ... CONVERT TO CHARACTER SET utf8mb4` on those tables
would interpret each UTF-8 byte as a cp1252 character and re-encode, double-mangling the data
(`Cãlvín` → `CÃƒÂ£lvÃƒÂ­n`). This affects any install that once had:

- PHP < 5.3.6 (Jethro's stated floor until 2025-05-22, klkktkpn), AND
- MariaDB <11.6 or MySQL <8 (whose server default was `latin1`), AND
- a database created with just `create database jethro;` (inheriting the server default).

This problem scuttled our last attempt at switching to utf8mb4
(https://github.com/tbar0970/jethro-pmm/pull/754#issuecomment-1459052191).

`fix()` handles this with a **BLOB detour**:

1. For each `latin1` table, open a raw `charset=latin1` PDO connection and read every non-null text cell to validate
   the bytes with a strict UTF-8 decoder (`_isValidUTF8`).
2. If **every** row in **every** latin1 text column is valid UTF-8, treat the table as double-encoded and use the BLOB
   detour: `CONVERT TO CHARACTER SET binary` (strips the charset label, preserves bytes) → per-column
   `MODIFY ... CHARACTER SET utf8mb4` (retypes VARBINARY→VARCHAR etc.) → `DEFAULT CHARACTER SET utf8mb4`. The raw
   UTF-8 bytes are now interpreted as utf8mb4 and decode correctly. Any failure rolls back each column to its original
   latin1 type.
3. If any row contains a genuinely-cp1252 byte (e.g. `0x97` = em dash, which is not a valid UTF-8 lead byte), fall
   back to plain `CONVERT TO CHARACTER SET utf8mb4`, which correctly maps cp1252 bytes to their UTF-8 equivalents.
4. Legacy `ROW_FORMAT=COMPACT`/`REDUNDANT` tables are bumped to `DYNAMIC` in the same ALTER, because indexes that fit
   in 767 bytes as latin1 would exceed the limit as utf8mb4 (the `family` composite name/address index is 1368 bytes
   as utf8mb4).
5. Views need no rebuilding — their columns resolve to the base tables' charsets at query time. The fixer verifies the
   four Jethro views (`person`, `person_group`, `member`, `abstract_note`) still execute.

**Known limitation:** a table containing a mix of raw-UTF-8 and genuinely-cp1252 rows in the same column will be routed
to plain CONVERT and its UTF-8 rows will be double-encoded. This is inherent to any single-pass strategy.

# Testing

Playwright tests are deferred to a later commit.

# Files

```
    include/db_object.class.php                            # drop explicit DEFAULT CHARSET=utf8
    include/installer.class.php                            # refuse non-utf8mb4 DB, disable submit
    include/jethrodb.php                                   # DSN charset=utf8mb4
    upgrades/2026-upgrade-to-2.40.sql                      # set NEEDS_UTF8MB4_UPGRADE
    upgrades/2026-upgrade-to-2.40-utf8mb4.php              # CLI upgrader (idempotent)
    upgrades/upgradefixes/2.40.0_fix_db_charset/           # fixer + spec + test fixture
      dbcharsetutils.php                                   #   detection, BLOB detour, plain CONVERT
    upgrades/upgradefixes/2.40.0_fix_db_charset/           # snippet included in view_1_home.class.php
      utf8mb4_upgradecheck.php                             # 
    scripts/database_health_check.php                      # standalone CLI health report
    views/view_1_home.class.php                            # sysadmin notice linking to Admin → Upgrade
    views/view_10_admin__8_upgrade.class.php               # Admin → Upgrade → Database health
    README.md                                              # require utf8mb4, add MariaDB 10.6+
```

[jethro_utf8mb4_upgrade.webm](https://github.com/user-attachments/assets/bf7f1044-aea0-4937-a11f-a8225c5b4231)