### PR TITLE
Define BASE_URL_ABSOLUTE for code explicitly needing an absolute URL

### DIFF
--- a/include/general.php
+++ b/include/general.php
@@ -813,25 +813,20 @@ function get_url_pathprefix()
 }
 
 /**
- * Infer Jethro's absolute base URL from the request.
+ * Infer Jethro's absolute base URL from the request (scheme + host + path).
+ * Returns e.g. "https://church.org/jethro" — no trailing slash.
+ * Proxy-aware: respects X-Forwarded-Proto and X-Forwarded-Host.
  */
 function baseurl_absolute()
 {
-    // Detect scheme
     $https = (
         (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ||
         (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443) ||
         (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
     );
     $scheme = $https ? 'https' : 'http';
-
-    // Detect host (with proxy awareness)
     $host = $_SERVER['HTTP_X_FORWARDED_HOST'] ?? $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'];
-
-    // Detect base path (the directory your app runs from)
     $scriptDir = baseurl_relative();
-
-    // Build base URL (no trailing slash if at root)
     return $scheme . '://' . $host . ($scriptDir !== '' ? $scriptDir : '');
 }
 

--- a/include/init.php
+++ b/include/init.php
@@ -49,6 +49,16 @@ if (defined('SESSION_TIMEOUT_MINS')) {
 // Infer BASE_URL from the request, if it hasn't been set manually.
 if (!defined('BASE_URL')) define('BASE_URL', baseurl_relative());
 
+// Infer the absolute base URL (scheme://host[/path]) from the request.
+// If BASE_URL is already absolute (e.g. set in conf.php), use it directly.
+if (!defined('BASE_URL_ABSOLUTE')) {
+	if (defined('BASE_URL') && str_starts_with(BASE_URL, 'http')) {
+		define('BASE_URL_ABSOLUTE', rtrim(BASE_URL, '/'));
+	} else {
+		define('BASE_URL_ABSOLUTE', baseurl_absolute());
+	}
+}
+
 if (session_id() == '') {
   	// If max length is set, set the cookie timeout - this will allow sessions to outlast browser invocations
   	$expiryTime = defined('SESSION_MAXLENGTH_MINS') ? SESSION_MAXLENGTH_MINS * 60 : NULL;

--- a/scripts/task_reminder.php
+++ b/scripts/task_reminder.php
@@ -22,7 +22,6 @@ if (!is_readable(JETHRO_ROOT.'/conf.php')) {
 require_once JETHRO_ROOT.'/conf.php';
 define('DB_MODE', 'PRIVATE');
 require_once JETHRO_ROOT.'/include/init.php';
-if (!BASE_URL) throw new \RuntimeException('Please define a non-blank BASE_URL in conf.php');
 
 if (ifdef('TASK_NOTIFICATION_ENABLED', FALSE) == FALSE) {
 	if ($VERBOSE) echo "Task notification is disabled in conf.php - exiting \n";
@@ -68,8 +67,9 @@ foreach ($reminders as $reminder) {
 	if ($reminder['total_notes'] > $reminder['new_notes']) {
 		$content .= sprintf($totalNotesText, $reminder['total_notes']);
 	}
+	$loginUrl = BASE_URL_ABSOLUTE;
 	$content .= sprintf($outroText,
-						BASE_URL,
+						$loginUrl,
 						SYSTEM_NAME);
 	
 	$html = nl2br($content);


### PR DESCRIPTION
Mostly we use relative URLs, but in a few spots we do need an absolute URL (task_reminder.php login URL, relative SMS_*_URL deref).

Currently the rule is: if you use task_reminder.php, you have to set BASE_URL explicitly to an absolute URL in conf.php. That is brittle and easy to forget.

This change makes the need explicit by defining a BASE_URL_ABSOLUTE constant to complement BASE_URL, and then using it in task_reminder.php. If BASE_URL happens to be set to an absolute URL in conf.php, BASE_URL_ABSOLUTE uses it, so it's fully backwards-compatible.