### PR TITLE
Safer interpretation of bool settings

### DIFF
--- a/include/config_manager.class.php
+++ b/include/config_manager.class.php
@@ -19,7 +19,11 @@ class Config_Manager {
 					add_message("The setting ".$symbol." has now been migrated to the database and should be removed from conf.php");
 				}
 			} else {
-				define($symbol, $details['value']);
+				$value = $details['value'];
+				if ($details['type'] === 'bool') {
+					$value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+				}
+				define($symbol, $value);
 			}
 		}
 		if (defined('AGE_BRACKET_OPTIONS')) {


### PR DESCRIPTION
Remove a footgun: if a boolean setting had a string value of 'false', as in this upgrade SQL:

```sql
('SMS_VERBOSE', 'bool', 'false', 'Log HTTP requests to upstream SMS provider', @sms_base + 40),
```

Jethro interpreted this setting as true, because strings are truthy.

Bool settings need to be interpreted via FILTER_VALIDATE_BOOLEAN.