### PR TITLE
Fix too-big textbox due to CSS regression. #1521

### DIFF
--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -846,9 +846,22 @@ table.custom-field-tooltip {
 .right {
 	text-align: right !important;
 }
+
 select, input, textarea,div.editor {
+	/* apply shrink-to-fit sizing rather than bootstrap's default 206px */
 	width: auto;
 }
+
+.modal input, .modal select, .modal textarea, .modal .uneditable-input {
+	/* In modals the shink-to-fit size from the rule above is too wide. Constrain it to the containing box */
+	max-width: 100%;
+	/* 'box-sizing: border-box' means max-width includes padding and
+	 * border. Without this, the padding + border makes the actual width exceed
+	 * 100% resulting in a scrollbar. Previously we had 'max-width: 97%' to avoid
+	 * that. */
+	box-sizing: border-box;
+}
+
 .full-width-input {
 	width: 99.5%;
 	-webkit-box-sizing: border-box;


### PR DESCRIPTION
Said someone on PR #1424:

```
The '(Choose)' clip is fixed, by removing a max-width: 97%. I've no idea what it achieved, so possibly I've broken
layout elsewhere, but I can't see it.
```

As it turns out, the `max-width:` is very necessary on the Services "Add ad-hoc service item" modal, where the `auto`
width algorithm yields a way too wide input element without the `max-width` constraint.

The clipping problem is now fixed by setting max-width to 100% rather than 97%. For select lists, the 'auto' algorithm
was getting the width correct, and 97% was 3% too small.

The reason we had 97% originally is because `max-width: 100%` resulted in a horizontal scrollbar. `max-width` means the
*content* width, and when padding + border were added, the final width exceeded 100% of the container, causing a
horizontal scrollbar. Removing 3% was a hack to avoid that.

The proper fix, now applied, is to specify `box-sizing: border-box;`, which makes the 'max-width: 100%' mean "100%
including border and margin width, whatever they are". So no scrollbar, and no clipping.

Fixes #1521


[jethro_dialog_widths.webm](https://github.com/user-attachments/assets/b6f3ee05-d2f9-4f6b-bb6e-e4579c2d43f9)

