### PR TITLE
status.php cleanups and 'warnings' summary field.

### DIFF
--- a/docs/docs/reference/status-php.mdx
+++ b/docs/docs/reference/status-php.mdx
@@ -1,0 +1,304 @@
+---
+sidebar_position: 8
+---
+
+# status.php
+
+Jethro's `status.php` endpoint reports the PHP, database, and web-server configuration as JSON. It is written for monitoring systems (e.g. Nagios) and for administrators checking that a Jethro install is healthy. The companion plugin `scripts/check_http_jethrostatus` turns the JSON into a pass/warn result.
+
+## How to read the output
+
+The endpoint returns three kinds of field, grouped in that order:
+
+- **Raw observations** — facts read directly from the environment (PHP ini values, the OS user, database state). No judgment, just the inputs.
+- **Derived verdicts** — `status.php`'s own judgment about whether something is wrong.
+- **Aggregate** — `warnings`, a summary of every verdict that is currently non-nominal.
+
+| Convention | Fields | Nominal (healthy) | Non-nominal (problem) |
+|---|---|---|---|
+| "problem" fields | `php_incompatible_version`, `*_performance_impact`, `*_misconfigured` | `false` | a descriptive string (`true` for `php_incompatible_version`) |
+| "status" fields | `php_extensions_installed`, `request_id_added` | `true` | `false` or a descriptive string |
+
+`warnings` is an array: empty (`[]`) when everything is nominal, otherwise a list of the field names that are currently non-nominal.
+
+---
+
+## Raw observations
+
+### `runtime_user`
+
+**Expected value:** `"jethro"` — or whatever non-root user your PHP-FPM pool runs as.
+
+Shows the OS user PHP is executing as (`$_SERVER['USER']`). It matters because PHP should never run as `root`: a vulnerability in the application would then have unrestricted system access.
+
+Non-nominal: `"root"` (or any user you did not expect).
+
+### `jethroversion` *(conditional)*
+
+**Expected value:** the Jethro version you intend to deploy.
+
+Present only when `SHOW_JETHRO_VERSION` is `true` in `status.php` (off by default). It reports the running `JETHRO_VERSION` so you can confirm the deployed version matches expectations. The check plugin flags it only when run with `--require-jethro-version`.
+
+### `max_input_vars`
+
+**Expected value:** `10000` or higher.
+
+Shows PHP's `max_input_vars` (default `1000`). The default is too low: large attendance sheets and many custom fields generate more GET/POST/COOKIE variables than 1000, and the excess is silently discarded ([#6](https://github.com/tbar0970/jethro-pmm/issues/6), [#152](https://github.com/tbar0970/jethro-pmm/issues/152); see also [PR #1497](https://github.com/tbar0970/jethro-pmm/pull/1497)).
+
+Non-nominal: a value below `10000` → inputs may be truncated.
+
+`php.ini` setting:
+
+```ini
+max_input_vars = 10000
+```
+
+### `post_max_size`
+
+**Expected value:** `"20M"` or higher (parsed as MB).
+
+Shows PHP's `post_max_size` verbatim as PHP reported it (e.g. `"8M"`, `"20M"`, `"1G"`). The default of 8M is too small — contact photos can exceed it ([#949](https://github.com/tbar0970/jethro-pmm/issues/949)).
+
+Non-nominal: leading integer below `20` → large form submissions / uploads fail.
+
+`php.ini` setting:
+
+```ini
+post_max_size = 20M
+```
+
+### `upload_max_filesize`
+
+**Expected value:** `"20M"` or higher (parsed as MB).
+
+Shows PHP's `upload_max_filesize` verbatim as PHP reported it (e.g. `"2M"`, `"20M"`). The default of 2M is too small for common uploads.
+
+Non-nominal: leading integer below `20` → uploads fail.
+
+`php.ini` setting:
+
+```ini
+upload_max_filesize = 20M
+```
+
+### `db_charset_results`
+
+**Expected value:** `"utf8mb4"`.
+
+Shows the MySQL session variable `@@character_set_results` on the connection. Jethro needs real 4-byte UTF-8; MySQL's historical `utf8` (now `utf8mb3`) is only 3-byte and cannot represent supplementary characters such as emoji, which causes upgrade problems ([#754](https://github.com/tbar0970/jethro-pmm/issues/754), [#1088](https://github.com/tbar0970/jethro-pmm/issues/1088)).
+
+Non-nominal: `utf8`, `utf8mb3`, `latin1`, etc.
+
+No php.ini setting — this is the database connection/server character set, configured on the MySQL server or the connection. Jethro 3.40+ may automatically diagnose/fix this problem ([#1517](https://github.com/tbar0970/jethro-pmm/pull/1517)).
+
+### `session_gc_maxlifetime`
+
+**Expected value:** at least `SESSION_TIMEOUT_MINS × 60` (Jethro's default is 90 minutes → `5400` seconds).
+
+Shows PHP's `session.gc_maxlifetime`. It is the raw input that `session_gc_misconfigured` (below) judges.
+
+`php.ini` setting:
+
+```ini
+session.gc_maxlifetime = 5400
+```
+
+### `session_gc_probability`
+
+**Expected value:** `1` (or any non-zero value).
+
+Shows PHP's `session.gc_probability`. The default (`1`) is fine; a value of `0` disables PHP's own garbage collection and is part of what triggers the `session_gc_misconfigured` warning.
+
+`php.ini` setting:
+
+```ini
+session.gc_probability = 1
+```
+
+### `xdebug_loaded`, `xdebug.mode`, `xdebug.start_with_request`
+
+**Expected value:** `xdebug_loaded` is informational (either `true` or `false`); what matters is the verdict in `xdebug_performance_impact` below.
+
+These three fields expose the raw Xdebug state: whether the extension is loaded, its `xdebug.mode`, and its `xdebug.start_with_request`. See [Understanding xdebug](#understanding-xdebug-settings) for the full explanation.
+
+---
+
+## Derived verdicts
+
+### `php_incompatible_version`
+
+**Expected value:** `false`.
+
+Shows `!version_compare(PHP_VERSION, '8.1', '>')` — `false` when PHP is newer than 8.1, `true` when it is not. Jethro requires PHP 8.1+.
+
+Non-nominal: `true` (PHP ≤ 8.1). No php.ini setting — install a newer PHP.
+
+### `php_extensions_installed`
+
+**Expected value:** `true`.
+
+Shows whether all required PHP extensions are loaded: `gettext`, `zip`, `xmlwriter`, `gd`, `curl`, `exif`.
+
+Non-nominal: `"Missing extensions: …"` listing whichever are absent. Install the missing extensions (as packages / `extension=` directives).
+
+### `request_id_added`
+
+**Expected value:** `true / false`
+
+Shows whether the `HTTP_X_REQUEST_ID` request header is present, which Nginx `$request_id` or Apache's `mod_unique_id`
+module sets. Setting a unique request ID header is optional, but useful in production, as lets you correlate access-log
+entries with error-log entries and application logging. E.g. in Nginx, one's main `location` block might set the header
+with:
+
+```nginx
+	fastcgi_param HTTP_X_REQUEST_ID $request_id;
+```
+
+and then in `log_format`, include the header with:
+
+```nginx
+    'jethrouid=$upstream_http_x_jethro_uid '
+```
+
+The `check_http_jethrostatus` plugin flags `false` as a warning only when run with `--require-request-id`.
+
+
+### `xdebug_performance_impact`
+
+**Expected value:** `false`.
+
+Shows whether Xdebug is loaded *and* actively doing work. The verdict logic is:
+
+```php
+extension_loaded('xdebug')
+    && xdebug.mode not in ('off', '')
+    && (mode contains 'develop' || start_with_request == 'yes')
+```
+
+Non-nominal: `"xdebug performance impact: mode=…, start_with_request=…"` when Xdebug is adding overhead. To make it nominal while keeping Xdebug installed, disable its mode:
+
+```ini
+[xdebug]
+xdebug.mode = off
+```
+
+#### Understanding Xdebug settings
+
+Xdebug's `xdebug.mode` is a comma-separated list of modes:
+
+| Mode | What it does | Overhead |
+|---|---|---|
+| `off` | Xdebug disabled | none |
+| `develop` | improved errors, stack traces, `var_dump` | small, **always on** when listed |
+| `debug` | step debugging | large, gated by `start_with_request` |
+| `trace` | function traces | large, gated by `start_with_request` |
+| `profile` | profiling | large, gated by `start_with_request` |
+
+`xdebug.start_with_request` controls when the *gated* modes (`debug`/`trace`/`profile`) begin:
+
+| Value | Meaning |
+|---|---|
+| `yes` | start on every request |
+| `no` | never start |
+| `trigger` | start only when a trigger (cookie/request parameter) is present |
+| `default` | same as `trigger` |
+
+`develop` ignores `start_with_request` — it is always active whenever it appears in `xdebug.mode`. And only `start_with_request=yes` actually starts a gated mode on every request; `trigger`/`default` arm on a cookie/param and cost nothing per-request until the trigger arrives. That asymmetry is what `xdebug_performance_impact` encodes:
+
+| Xdebug loaded | `xdebug.mode` | `start_with_request` | `xdebug_performance_impact` |
+|---|---|---|---|
+| no | — | — | `false` |
+| yes | `off` | — | `false` |
+| yes | *(empty)* | — | `false` |
+| yes | `develop` | `no` | string (impact) |
+| yes | `develop` | `default` | string (impact) |
+| yes | `debug` | `no` | `false` |
+| yes | `debug` | `yes` | string (impact) |
+| yes | `debug` | `trigger` | `false` |
+| yes | `debug` | `default` | `false` |
+
+Note: `trigger`/`default` mean an attacker who knows the trigger cookie/parameter can enable step-debugging on a public endpoint. That is a *security* concern, not a performance one, and this field does not police it — production installs should not load Xdebug at all.
+
+### `opcache_performance_impact`
+
+**Expected value:** `false`.
+
+Shows the opcache/JIT state. Nominal means opcache bytecode caching is **on** and JIT is **off**:
+
+- `"opcache is not enabled"` — opcache is disabled, so no bytecode cache.
+- `"opcache JIT is enabled"` — JIT is on, which burns CPU on warmup and is pointless for Jethro's short-lived request/response pages.
+
+```ini
+[opcache]
+opcache.enable = 1
+opcache.jit = off
+```
+
+### `session_gc_misconfigured`
+
+**Expected value:** `false`.
+
+Shows whether session garbage collection is configured so that sessions can expire prematurely. The condition is `session.gc_probability == 0` **and** `session.gc_maxlifetime < SESSION_TIMEOUT_MINS × 60`.
+
+Why it matters: Debian/Ubuntu ship a `sessionclean` cron job that deletes session files older than `session.gc_maxlifetime`. When PHP's own GC is disabled (`gc_probability = 0`) *and* `gc_maxlifetime` is shorter than Jethro's session timeout, that cron reaps sessions early and users get logged out unexpectedly. This surfaced in [#1088](https://github.com/tbar0970/jethro-pmm/issues/1088) — specifically [the sessionclean discussion](https://github.com/tbar0970/jethro-pmm/issues/1088#issuecomment-2436805398).
+
+Non-nominal: `"Session GC misconfigured: gc_probability=0, gc_maxlifetime=…s < SESSION_TIMEOUT_MINS*60"`. The fix is to make the reap threshold at least as long as Jethro's session timeout (default 90 minutes → 5400 s):
+
+```ini
+session.gc_maxlifetime = 5400
+```
+
+### `logging_misconfigured`
+
+**Expected value:** `false`.
+
+Shows whether PHP's `log_errors` is On. Errors must be logged (rather than only displayed) so problems can be diagnosed in production.
+
+Non-nominal: `"log_errors=Off"` (or `"log_errors=0"` if set explicitly to `0`).
+
+```ini
+log_errors = On
+```
+
+For production also hide errors from output:
+
+```ini
+display_errors = Off
+```
+
+---
+
+## Aggregate
+
+### `warnings`
+
+**Expected value:** `[]` (an empty array).
+
+Lists the field names currently in a non-nominal state. It is derived from every verdict above plus the threshold comparisons (`max_input_vars`, `post_max_size`, `upload_max_filesize`, `db_charset_results`). An empty array means everything is healthy; a non-empty array tells you at a glance which fields to look up in this guide.
+
+No php.ini setting — fix the individual fields it names.
+
+---
+
+## Nominal php.ini reference
+
+These are recommended `php.ini` settings to run Jethro with, which `status.php` expects:
+
+```ini
+[php]
+max_input_vars        = 10000
+post_max_size         = 20M
+upload_max_filesize   = 20M
+session.gc_maxlifetime = 5400   ; SESSION_TIMEOUT_MINS (90) × 60
+session.gc_probability = 1
+log_errors            = On
+
+[opcache]
+opcache.enable        = 1
+opcache.jit           = off
+
+[xdebug]
+xdebug.mode           = off       ; or omit xdebug entirely
+```
+
+Remember to restart PHP-FPM after editing php.ini.

--- a/scripts/check_http_jethrostatus
+++ b/scripts/check_http_jethrostatus
@@ -28,6 +28,7 @@ my $opt_post_max_size       = 20;       # MB
 my $opt_upload_max_filesize = 20;       # MB
 my $opt_db_charset_results  = 'utf8mb4';
 my $opt_require_jethro_version = 0;
+my $opt_require_request_id = 0;
 my $opt_required_runtime_user = undef;
 
 GetOptions(
@@ -40,6 +41,7 @@ GetOptions(
     'upload-max-filesize=i'     => \$opt_upload_max_filesize,
     'db-charset-results=s'      => \$opt_db_charset_results,
     'require-jethro-version'    => \$opt_require_jethro_version,
+    'require-request-id'        => \$opt_require_request_id,
     'expected-runtime-user=s'   => \$opt_required_runtime_user,
 ) or exit UNKNOWN;
 
@@ -53,8 +55,10 @@ if ($opt_help || !$opt_url) {
     print "  -t, --timeout   HTTP request timeout (default: $opt_timeout)\n";
     print "  --max-input-vars          Minimum max_input_vars (default: $opt_max_input_vars)\n";
     print "  --post-max-size           Minimum post_max_size in MB (default: $opt_post_max_size)\n";
+    print "  --upload-max-filesize     Minimum upload_max_filesize in MB (default: $opt_upload_max_filesize)\n";
     print "  --db-charset-results      Required db_charset_results (default: $opt_db_charset_results)\n";
     print "  --require-jethro-version  Require jethroversion field in response\n";
+    print "  --require-request-id      Require request_id_added=true in response\n";
     print "  --expected-runtime-user   Required OS user (e.g. 'jethro', not 'root')\n";
     exit UNKNOWN;
 }
@@ -87,11 +91,46 @@ eval {
     exit CRITICAL;
 };
 
-# Helper: status fields now use "true if good, error string if bad"
-sub is_good { my $v = shift; return JSON::PP::is_bool($v) && $v; }
-
+# Two value conventions for good/bad fields:
+#   - "problem" fields (*_performance_impact, *_misconfigured, *_incompatible_version):
+#     JSON false = nominal (no problem); anything else (a descriptive string or JSON true) = a problem.
+#   - "status" fields (php_extensions_installed, request_id_added):
+#     JSON true = good; a descriptive string = a problem.
+#
 # ── validate ────────────────────────────────────────────────────────────────
 my @errs;
+
+sub check_nominal {
+    my ($name) = @_;
+    my $val = $status->{$name};
+    if (!defined $val) {
+        push @errs, "$name is missing from response";
+    } elsif (JSON::PP::is_bool($val)) {
+        push @errs, "$name is true" if $val;
+    } else {
+        push @errs, $val;
+    }
+}
+
+sub check_enabled {
+    my ($name) = @_;
+    my $val = $status->{$name};
+    if (!defined $val) {
+        push @errs, "$name is missing from response";
+    } elsif (JSON::PP::is_bool($val)) {
+        push @errs, "$name is false" unless $val;
+    } else {
+        push @errs, $val;
+    }
+}
+# Parse a PHP shorthand-bytes ini value ("20M", "1G", "512K", or bare bytes) into
+# a byte count. Returns 0 for malformed input.
+sub parse_ini_bytes {
+    my ($v) = @_;
+    return 0 unless defined $v && $v =~ /^\s*(\d+)\s*([kmg]?)\s*$/i;
+    my %mult = ('' => 1, k => 1024, m => 1024**2, g => 1024**3);
+    return $1 * $mult{lc $2};
+}
 
 # max_input_vars
 {
@@ -108,8 +147,8 @@ my @errs;
     my $val = $status->{post_max_size};
     if (!defined $val) {
         push @errs, "post_max_size is missing from response";
-    } elsif ($val < $opt_post_max_size) {
-        push @errs, sprintf("post_max_size is %sM, must be >= %sM", $val, $opt_post_max_size);
+    } elsif (parse_ini_bytes($val) < $opt_post_max_size * 1024**2) {
+        push @errs, sprintf("post_max_size is %s, must be >= %sM", $val, $opt_post_max_size);
     }
 }
 
@@ -118,8 +157,8 @@ my @errs;
     my $val = $status->{upload_max_filesize};
     if (!defined $val) {
         push @errs, "upload_max_filesize is missing from response";
-    } elsif ($val < $opt_upload_max_filesize) {
-        push @errs, sprintf("upload_max_filesize is %sM, must be >= %sM", $val, $opt_upload_max_filesize);
+    } elsif (parse_ini_bytes($val) < $opt_upload_max_filesize * 1024**2) {
+        push @errs, sprintf("upload_max_filesize is %s, must be >= %sM", $val, $opt_upload_max_filesize);
     }
 }
 
@@ -135,72 +174,34 @@ my @errs;
 
 # runtime_user — validated only when --expected-runtime-user is set
 if (defined $opt_required_runtime_user) {
-    my $val = $status->{user};
+    my $val = $status->{runtime_user};
     if (!defined $val) {
-        push @errs, "user is missing from response";
+        push @errs, "runtime_user is missing from response";
     } elsif ($val ne $opt_required_runtime_user) {
         push @errs, sprintf("runtime user is '%s', must be '%s'", $val, $opt_required_runtime_user);
     }
 }
-# xdebug.start_with_request — must be off (0 / false)
-{
-    my $val = $status->{"xdebug.start_with_request"};
-    if (!defined $val) {
-        # Not having the key is fine — xdebug likely not loaded
-    } elsif ($val) {
-        push @errs, sprintf("xdebug.start_with_request is '%s', must be off", $val);
-    }
-}
+# xdebug_performance_impact — false if off/not loaded, else error string
+check_nominal('xdebug_performance_impact');
+# opcache_performance_impact — false if opcache on + JIT off, else error string
+check_nominal('opcache_performance_impact');
 
-# opcache_jit_impact — true if JIT disabled (good), else error string
-{
-    my $val = $status->{opcache_jit_impact};
-    if (!defined $val) {
-        push @errs, "opcache_jit_impact is missing from response";
-    } elsif (!is_good($val)) {
-        push @errs, JSON::PP::is_bool($val) ? "opcache_jit_impact is false" : $val;
-    }
-}
-
-# php_compatible_version — true if PHP > 8.1, else error string
-{
-    my $val = $status->{php_compatible_version};
-    if (!defined $val) {
-        push @errs, "php_compatible_version is missing from response";
-    } elsif (!is_good($val)) {
-        push @errs, JSON::PP::is_bool($val) ? "php_compatible_version is false" : $val;
-    }
-}
+# php_incompatible_version — false if PHP > 8.1, else error string
+check_nominal('php_incompatible_version');
 
 # php_extensions_installed — true if all required loaded, else error string
-{
-    my $val = $status->{php_extensions_installed};
-    if (!defined $val) {
-        push @errs, "php_extensions_installed is missing from response";
-    } elsif (!is_good($val)) {
-        push @errs, JSON::PP::is_bool($val) ? "php_extensions_installed is false" : $val;
-    }
+check_enabled('php_extensions_installed');
+
+# request_id_added — validated only when --require-request-id is set
+if ($opt_require_request_id) {
+    check_enabled('request_id_added');
 }
 
-# mod_unique_id_loaded — true if loaded, else error string
-{
-    my $val = $status->{mod_unique_id_loaded};
-    if (!defined $val) {
-        push @errs, "mod_unique_id_loaded is missing from response";
-    } elsif (!is_good($val)) {
-        push @errs, JSON::PP::is_bool($val) ? "mod_unique_id_loaded is false" : $val;
-    }
-}
+# session_gc_misconfigured — false if GC config fine, else error string
+check_nominal('session_gc_misconfigured');
 
-# session_gc_misconfigured — true if GC config is fine, else error string
-{
-    my $val = $status->{session_gc_misconfigured};
-    if (!defined $val) {
-        push @errs, "session_gc_misconfigured is missing from response";
-    } elsif (!is_good($val)) {
-        push @errs, JSON::PP::is_bool($val) ? "session_gc_misconfigured is false" : $val;
-    }
-}
+# logging_misconfigured — false if log_errors On, else error string
+check_nominal('logging_misconfigured');
 
 
 # jethroversion — conditionally checked when status.php has SHOW_JETHRO_VERSION=true
@@ -212,7 +213,7 @@ if ($opt_require_jethro_version) {
 }
 # ── output ──────────────────────────────────────────────────────────────────
 if (!@errs) {
-    printf "OK - all checks passed | max_input_vars=%d post_max_size=%d upload_max_filesize=%d\n",
+    printf "OK - all checks passed | max_input_vars=%d post_max_size=%s upload_max_filesize=%s\n",
         $status->{max_input_vars},
         $status->{post_max_size},
         $status->{upload_max_filesize};

--- a/status.php
+++ b/status.php
@@ -8,23 +8,24 @@
  * Example JSON output:
  *
  *     {
- *       "user": "jethro",
- *       "php_compatible_version": true,
+ *       "runtime_user": "jethro",
  *       "max_input_vars": 1000,
- *       "xdebug_loaded": false,
- *       "xdebug.mode": false,
- *       "xdebug.start_with_request": false,
- *       "xdebug_performance_impact": true,
- *       "opcache_jit_impact": true,
- *       "post_max_size": 8,
- *       "upload_max_filesize": 2,
+ *       "post_max_size": "8M",
+ *       "upload_max_filesize": "2M",
  *       "db_charset_results": "utf8mb4",
  *       "session_gc_maxlifetime": 5400,
  *       "session_gc_probability": 1,
- *       "session_gc_misconfigured": true,
+ *       "xdebug_loaded": false,
+ *       "xdebug.mode": false,
+ *       "xdebug.start_with_request": false,
+ *       "php_incompatible_version": false,
  *       "php_extensions_installed": true,
- *       "mod_unique_id_loaded": true,
- *       "log_errors": "0"
+ *       "request_id_added": true,
+ *       "xdebug_performance_impact": false,
+ *       "opcache_performance_impact": false,
+ *       "session_gc_misconfigured": false,
+ *       "logging_misconfigured": false,
+ *       "warnings": ["max_input_vars", "post_max_size", "upload_max_filesize"]
  *     }
  *
  * For the above JSON, check_http_jethrostatus would report:
@@ -38,17 +39,19 @@
  *
  *     Field                       | Expected  | Problem                                      | Explanation
  *     ----------------------------|-----------|----------------------------------------------|--------------------------------------------------------------------------
- *     `user`                      | "jethro"  | "root"                                       | Ensure PHP is running as the correct OS user (e.g. not root)
- *     `php_compatible_version`    | true      | "PHP 8.0.30 is not > 8.1"                    | Ensure the expected PHP version is used
+ *     `runtime_user`              | "jethro"  | "root"                                       | Ensure PHP is running as the correct OS user (e.g. not root)
+ *     `php_incompatible_version`  | false     | true                                         | Ensure the expected PHP version is used
  *     `php_extensions_installed`  | true      | "Missing extensions: exif, gd"               | Jethro requires `curl`, `gd`, `zip`, etc as documented in README.md
  *     `max_input_vars`            | 10000     | 1000                                         | Default 1000 is too few for large attendances (#6) or many custom fields (#152)
- *     `post_max_size`             | 20        | 8                                            | Default 8MB is too small; contact photos may exceed it (#949)
- *     `upload_max_filesize`       | 20        | 2                                            | Default 2MB is too small for common uploads
+ *     `post_max_size`             | "20M"     | "8M"                                         | Default 8MB is too small; contact photos may exceed it (#949)
+ *     `upload_max_filesize`       | "20M"     | "2M"                                         | Default 2MB is too small for common uploads
  *     `db_charset_results`        | `utf8mb4` | `utf8`, `latin1`                             | Old MySQL `utf8` isn't real UTF-8 — causes upgrade mess (#754, #1088)
- *     `opcache_jit_impact`        | true      | "opcache JIT is enabled"                     | JIT burns CPU on warmup; pointless for short-lived PHP processes — returns true when JIT is off (good)
- *     `session_gc_misconfigured`  | true      | "Session GC misconfigured: …"               | Debian/Ubuntu sessionclean trap: cron GC with low maxlifetime causes premature session expiry (#1088)
- *     `mod_unique_id_loaded`      | true      | "mod_unique_id Apache module not enabled"    | Apache unique request IDs for log correlation and request tracing
- *     `xdebug_performance_impact` | true      | "xdebug performance impact: mode=debug…"    | Xdebug overhead even when not debugging — returns true when safe, error string when impacting performance
+ *     `opcache_performance_impact` | false     | "opcache JIT is enabled" / "opcache is not enabled" | JIT burns CPU on warmup; pointless for one-shot pages — false when opcache on + JIT off
+ *     `session_gc_misconfigured`  | false     | "Session GC misconfigured: …"               | Debian/Ubuntu sessionclean trap: cron GC with low maxlifetime causes premature session expiry (#1088)
+ *     `logging_misconfigured`     | false     | "log_errors=0"                               | log_errors must be On
+ *     `request_id_added`          | true      | false                                        | Enable Apache `mod_unique_id` (or set `X-Request-Id` upstream) for log correlation
+ *     `xdebug_performance_impact` | false     | "xdebug performance impact: mode=debug…"    | Xdebug overhead even when not debugging — false when safe, error string when impacting performance
+ *     `warnings`                  | []        | ["max_input_vars", "post_max_size"]         | Array of fields currently in a warning state; empty when all nominal
  *
  * @see scripts/check_http_jethrostatus
  */
@@ -61,39 +64,82 @@ define('SHOW_JETHRO_VERSION', false);
 // I have considered setting a custom error handler with set_error_handler() and returning HTTP 500 with a json response, but the caller should
 // be treating any failure to return JSON as critical anyway.
 $result = [];
+
+// ── Raw observations ──
 if (SHOW_JETHRO_VERSION) $result['jethroversion'] = JETHRO_VERSION;
-$result['user'] = $_SERVER['USER'];
-$result['php_compatible_version'] = version_compare(PHP_VERSION, '8.1', '>') ? true : "PHP " . PHP_VERSION . " is not > 8.1";
+$result['runtime_user'] = $_SERVER['USER'];
 $result['max_input_vars'] = (int)ini_get('max_input_vars');
+$result['post_max_size'] = ini_get('post_max_size');
+$result['upload_max_filesize'] = ini_get('upload_max_filesize');
+$result['db_charset_results'] =  $GLOBALS['db']->queryOne('select @@character_set_results');
+$result['session_gc_maxlifetime'] = (int)ini_get('session.gc_maxlifetime');
+$result['session_gc_probability'] = (int)ini_get('session.gc_probability');
+
 // Xdebug runtime status — these settings affect production performance
 $result['xdebug_loaded'] = extension_loaded('xdebug');
 $result['xdebug.mode'] = ini_get('xdebug.mode');                    // e.g. 'off', 'develop', 'debug', 'trace', 'profile'
 $result['xdebug.start_with_request'] = ini_get('xdebug.start_with_request'); // e.g. 'default', 'yes', 'no', 'trigger'
-// Derived: xdebug is "hot" (may slow things down) if loaded *and* mode is not off/empty *and* start_with_request isn't 'no'
-$result['xdebug_performance_impact'] = (extension_loaded('xdebug')
-    && ini_get('xdebug.mode') !== 'off'
-    && ini_get('xdebug.mode') !== ''
-    && ini_get('xdebug.start_with_request') !== 'no')
-    ? "xdebug performance impact: mode=" . ini_get('xdebug.mode') . ", start_with_request=" . ini_get('xdebug.start_with_request')
-    : true;
-$result['opcache_jit_impact'] = opcache_get_status()['jit']['enabled'] ? "opcache JIT is enabled" : true;
-$result['post_max_size'] = (int)ini_get('post_max_size');
-$result['upload_max_filesize'] = (int)ini_get('upload_max_filesize');
-$result['db_charset_results'] =  $GLOBALS['db']->queryOne('select @@character_set_results');
-// Session GC config — check for Debian/Ubuntu sessionclean misconfiguration
-// Ref: https://github.com/tbar0970/jethro-pmm/issues/1088#issuecomment-2436805398
-$result['session_gc_maxlifetime'] = (int)ini_get('session.gc_maxlifetime');
-$result['session_gc_probability'] = (int)ini_get('session.gc_probability');
-$result['session_gc_misconfigured'] = ((int)ini_get('session.gc_probability') === 0)
-    && ((int)ini_get('session.gc_maxlifetime') < (defined('SESSION_TIMEOUT_MINS') ? SESSION_TIMEOUT_MINS * 60 : PHP_INT_MAX))
-    ? "Session GC misconfigured: gc_probability=0, gc_maxlifetime=" . ini_get('session.gc_maxlifetime') . "s < SESSION_TIMEOUT_MINS*60"
-    : true;
+
+// ── Derived verdicts ──
+// Return a bool. Reporting the actual PHP version would be an info-disclosure risk.
+$result['php_incompatible_version'] = !version_compare(PHP_VERSION, '8.1', '>');
+
 # Required PHP extensions per README.md
 $required_extensions = ['gettext', 'zip', 'xmlwriter', 'gd', 'curl', 'exif'];
 $missing = array_values(array_filter($required_extensions, fn($ext) => !extension_loaded($ext)));
 $result['php_extensions_installed'] = empty($missing) ? true : "Missing extensions: " . join(', ', $missing);
-$result['mod_unique_id_loaded'] = array_key_exists('HTTP_X_REQUEST_ID', $_SERVER) ? true : "mod_unique_id Apache module not enabled";
-$result['log_errors'] = ini_get('log_errors');
+
+$result['request_id_added'] = array_key_exists('HTTP_X_REQUEST_ID', $_SERVER);
+
+// Derived: Xdebug only adds per-request overhead when actually engaged.
+//   - 'develop' mode is always-on whenever listed (small overhead).
+//   - 'debug'/'trace'/'profile' start every request only when start_with_request='yes'.
+//     'no' never starts; 'trigger'/'default' arm on a cookie/param and cost nothing until
+//     that trigger arrives — so they're treated as inactive here. (Attacker-triggerable
+//     debug is a separate concern; production shouldn't load xdebug at all.)
+$result['xdebug_performance_impact'] = (extension_loaded('xdebug')
+    && ini_get('xdebug.mode') !== 'off'
+    && ini_get('xdebug.mode') !== ''
+    && (str_contains(ini_get('xdebug.mode'), 'develop')
+        || ini_get('xdebug.start_with_request') === 'yes'))
+    ? "xdebug performance impact: mode=" . ini_get('xdebug.mode') . ", start_with_request=" . ini_get('xdebug.start_with_request')
+    : false;
+
+$opcachestatus = opcache_get_status();
+$result['opcache_performance_impact'] = ($opcachestatus === false)
+    ? "opcache is not enabled"
+    : (($opcachestatus['jit']['enabled'] ?? false) ? "opcache JIT is enabled" : false);
+
+// Session GC config — check for Debian/Ubuntu sessionclean misconfiguration
+// Ref: https://github.com/tbar0970/jethro-pmm/issues/1088#issuecomment-2436805398
+$result['session_gc_misconfigured'] = ((int)ini_get('session.gc_probability') === 0)
+    && ((int)ini_get('session.gc_maxlifetime') < (defined('SESSION_TIMEOUT_MINS') ? SESSION_TIMEOUT_MINS * 60 : PHP_INT_MAX))
+    ? "Session GC misconfigured: gc_probability=0, gc_maxlifetime=" . ini_get('session.gc_maxlifetime') . "s < SESSION_TIMEOUT_MINS*60"
+    : false;
+
+$result['logging_misconfigured'] = filter_var(ini_get('log_errors'), FILTER_VALIDATE_BOOLEAN)
+    ? false
+    : "log_errors=" . (ini_get('log_errors') === '' ? 'Off' : ini_get('log_errors'));
+
+// ── Aggregate warnings ──
+// Raw-observation thresholds are hard-coded here to match scripts/check_http_jethrostatus
+// defaults; the check plugin duplicates them so operators can override via CLI flags.
+// If you change one, change both.
+$warnings = [];
+// Raw threshold breaches (same order as the field emission above).
+if ($result['max_input_vars'] < 10000)               $warnings[] = 'max_input_vars';
+if ((int)$result['post_max_size'] < 20)              $warnings[] = 'post_max_size';
+if ((int)$result['upload_max_filesize'] < 20)        $warnings[] = 'upload_max_filesize';
+if ($result['db_charset_results'] !== 'utf8mb4')     $warnings[] = 'db_charset_results';
+// Derived verdicts.
+if ($result['php_incompatible_version'] !== false)   $warnings[] = 'php_incompatible_version';
+if ($result['php_extensions_installed'] !== true)    $warnings[] = 'php_extensions_installed';
+if ($result['request_id_added'] !== true)            $warnings[] = 'request_id_added';
+if ($result['xdebug_performance_impact'] !== false)  $warnings[] = 'xdebug_performance_impact';
+if ($result['opcache_performance_impact'] !== false) $warnings[] = 'opcache_performance_impact';
+if ($result['session_gc_misconfigured'] !== false)   $warnings[] = 'session_gc_misconfigured';
+if ($result['logging_misconfigured'] !== false)      $warnings[] = 'logging_misconfigured';
+$result['warnings'] = $warnings;
 header('Content-Type: application/json');
 print(json_encode($result, JSON_PRETTY_PRINT));
 session_destroy(); // Don't accumulate sessions unnecessarily


### PR DESCRIPTION
A follow-up to https://github.com/tbar0970/jethro-pmm/pull/1497 with many status.php fixes and improvements:

- Add a `warnings` array field that, if blank, indicates everything is fine, and if not, references other fields that show 'bad' values.
- Don't report the actual PHP version as it is an info-disclosure risk
- `post_max_size` and `upload_max_filesize` no longer incorrectly interpret '20M' as '20'. `scripts/check_http_jethrostatus` now correctly parses what PHP delivers.
- Rename `mod_unique_id_loaded` to `request_id_added` to avoid the Apache-ism
- Improve the `xdebug_performance_impact` rules
- `opcache_jit_impact` generalized to `opcache_performance_impact` which now also flags opcache being disabled as bad (for Jethro, opcache is good, jit is bad).
- Replace `log_errors` (unclear - does it mean "errors are logged" or "there are errors in the log?) with `logging_misconfigured`.
- `user` renamed to `runtime_user` to distinguish it from Jethro user

Also updated the monitoring script `scripts/check_http_jethrostatus` to parse the new output, and added a reference doc to interpret `status.php` output.

Old output:

```json
{
    "user": "jethro",
    "php_compatible_version": true,
    "max_input_vars": 10000,
    "xdebug_loaded": false,
    "xdebug.mode": false,
    "xdebug.start_with_request": false,
    "xdebug_performance_impact": true,
    "opcache_jit_impact": true,
    "post_max_size": 20,
    "upload_max_filesize": 20,
    "db_charset_results": "utf8mb3",
    "session_gc_maxlifetime": 1440,
    "session_gc_probability": 1,
    "session_gc_misconfigured": true,
    "php_extensions_installed": true,
    "mod_unique_id_loaded": true,
    "log_errors": "1"
}
```

New output:

```json
{
    "runtime_user": "jethro",
    "max_input_vars": 10000,
    "post_max_size": "20M",
    "upload_max_filesize": "20M",
    "db_charset_results": "utf8mb3",
    "session_gc_maxlifetime": 1440,
    "session_gc_probability": 1,
    "xdebug_loaded": false,
    "xdebug.mode": false,
    "xdebug.start_with_request": false,
    "php_incompatible_version": false,
    "php_extensions_installed": true,
    "request_id_added": true,
    "xdebug_performance_impact": false,
    "opcache_performance_impact": false,
    "session_gc_misconfigured": false,
    "logging_misconfigured": false,
    "warnings": [
        "db_charset_results"
    ]
}