### PR TITLE
Stop the load-time autofocus timer stealing focus. #1525

### DIFF
--- a/resources/js/tb_lib.js
+++ b/resources/js/tb_lib.js
@@ -15,10 +15,14 @@ $(document).ready(function() {
 	if (!('autofocus' in i) || $('[autofocus]').length == 0) {
 		// native autofocus is not supported, or no element is using it
 		if ($('.initial-focus, .autofocus, [autofocus]').length) {
-			setTimeout("$('.initial-focus, .autofocus, [autofocus]').get(0).focus()", 200);
+			setTimeout(function() {
+				TBLib.applyInitialFocus($('.initial-focus, .autofocus, [autofocus]'));
+			}, 200);
 		} else if (document.location.hash.length == 0) {
 			// Focus the first visible input
-			setTimeout("try { $('body input[type!=checkbox]:visible, select:visible').not('.btn-link, [type=checkbox], [type=radio], [type=submit]').not('.no-autofocus *, .no-autofocus').get(0).focus(); } catch (e) {}", 200);
+			setTimeout(function() {
+				TBLib.applyInitialFocus($('body input[type!=checkbox]:visible, select:visible').not('.btn-link, [type=checkbox], [type=radio], [type=submit]').not('.no-autofocus *, .no-autofocus'));
+			}, 200);
 		}
 	}
 	$('input[autoselect]').each(function() {
@@ -430,6 +434,44 @@ $(document).ready(function() {
 
 	highlightControlGroupFromUrlParams();
 });
+
+/**
+ * Focus the first element of jqElts, unless focus has already moved elsewhere.
+ *
+ * Called from a 200ms timer in $(document).ready (above).  That delay is long
+ * enough for a fast typist -- or a browser-automation script -- to have focused
+ * a field of their own first, and yanking focus back then sends the rest of
+ * their keystrokes into the wrong input.  So we only place the initial focus
+ * while nothing else holds it.
+ *
+ * Reproducing the bug this guards against (it hit the Playwright setup-wizard
+ * test, tests/functional/walkthrough/walkthrough.spec.ts):
+ *
+ *   1. Open a page whose first visible input is not the one you want to type
+ *      into -- e.g. the installer on an empty database: System Name is the
+ *      first field, the Congregations table the last.
+ *   2. Less than 200ms after DOMContentLoaded, focus one of the later fields
+ *      and type into it.  Playwright's fill() hits the window reliably: it
+ *      focuses + selects the target in one round trip, then delivers the text
+ *      as keystrokes (CDP Input.insertText) in the next one.
+ *   3. Unguarded, the timer fires between those two round trips and focuses
+ *      System Name, so the text lands there instead: "St DemosVille" + "6pm"
+ *      = "St DemosVille6pm", while the congregation row stays empty.  The
+ *      Congregations table then stops growing too, because rows are appended
+ *      on focus (TBLib.handleTableExpansion) only when the row above is
+ *      non-empty.
+ *
+ * While nothing is focused the browser reports document.activeElement as
+ * <body> (or <html>, or null in a detached document), so that is what we treat
+ * as "the initial focus is still ours to place".
+ */
+TBLib.applyInitialFocus = function(jqElts)
+{
+	var active = document.activeElement;
+	if (active && (active !== document.body) && (active !== document.documentElement)) return;
+	var elt = jqElts.get(0);
+	if (elt) elt.focus();
+}
 
 /**
  * Highlight a particular edit-mode form element ('.control-group'), with a text callout saying what needs to happen. 'hl' URL param identifies the form element, and 'hltext' supplies the help text.


### PR DESCRIPTION
tb_lib.js focuses the first visible input 200ms after DOMContentLoaded, on pages where no element carries a native autofocus attribute.  The timer fired blind, so it also yanked focus away from a field the user (or page JS) had already focused during those 200ms, and keystrokes still in flight landed in the wrong input.

TBLib.applyInitialFocus() now places the initial focus only while nothing else holds it (document.activeElement still <body>/<html>).  Deliberate focus set by page JS during ready -- jethro.js's data-toggle=enable handler, and highlightControlGroup() for ?hl= deep links -- now survives as well, where previously it was overridden 200ms later.

To replicate the problem, revert this commit and then:

  1. Open the installer against an empty database.  System Name is the first visible input; the Congregations table is last.
  2. Within 200ms of DOMContentLoaded -- before the timer fires -- focus a congregation row and type into it.  By hand: load the page and immediately type into the bottom field.  Reliably: use Playwright's fill(), which focuses + selects the target in one CDP round trip and then delivers the text with Input.insertText in the next.
  3. The timer fires between those two round trips, focus jumps to System Name, and the text is appended there instead: System Name reads "St DemosVille6pm" while the congregation row stays empty.  The Congregations table also stops expanding, because rows are appended on focus (TBLib.handleTableExpansion) only when the row above is non-empty.

That is how it surfaced: an intermittent failure of the setup-wizard functional test (tests/functional/walkthrough/walkthrough.spec.ts:42), which fills 8 fields before the congregation rows.  Whichever fill was in flight at DOMContentLoaded+200ms lost its text, so the failure moved around with machine load.

Fixes #1525