### PR TITLE
Fix members portal errors from staff/public-only guards. #1486

### DIFF
--- a/public/views/view_0_roster_role_description.class.php
+++ b/public/views/view_0_roster_role_description.class.php
@@ -21,7 +21,9 @@ class View__Roster_Role_Description extends View
 
 	function printView()
 	{
-		if (defined('PUBLIC_ROSTER_SECRET')
+		// This view is used by /members and /public, and only /public supports 'private' URLs. #1486
+		if ((defined('DB_MODE') && (DB_MODE == 'PUBLIC'))
+					&& defined('PUBLIC_ROSTER_SECRET')
 					&& strlen(PUBLIC_ROSTER_SECRET)
 					&& (array_get($_REQUEST, 'secret') != PUBLIC_ROSTER_SECRET)) {
 			print_message("Please contact your church admin to get the private URL for rosters", "error");


### PR DESCRIPTION
Roster role descriptions may be made semi-public, accessible via /public/?view=_roster_role_description&secret=... with the correct `?secret=...` URL param, by defining the `PUBLIC_ROSTER_SECRET` setting.

However Roster roles are also visible to members, via Rosters -> 'View Roster Role Descriptions'. In this scenario the user is already authenticated, and no secret should be necessary.

Jethro uses the same code snippet for /members and /public codepaths, and was incorrectly requiring a secret for the /members view. Fixed with an extra condition in the code.

Fixes #1486