### PR TITLE
status.php: fix opcache.jit detection

### DIFF
--- a/status.php
+++ b/status.php
@@ -108,7 +108,7 @@ $result['xdebug_performance_impact'] = (extension_loaded('xdebug')
 $opcachestatus = opcache_get_status();
 $result['opcache_performance_impact'] = ($opcachestatus === false)
     ? "opcache is not enabled"
-    : (($opcachestatus['jit']['enabled'] ?? false) ? "opcache JIT is enabled" : false);
+    : (($opcachestatus['jit']['on'] ?? false) ? "opcache JIT is enabled" : false);
 
 // Session GC config — check for Debian/Ubuntu sessionclean misconfiguration
 // Ref: https://github.com/tbar0970/jethro-pmm/issues/1088#issuecomment-2436805398


### PR DESCRIPTION
status.php incorrectly reports `"opcache_performance_impact": "opcache JIT is enabled"` if PHP reports `opcache.jit` as having "no value" (per status.php), which I'm pretty sure means 'off'. This code change seems to handle this variant.

Relates to #1523