### PR TITLE
Settings page should not show SMS credentials. #1536

### DIFF
--- a/include/config_manager.class.php
+++ b/include/config_manager.class.php
@@ -53,6 +53,7 @@ class Config_Manager {
 			|| str_contains($upper, 'API_KEY')
 			|| str_contains($upper, 'PASSWORD')
 			|| str_contains($upper, 'SECRET')
+			|| str_contains($upper, 'SMS_HTTP_HEADER_TEMPLATE')
 			|| str_contains($upper, 'TOKEN');
 	}
 


### PR DESCRIPTION
The `SMS_HTTP_HEADER_TEMPLATE` setting is set in `conf.php` to configure 5centsms.com.au:

```php
define_if('SMS_HTTP_HEADER_TEMPLATE', "User: david@mychurch.org\r\nApi-Key: xxxxxxxxxxxxxxxxxxxxxxxxx\r\n");
```

Its value is sensitive and should not be shown to Jethro administrators in the System Configuration page. However due change 90cd409d9ffa49052bc5768ec8af3fa27a9bf496, it is now inadvertently exposed.

This change adds `SMS_HTTP_HEADER_TEMPLATE` to the list of security-sensitive settings, so it is hidden.

Fixes #1536