### PR TITLE
Fix too-wide Add Note on Family page (#1538)

### DIFF
--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -850,11 +850,11 @@ table.custom-field-tooltip {
 select, input, textarea,div.editor {
 	/* apply shrink-to-fit sizing rather than bootstrap's default 206px */
 	width: auto;
+	/* Constrain width to the containing box */
+	max-width: 100%;
 }
 
-.modal input, .modal select, .modal textarea, .modal .uneditable-input {
-	/* In modals the shink-to-fit size from the rule above is too wide. Constrain it to the containing box */
-	max-width: 100%;
+div.editor {
 	/* 'box-sizing: border-box' means max-width includes padding and
 	 * border. Without this, the padding + border makes the actual width exceed
 	 * 100% resulting in a scrollbar. Previously we had 'max-width: 97%' to avoid


### PR DESCRIPTION
Commit 5e3a0481 (PR #1414) removed `max-width: 97%` from all select, input, textarea and `.editor` divs.

It turns out, that `max-width` was keeping the width constrained in modals (#1521), on the 'Add note' action on the Family page (#1538) and probably elsewhere.

This change restores `max-width` to where it was originally, except makes it 100% instead of 97%, and adds `box-sizing: border-box;` to make that 100% include border/margin widths.

Fixes #1538, #1521

A screencast showing the fix applied, switching to mobile halfway:

https://github.com/user-attachments/assets/fda11625-2a3d-4d75-8ef7-333923ef7561

A separate issue shown in this video: on mobile the Note field remains wider than the viewport when the viewport is very narrow, because of the `cols="50"` attribute.