### PR TITLE
Fix broken Actions dropdown on narrow screens in report list (#1539)

### DIFF
--- a/resources/less/jethro.less.php
+++ b/resources/less/jethro.less.php
@@ -1505,6 +1505,27 @@ img.person-photo {
 		display: block;
 		margin-top: 3px;
 	}
+	/* The dropdown-menu and its links must keep readable labels - only the toggle collapses to an icon.
+	   (BS2 dropdowns stay full-size overlays at any width; the selectors above match menu links too,
+	   since they are descendants of td.action-cell.) */
+	#body td.action-cell .dropdown-menu {
+		right: 0; /* open leftward so the menu stays in the viewport */
+		left: auto;
+	}
+	#body td.action-cell .dropdown-menu a {
+		display: block;
+		width: auto;
+		height: auto !important;
+		font-size: @baseFontSize;
+		text-indent: 0;
+		overflow: visible;
+		padding: 3px 20px;
+		white-space: nowrap;
+	}
+	#body td.action-cell .dropdown-menu a i {
+		display: inline-block;
+		margin-top: 0;
+	}
 }
 
 /* widgets at the top of "list all" pages */

--- a/views/view_3_persons__3_reports.class.php
+++ b/views/view_3_persons__3_reports.class.php
@@ -202,7 +202,7 @@ class View_Persons__Reports extends View
 								<a href="?view=<?php echo ents($_REQUEST['view']); ?>&queryid=<?php echo $id; ?>"><i class="icon-list"></i><?php echo _('View');?></a> &nbsp;
 								<a href="?view=<?php echo ents($_REQUEST['view']); ?>&queryid=<?php echo $id; ?>&configure=1"><i class="icon-wrench"></i><?php echo _('Configure');?></a> &nbsp;
 								<span class="dropdown nowrap">
-									<a class="dropdown-toggle" data-toggle="dropdown" href="#"><?php echo _('Actions'); ?><i class="caret"></i></a>
+									<a class="dropdown-toggle" data-toggle="dropdown" href="#"><i class="icon-chevron-down"></i><?php echo _('Actions'); ?></a>
 									<ul class="dropdown-menu" role="menu" style="z-index:9999">
 										<li>
 											<?php


### PR DESCRIPTION
On screens <=640px wide with a desktop-sized session, the persons-reports actions dropdown was unusable: its label-first toggle collapsed to a blank 20x20 box (the caret fell below the overflow-hidden area), the menu items were collapsed to unreadable 20x20 icon boxes by the td.action-cell collapse rules (which match all descendant anchors), and the menu overflowed the right viewport edge.

Make the toggle icon-first with icon-chevron-down (matching the roster-view idiom), exempt .dropdown-menu links from the icon-collapse (restoring Bootstrap 2's block/14px/padded menu items), and right-align action-cell dropdown menus at narrow widths so they open leftward and stay on screen.

Fixes #1539

The original bug:

https://github.com/user-attachments/assets/c3cf697d-f360-4dd1-a6f3-5624e3d3d397

Fixed version (note: the screen recorder is showing a varying width viewport in a constant-width screencast so it appears to zoom):

https://github.com/user-attachments/assets/a483c1c3-7cb8-475e-953d-2e7b1617d595

