### PR TITLE
Right-align service schedule date-row dropdown menus (#1542)

### DIFF
--- a/views/view_8_services__1_list_all.class.php
+++ b/views/view_8_services__1_list_all.class.php
@@ -399,7 +399,7 @@ class View_Services__List_All extends View
 						<td>
 							<span class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#"><i class="icon-chevron-down"></i></a>
-							<ul class="dropdown-menu" role="menu">
+							<ul class="dropdown-menu pull-right" role="menu">
 								<li>
 								<?php
 								$printed = FALSE;


### PR DESCRIPTION
The per-date "generate service documents" dropdown in services__list_all sits in the right-most column of the table, and its menu opened with left:0 from the toggle - running off the right edge of narrow viewports. Add pull-right (Bootstrap 2's right-aligned dropdown-menu modifier, as already used by the service-plan tools dropdown) so the menu opens leftward and stays on screen at any width.

Before the fix:

<img width="851" height="657" alt="image" src="https://github.com/user-attachments/assets/832d8a97-71d5-4bbc-b14f-eb2c9efd1041" />

With fix applied:

<img width="851" height="657" alt="image" src="https://github.com/user-attachments/assets/0f89986a-9fe2-47a4-9c99-78621f85d93f" />

Fixes #1542