### PR TITLE
Handle requests arriving without Referer/User-Agent headers (#1544)

### DIFF
--- a/db_objects/person.class.php
+++ b/db_objects/person.class.php
@@ -295,7 +295,7 @@ class Person extends DB_Object
 						$printedModal = TRUE;
 					}
 				}
-				if (FALSE !== strpos($_SERVER['HTTP_USER_AGENT'], 'Macintosh')) {
+				if (FALSE !== strpos(array_get($_SERVER, 'HTTP_USER_AGENT', ''), 'Macintosh')) {
 					// on mac we can use the messages app
 					$msg = _('SMS via iMessage');
 					$links[] = '<a href="imessage:'.ents($value).'"><i class="icon-envelope"></i> '.$msg.'</a>';

--- a/include/general.php
+++ b/include/general.php
@@ -160,7 +160,11 @@ function redirect($view, $params=Array(), $hash='')
 	session_write_close();
 	if ($view == -1) {
 		// go back
-		$url = $_SERVER['HTTP_REFERER'];
+		$url = array_get($_SERVER, 'HTTP_REFERER');
+		if (!$url) {
+			// No referer to go back to (direct entry, privacy stripping etc) - go home instead
+			$url = build_url(Array('view' => 'home'));
+		}
 	} else {
 		$params['view'] = $view;
 		$url = build_url($params);
@@ -309,7 +313,7 @@ function print_widget($name, $params, $value)
 			} else {
 				$width_exp = 'size="5" ';
 			}
-			$intType = (FALSE !== strpos($_SERVER['HTTP_USER_AGENT'], 'iPhone')) ? 'tel' : 'number';
+			$intType = (FALSE !== strpos(array_get($_SERVER, 'HTTP_USER_AGENT', ''), 'iPhone')) ? 'tel' : 'number';
 			?>
 			<input pattern="[0-9]*" inputmode="numeric" type="<?php echo $intType; ?>" name="<?php echo $name; ?>" value="<?php echo $value; ?>" class="<?php echo trim($classes); ?>" <?php echo $width_exp; ?> <?php echo $attrs; ?> />
 			<?php
@@ -944,8 +948,8 @@ function get_email_href($to, $name=NULL, $bcc=NULL, $subject=NULL)
 	if (function_exists('custom_email_href')) return custom_email_href($to, $name, $bcc, $subject);
 
 	// Chrome on mac with mac:mail as the mailto handler cannot cope with fullname in the address
-	$is_chrome_mac = (FALSE !== strpos(strtolower($_SERVER['HTTP_USER_AGENT']), 'chrome/'))
-						&& (FALSE !== strpos(strtolower($_SERVER['HTTP_USER_AGENT']), 'macintosh'));
+	$ua = strtolower(array_get($_SERVER, 'HTTP_USER_AGENT', ''));
+	$is_chrome_mac = (FALSE !== strpos($ua, 'chrome/')) && (FALSE !== strpos($ua, 'macintosh'));
 
 	$res = ents($to);
 	$extras = Array();

--- a/include/size_detector.class.php
+++ b/include/size_detector.class.php
@@ -16,7 +16,7 @@ class SizeDetector {
 		});
 		</script>
 		<?php
-		if (!empty($_REQUEST['showsize'])) bam($_SERVER['HTTP_USER_AGENT']);
+		if (!empty($_REQUEST['showsize'])) bam(array_get($_SERVER, 'HTTP_USER_AGENT', ''));
 	}
 
 	static function processRequest() {

--- a/views/view_7_rosters__2_edit_roster_assignments.class.php
+++ b/views/view_7_rosters__2_edit_roster_assignments.class.php
@@ -19,7 +19,7 @@ class View_Rosters__Edit_Roster_Assignments extends View_Rosters__Display_Roster
 		}
 		if (!empty($_REQUEST['goback']) && empty($_SESSION['roster_backto'])) {
 			// Save where we came from in order to go back there afterwards
-			$_SESSION['roster_backto'] = ($_SERVER['HTTP_REFERER']);
+			$_SESSION['roster_backto'] = array_get($_SERVER, 'HTTP_REFERER');
 		}
 
 		parent::processView();


### PR DESCRIPTION
Handle requests arriving without Referer/User-Agent headers (#1544)

In a few places Jethro assumed a valid Referer or User-Agent header. This was a
bad assumption: browsers are free to omit the Referer and User-Agent headers
(direct URL entry, bookmarks, tab restore, privacy stripping, HTTPS->HTTP
downgrade), and PHP 8 turns the resulting "Undefined array key" warnings into
system error reports. redirect(-1) was worse: it sent a "Location: " header with
an empty URL. 

This commit fixes all places we assumed a header. We now use array_get() and
provide sensible fallbacks that preserve existing behaviour when the headers are
present:

- view_7_rosters__2_edit_roster_assignments: leave roster_backto unset, so
  saving falls back to the normal roster display redirect (#1544)
- redirect(-1): fall back to the home view, matching system_controller's
  array_get($_REQUEST, 'view', 'home') default
- print_widget() int fields: no UA means type="number" (not "tel")
- get_email_href(): no UA means the Chrome-on-mac mailto tweak is skipped
- person mobile_tel: no UA omits the iMessage link; size_detector
  debug output shows an empty UA

Fixes #1544