### PR TITLE
Escape reflected QUERY_STRING in edit lock-conflict links

### DIFF
--- a/views/abstract_view_edit_object.class.php
+++ b/views/abstract_view_edit_object.class.php
@@ -90,7 +90,7 @@ class Abstract_View_Edit_Object extends View
 				} else {
 					// could not re-acquire lock
 					?>
-					<div class="failure"><?php echo _('Your changes could not be saved because your lock has expired.  The lock has now been acquired by another user.  Wait some time for them to finish and then');?> <a href="<?php echo $_SERVER['QUERY_STRING']; ?>">_(try again)</a></div>
+					<div class="failure"><?php echo _('Your changes could not be saved because your lock has expired.  The lock has now been acquired by another user.  Wait some time for them to finish and then');?> <a href="?<?php echo $_SERVER['QUERY_STRING']; ?>">try again</a></div>
 					<?php
 					$show_form = false;
 				}

--- a/views/abstract_view_edit_object.class.php
+++ b/views/abstract_view_edit_object.class.php
@@ -90,7 +90,7 @@ class Abstract_View_Edit_Object extends View
 				} else {
 					// could not re-acquire lock
 					?>
-					<div class="failure"><?php echo _('Your changes could not be saved because your lock has expired.  The lock has now been acquired by another user.  Wait some time for them to finish and then');?> <a href="?<?php echo $_SERVER['QUERY_STRING']; ?>">try again</a></div>
+					<div class="failure"><?php echo _('Your changes could not be saved because your lock has expired.  The lock has now been acquired by another user.  Wait some time for them to finish and then');?> <a href="?<?php echo ents($_SERVER['QUERY_STRING']); ?>">try again</a></div>
 					<?php
 					$show_form = false;
 				}
@@ -102,7 +102,7 @@ class Abstract_View_Edit_Object extends View
 			// hasn't been submitted yet
 			if (!$this->_edited_object->acquireLock()) {
 				?>
-				<div class="failure">This <?php echo $this->getEditingTypeFriendly(); ?> cannot currently be edited because another user has the lock.  Wait some time for them to finish and then <a href="?<?php echo $_SERVER['QUERY_STRING']; ?>">try again</a></div>
+				<div class="failure">This <?php echo $this->getEditingTypeFriendly(); ?> cannot currently be edited because another user has the lock.  Wait some time for them to finish and then <a href="?<?php echo ents($_SERVER['QUERY_STRING']); ?>">try again</a></div>
 				<?php
 				$show_form = false;
 			}


### PR DESCRIPTION
This is a reflected XSS, fortunately not exploitable in modern browsers.

When another user holds the edit lock, the "try again" links echoed the
raw query string into the page. A query string containing a double quote
could therefore inject HTML there. Exploitation needs a raw HTTP request
- modern browsers percent-encode quotes in query strings, so a victim
clicking a crafted link is safe. Still never reflect user input raw:
both echoes now go through ents().
