### PR TITLE
Fix unexpanded roster role link on the personnel format help page (#1547)

### DIFF
--- a/calls/call_service_comp_help_personnel_format.class.php
+++ b/calls/call_service_comp_help_personnel_format.class.php
@@ -80,7 +80,7 @@ class call_service_comp_help_personnel_format extends Call
                             <code>%<?php echo $titleinfo['title_uppercase']; ?>_n_FIRSTNAME%</code><br>
                         </td>
                         <td>
-                            <a href="?view=rosters__define_roster_roles&roster_roleid=${titleinfo['id']}"><?php echo $titleinfo['title']; ?></a>
+                            <a href="?view=rosters__define_roster_roles&roster_roleid=<?php echo (int)$titleinfo['id']; ?>"><?php echo $titleinfo['title']; ?></a>
                             service personnel value
                         </td>
                     </tr>

--- a/db_objects/roster_role.class.php
+++ b/db_objects/roster_role.class.php
@@ -112,7 +112,7 @@ class Roster_Role extends db_object
 				echo implode(', ', array_map(function ($val) {
 					$group = new Person_group($val);
 					return '<a href="?view=groups&groupid='.(int)$val.'">'.ents($group->getValue('name')).'</a>';
-				}, $this->getValue($name)));
+				}, $this->getValue($name) ?? []));
 				break;
 			case 'volunteer_group':
 				if ($val = $this->getValue($name)) {


### PR DESCRIPTION
The "service personnel value" link on the Personnel Format help page
emitted a raw-HTML href containing ${titleinfo['id']}, which PHP never
interpolates because the link sits in template HTML rather than a PHP
string. Clicking it navigated to rosters__define_roster_roles with the
literal ${titleinfo['id']} text as roster_roleid; the (int) cast turned
that into 0, constructing an unloaded Roster_Role whose summary
rendering passed null to array_map(), causing a TypeError.

Fixes #1547

<img width="815" height="218" alt="image" src="https://github.com/user-attachments/assets/f3eb2fbc-2774-4c35-b8a6-22aa9dbc94f3" />
