### PR TITLE
Gracefully render person report forms that reference deleted groups (#1550)

### DIFF
--- a/db_objects/person_group.class.php
+++ b/db_objects/person_group.class.php
@@ -491,7 +491,8 @@ class Person_Group extends db_object
 				$allData['c'.$k] = $v;
 			}
 			foreach ($chosen as $val => $x) {
-				$chosen[$val] = $allData[$val];
+				$deletedLabel = (is_string($val) && ($val[0] == 'c')) ? '(deleted category)' : '(deleted group)';
+				$chosen[$val] = array_get($allData, $val, Array('name' => $deletedLabel));
 			}
 		}
 

--- a/db_objects/person_query.class.php
+++ b/db_objects/person_query.class.php
@@ -157,6 +157,12 @@ class Person_Query extends DB_Object
 		$GLOBALS['system']->includeDBClass('person_group');
 		$params = $this->_convertParams($this->getValue('params'));
 		if ($params === null) $params = Array();
+		if (!empty($params)) {
+			// Drop references to entities deleted since the report was saved (groups,
+			// custom fields etc.) so the form only renders entities that still exist.
+			// The configure view separately warns the user about what was dropped.
+			list($params,) = $this->validateQueryParams($params);
+		}
 		$rules = array_get($params, 'rules', Array());
 		if (!$GLOBALS['user_system']->havePerm(PERM_MANAGEREPORTS) && ($this->getValue('owner') == NULL)) {
 			// we are editing a shared report, but don't have permission to save a shared report


### PR DESCRIPTION
A saved person report referencing a deleted group or group category (e.g. exclude_groups pointing at a group removed since the report was saved) made the report configure page throw "Undefined array key" and render a SYSTEM ERROR alert, because Person_Group::printMultiChooser() read $allData[$val] without a fallback and Person_Query::printForm() rendered the raw saved params rather than the validated set. Issue #1413's fix (qquwopln) validated params only on the results path (getSQL) and warned via a banner; the form render still used stale references.

- Person_Query::printForm() now runs validateQueryParams() on converted params (guarded for new/empty queries) so the form renders only entities that still exist; the configure view's warning banner is unchanged.
- Person_Group::printMultiChooser() now falls back to a "(deleted group)" / "(deleted category)" option label via array_get() instead of an unguarded array read, protecting its other callers too (roster roles, user account restrictions, action plans).

Fixes #1550

[jethro_report_stacktrace_deleted_group_fixed.webm](https://github.com/user-attachments/assets/d6f958d0-069d-4c31-a458-bb31e7f74e92)
