### PR TITLE
Keep the Submit button usable when client-side validation cancels a form submission (#1552)

### DIFF
--- a/resources/js/jethro.js
+++ b/resources/js/jethro.js
@@ -2351,11 +2351,37 @@ $(document).ready(function() {
 		//
 		// The workaround is to preserve that &confirm_delete= param in a hidden
 		// field, so the receiver still can tell what action was taken.
+		var form = this;
 		var submitter = e.originalEvent && e.originalEvent.submitter;
-		if (submitter && submitter.name) {
-			$(this).append($('<input type="hidden">').attr('name', submitter.name).val($(submitter).val()));
-		}
-		$(this).find('input[type=submit], button[type=submit]').prop('disabled', true);
+		// All submit handlers on a form run synchronously, in the order they were
+		// bound, during one event dispatch. This handler is bound before the
+		// validators (TBLib.handleFormSubmit, and view-specific ones like
+		// handleNewFamilySubmit), so at this moment we cannot know whether the
+		// submission will go ahead: a later handler may still cancel it by
+		// returning false, and a synchronous check of e.isDefaultPrevented() here
+		// would only see cancellations from handlers bound earlier. Disabling
+		// now is what caused #1552: validation failed, the form never
+		// navigated, and the buttons stayed disabled forever.
+		//
+		// setTimeout(0) means "run after the current task finishes", i.e. after
+		// the ENTIRE submit dispatch has completed. In the callback,
+		// isDefaultPrevented() is a final answer regardless of binding order: if
+		// any handler cancelled, we leave the buttons enabled so the user can fix
+		// the form and resubmit.
+		//
+		// If nothing cancelled, the browser has not yet started the POST: the
+		// submission is queued as a task AFTER this timer (it was queued during
+		// the dispatch), so the buttons are locked before the request leaves and
+		// double-submit protection still holds. The remaining double-click
+		// window is a single event-loop turn, versus the seconds-long POST that
+		// the protection actually targets.
+		setTimeout(function() {
+			if (e.isDefaultPrevented()) return;
+			if (submitter && submitter.name) {
+				$(form).append($('<input type="hidden">').attr('name', submitter.name).val($(submitter).val()));
+			}
+			$(form).find('input[type=submit], button[type=submit]').prop('disabled', true);
+		}, 0);
 	});
 });
 


### PR DESCRIPTION
On the Add Family page (?view=families__add), submitting a family whose second member has no age bracket shows an error ("Every family member must have an age bracket") but leaves the Submit button permanently disabled - the form can never be resubmitted without reloading the page.

Cause: 072d6567 added a submit handler that disables the submit buttons to prevent double-submits on slow connections. Handlers run synchronously in binding order, and that handler is bound before the validators (TBLib.handleFormSubmit and page-specific ones like handleNewFamilySubmit). When a validator fails it returns false, cancelling the submission so the page never navigates - but the buttons were already disabled, and nothing re-enables them.

Fix: defer the disabling with setTimeout(0) and skip it if e.isDefaultPrevented() is set. By the time the timeout runs, the entire submit dispatch has completed, so the cancelled-or-not decision is final regardless of binding order. If the submission proceeds, the browser queues the navigation after the timer, so the buttons are still disabled before the POST leaves and double-submit protection is unchanged, including preservation of the clicked button's name/value for multi-button forms. Checking cancellation after the fact (rather than trying to bind the disable handler last) was chosen deliberately: handler order depends on script load order, and any future $("form").submit() binding could otherwise silently reintroduce the bug.

Fixes #1552