### PR TITLE
Fix fatal error when ad-hoc run-sheet item shown in full in service handout (#1555)

### DIFF
--- a/db_objects/service.class.php
+++ b/db_objects/service.class.php
@@ -852,11 +852,12 @@ class service extends db_object
 		}
 	}
 
-    /** @return Whether a service component HTML body contains a single %.*_CONTENT% token (i.e. bible readings) which is the only case in which we allow substitution.
+    /** @return bool Whether a service component HTML body contains a single %.*_CONTENT% token (i.e. bible readings) which is the only case in which we allow substitution.
+     * $content is null for ad-hoc service items (componentid is NULL), which have no component body.
      */
-    private function keywordsInBody(string $content): bool
+    private function keywordsInBody(?string $content): bool
     {
-        $stripped = trim(strip_tags($content));
+        $stripped = trim(strip_tags((string)$content));
         return preg_match('/^%[A-Z0-9_]+_CONTENT%$/i', $stripped) === 1;
     }
 


### PR DESCRIPTION
To trigger: on a service run sheet, add an item directly (typing its title rather than picking a component from the library, so service_item.componentid stays NULL) and set its "Show in handout" to "Full". Then open the service handout page (`?view=services&date=...&congregationid=...`). The page fatals with `"service::keywordsInBody(): Argument #1 ($content) must be of type string, null given"`.

getItems(TRUE) LEFT JOINs service_component, so such items come back with NULL content_html/credits, and keywordsInBody() declared its parameter as non-nullable string.

Fix: keywordsInBody() now accepts ?string and casts to string, so NULL content returns false (no keyword substitution) and the item prints with an empty body, as before the type hint was added.

Fixes #1555